### PR TITLE
Fix n2curl permutations

### DIFF
--- a/cpp/raviart-thomas.cpp
+++ b/cpp/raviart-thomas.cpp
@@ -167,8 +167,6 @@ Eigen::MatrixXd basix::dofperms::triangle_rt_rotation(int degree)
     perm(2 * degree + i, i) = 1;
   }
 
-  return perm;
-
   // Rotate face
   const int face_start = 3 * degree;
   Eigen::ArrayXi face_rot = dofperms::triangle_rotation(degree - 1);

--- a/test/test_permutations.py
+++ b/test/test_permutations.py
@@ -51,5 +51,4 @@ def test_non_zero(cell_name, element_name, order):
 
     for perm in e.base_permutations:
         for row in perm:
-            print(row)
             assert max(abs(i) for i in row) > 1e-6

--- a/test/test_permutations.py
+++ b/test/test_permutations.py
@@ -10,7 +10,7 @@ import pytest
     "Lagrange", "Discontinuous Lagrange"])
 @pytest.mark.parametrize("order", [1, 2, 3])
 def test_interval_permutation_size(element_name, order):
-    e = basix.create_element(element_name, "interval", 1)
+    e = basix.create_element(element_name, "interval", order)
     assert len(e.base_permutations) == 0
 
 
@@ -23,7 +23,7 @@ def test_triangle_permutation_size(element_name, order):
     if element_name == "Crouzeix-Raviart" and order != 1:
         pytest.xfail()
 
-    e = basix.create_element(element_name, "triangle", 1)
+    e = basix.create_element(element_name, "triangle", order)
     assert len(e.base_permutations) == 3
 
 
@@ -36,5 +36,20 @@ def test_tetrahedron_permutation_size(element_name, order):
     if element_name == "Crouzeix-Raviart" and order != 1:
         pytest.xfail()
 
-    e = basix.create_element(element_name, "tetrahedron", 1)
+    e = basix.create_element(element_name, "tetrahedron", order)
     assert len(e.base_permutations) == 14
+
+
+@pytest.mark.parametrize("cell_name, element_name",
+    [("tetrahedron", "Nedelec 2nd kind H(curl)")])
+@pytest.mark.parametrize("order", [1, 2, 3])
+def test_non_zero(cell_name, element_name, order):
+    if element_name == "Crouzeix-Raviart" and order != 1:
+        pytest.xfail()
+
+    e = basix.create_element(element_name, cell_name, order)
+
+    for perm in e.base_permutations:
+        for row in perm:
+            print(row)
+            assert max(abs(i) for i in row) > 1e-6

--- a/test/test_permutations.py
+++ b/test/test_permutations.py
@@ -5,19 +5,27 @@
 import basix
 import pytest
 
+interval_elements = ["Lagrange", "Discontinuous Lagrange"]
+triangle_elements = [
+    "Lagrange", "Discontinuous Lagrange",
+    "Nedelec 1st kind H(curl)", "Nedelec 2nd kind H(curl)",
+    "Raviart-Thomas", "Regge", "Crouzeix-Raviart"]
+tetrahedron_elements = [
+    "Lagrange", "Discontinuous Lagrange",
+    "Nedelec 1st kind H(curl)", "Nedelec 2nd kind H(curl)",
+    "Raviart-Thomas", "Regge", "Crouzeix-Raviart"]
+quadrilateral_elements = ["Q"]
+hexahedron_elements = ["Q"]
 
-@pytest.mark.parametrize("element_name", [
-    "Lagrange", "Discontinuous Lagrange"])
+
+@pytest.mark.parametrize("element_name", interval_elements)
 @pytest.mark.parametrize("order", [1, 2, 3])
 def test_interval_permutation_size(element_name, order):
     e = basix.create_element(element_name, "interval", order)
     assert len(e.base_permutations) == 0
 
 
-@pytest.mark.parametrize("element_name", [
-    "Lagrange", "Discontinuous Lagrange",
-    "Nedelec 1st kind H(curl)", "Nedelec 2nd kind H(curl)",
-    "Raviart-Thomas", "Regge", "Crouzeix-Raviart"])
+@pytest.mark.parametrize("element_name", triangle_elements)
 @pytest.mark.parametrize("order", [1, 2, 3])
 def test_triangle_permutation_size(element_name, order):
     if element_name == "Crouzeix-Raviart" and order != 1:
@@ -27,10 +35,7 @@ def test_triangle_permutation_size(element_name, order):
     assert len(e.base_permutations) == 3
 
 
-@pytest.mark.parametrize("element_name", [
-    "Lagrange", "Discontinuous Lagrange",
-    "Nedelec 1st kind H(curl)", "Nedelec 2nd kind H(curl)",
-    "Raviart-Thomas", "Regge", "Crouzeix-Raviart"])
+@pytest.mark.parametrize("element_name", tetrahedron_elements)
 @pytest.mark.parametrize("order", [1, 2, 3])
 def test_tetrahedron_permutation_size(element_name, order):
     if element_name == "Crouzeix-Raviart" and order != 1:
@@ -40,8 +45,35 @@ def test_tetrahedron_permutation_size(element_name, order):
     assert len(e.base_permutations) == 14
 
 
-@pytest.mark.parametrize("cell_name, element_name",
-    [("tetrahedron", "Nedelec 2nd kind H(curl)")])
+@pytest.mark.parametrize("element_name", quadrilateral_elements)
+@pytest.mark.parametrize("order", [1, 2, 3])
+def test_quadrilateral_permutation_size(element_name, order):
+    if element_name == "Crouzeix-Raviart" and order != 1:
+        pytest.xfail()
+
+    e = basix.create_element(element_name, "quadrilateral", order)
+    assert len(e.base_permutations) == 4
+
+
+@pytest.mark.parametrize("element_name", hexahedron_elements)
+@pytest.mark.parametrize("order", [1, 2, 3])
+def test_hexahedron_permutation_size(element_name, order):
+    if element_name == "Crouzeix-Raviart" and order != 1:
+        pytest.xfail()
+
+    e = basix.create_element(element_name, "hexahedron", order)
+    assert len(e.base_permutations) == 24
+
+
+@pytest.mark.parametrize(
+    "cell_name, element_name",
+    [(cell, e) for cell, elements in [
+        ("interval", interval_elements),
+        ("triangle", triangle_elements),
+        ("quadrilateral", quadrilateral_elements),
+        ("tetrahedron", tetrahedron_elements),
+        ("hexahedron", hexahedron_elements)]
+     for e in elements])
 @pytest.mark.parametrize("order", [1, 2, 3])
 def test_non_zero(cell_name, element_name, order):
     if element_name == "Crouzeix-Raviart" and order != 1:


### PR DESCRIPTION
Removed an early return that should never have been there.

Added tests to check that the rows of a permutation are never 0