### PR TITLE
Add mappings

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -11,6 +11,7 @@ endif()
 # Executable
 add_library(basix SHARED lattice.cpp polyset.cpp dof-permutations.cpp
                           moments.cpp lagrange.cpp finite-element.cpp
+                          mappings.cpp
                           quadrature.cpp brezzi-douglas-marini.cpp
                           nedelec.cpp raviart-thomas.cpp cell.cpp regge.cpp
                           crouzeix-raviart.cpp basix.cpp)

--- a/cpp/basix.cpp
+++ b/cpp/basix.cpp
@@ -2,6 +2,7 @@
 #include "basix.h"
 #include "cell.h"
 #include "finite-element.h"
+#include "mappings.h"
 #include "quadrature.h"
 #include <memory>
 #include <vector>
@@ -92,7 +93,7 @@ const char* basix::family_name(int handle)
 const char* basix::mapping_name(int handle)
 {
   check_handle(handle);
-  return _registry[handle]->mapping_name().c_str();
+  return mapping::type_to_str(_registry[handle]->mapping_type()).c_str();
 }
 
 Eigen::ArrayXXd basix::geometry(const char* cell_type)

--- a/cpp/basix.cpp
+++ b/cpp/basix.cpp
@@ -42,13 +42,13 @@ std::vector<Eigen::ArrayXXd> basix::tabulate(int handle, int nd,
   return _registry[handle]->tabulate(nd, x);
 }
 
-Eigen::ArrayXXd basix::apply_mapping(int handle,
-                                     const Eigen::ArrayXd& reference_data,
-                                     const Eigen::MatrixXd& J, double detJ,
-                                     const Eigen::MatrixXd& K)
+Eigen::ArrayXXd basix::map_push_forward(int handle,
+                                        const Eigen::ArrayXd& reference_data,
+                                        const Eigen::MatrixXd& J, double detJ,
+                                        const Eigen::MatrixXd& K)
 {
   check_handle(handle);
-  return _registry[handle]->apply_mapping(reference_data, J, detJ, K);
+  return _registry[handle]->map_push_forward(reference_data, J, detJ, K);
 }
 
 const char* basix::cell_type(int handle)

--- a/cpp/basix.cpp
+++ b/cpp/basix.cpp
@@ -51,6 +51,15 @@ Eigen::ArrayXXd basix::map_push_forward(int handle,
   return _registry[handle]->map_push_forward(reference_data, J, detJ, K);
 }
 
+Eigen::ArrayXXd basix::map_pull_back(int handle,
+                                     const Eigen::ArrayXd& physical_data,
+                                     const Eigen::MatrixXd& J, double detJ,
+                                     const Eigen::MatrixXd& K)
+{
+  check_handle(handle);
+  return _registry[handle]->map_pull_back(physical_data, J, detJ, K);
+}
+
 const char* basix::cell_type(int handle)
 {
   check_handle(handle);

--- a/cpp/basix.cpp
+++ b/cpp/basix.cpp
@@ -42,6 +42,15 @@ std::vector<Eigen::ArrayXXd> basix::tabulate(int handle, int nd,
   return _registry[handle]->tabulate(nd, x);
 }
 
+Eigen::ArrayXXd basix::apply_mapping(int handle,
+                                     const Eigen::ArrayXd& reference_data,
+                                     const Eigen::MatrixXd& J, double detJ,
+                                     const Eigen::MatrixXd& K)
+{
+  check_handle(handle);
+  return _registry[handle]->apply_mapping(reference_data, J, detJ, K);
+}
+
 const char* basix::cell_type(int handle)
 {
   check_handle(handle);

--- a/cpp/basix.h
+++ b/cpp/basix.h
@@ -35,7 +35,7 @@ int dim(int handle);
 /// Family name
 const char* family_name(int handle);
 
-/// Mapping name (affine, piola etc.)
+/// Mapping name (identity, piola etc.)
 const char* mapping_name(int handle);
 
 /// Number of dofs per entity, ordered from vertex, edge, facet, cell

--- a/cpp/basix.h
+++ b/cpp/basix.h
@@ -17,6 +17,11 @@ void release_element(int handle);
 std::vector<Eigen::ArrayXXd> tabulate(int handle, int nd,
                                       const Eigen::ArrayXXd& x);
 
+/// Apply mapping
+Eigen::ArrayXXd apply_mapping(int handle, const Eigen::ArrayXd& reference_data,
+                              const Eigen::MatrixXd& J, double detJ,
+                              const Eigen::MatrixXd& K);
+
 /// Cell type
 const char* cell_type(int handle);
 

--- a/cpp/basix.h
+++ b/cpp/basix.h
@@ -17,11 +17,32 @@ void release_element(int handle);
 std::vector<Eigen::ArrayXXd> tabulate(int handle, int nd,
                                       const Eigen::ArrayXXd& x);
 
-/// Apply mapping to push reference data to the physical cell
+/// Push reference data forward to the physical cell
+/// @param[in] handle The handle of the basix element
+/// @param[in] reference_data The reference data at a single point
+/// @param[in] J The Jacobian of the map to the cell (evaluated at the point)
+/// @param[in] detJ The determinant of the Jacobian of the map to the cell
+/// (evaluated at the point)
+/// @param[in] K The inverse of the Jacobian of the map to the cell (evaluated
+/// at the point)
+/// @return The data on the physical cell at the corresponding point
 Eigen::ArrayXXd map_push_forward(int handle,
                                  const Eigen::ArrayXd& reference_data,
                                  const Eigen::MatrixXd& J, double detJ,
                                  const Eigen::MatrixXd& K);
+
+/// Pull physical data back to the reference element
+/// @param[in] handle The handle of the basix element
+/// @param[in] physical_data The physical data at a single point
+/// @param[in] J The Jacobian of the map to the cell (evaluated at the point)
+/// @param[in] detJ The determinant of the Jacobian of the map to the cell
+/// (evaluated at the point)
+/// @param[in] K The inverse of the Jacobian of the map to the cell (evaluated
+/// at the point)
+/// @return The data on the reference element at the corresponding point
+Eigen::ArrayXXd map_pull_back(int handle, const Eigen::ArrayXd& physical_data,
+                              const Eigen::MatrixXd& J, double detJ,
+                              const Eigen::MatrixXd& K);
 
 /// Cell type
 const char* cell_type(int handle);

--- a/cpp/basix.h
+++ b/cpp/basix.h
@@ -17,10 +17,11 @@ void release_element(int handle);
 std::vector<Eigen::ArrayXXd> tabulate(int handle, int nd,
                                       const Eigen::ArrayXXd& x);
 
-/// Apply mapping
-Eigen::ArrayXXd apply_mapping(int handle, const Eigen::ArrayXd& reference_data,
-                              const Eigen::MatrixXd& J, double detJ,
-                              const Eigen::MatrixXd& K);
+/// Apply mapping to push reference data to the physical cell
+Eigen::ArrayXXd map_push_forward(int handle,
+                                 const Eigen::ArrayXd& reference_data,
+                                 const Eigen::MatrixXd& J, double detJ,
+                                 const Eigen::MatrixXd& K);
 
 /// Cell type
 const char* cell_type(int handle);

--- a/cpp/basix.h
+++ b/cpp/basix.h
@@ -17,7 +17,7 @@ void release_element(int handle);
 std::vector<Eigen::ArrayXXd> tabulate(int handle, int nd,
                                       const Eigen::ArrayXXd& x);
 
-/// Push reference data forward to the physical cell
+/// Map a function value from the reference to a physical cell
 /// @param[in] handle The handle of the basix element
 /// @param[in] reference_data The reference data at a single point
 /// @param[in] J The Jacobian of the map to the cell (evaluated at the point)
@@ -31,7 +31,7 @@ Eigen::ArrayXXd map_push_forward(int handle,
                                  const Eigen::MatrixXd& J, double detJ,
                                  const Eigen::MatrixXd& K);
 
-/// Pull physical data back to the reference element
+/// Map a function value from a physical cell to the reference
 /// @param[in] handle The handle of the basix element
 /// @param[in] physical_data The physical data at a single point
 /// @param[in] J The Jacobian of the map to the cell (evaluated at the point)

--- a/cpp/basix/__init__.py
+++ b/cpp/basix/__init__.py
@@ -2,7 +2,7 @@ import os
 
 # Public interface
 from ._basixcpp import __version__
-from ._basixcpp import create_element, CellType, MappingType
+from ._basixcpp import create_element, CellType, MappingType, mapping_to_str
 
 
 # To possibly be removed

--- a/cpp/basix/__init__.py
+++ b/cpp/basix/__init__.py
@@ -2,7 +2,7 @@ import os
 
 # Public interface
 from ._basixcpp import __version__
-from ._basixcpp import create_element, CellType, mapping_to_str, family_to_str
+from ._basixcpp import create_element, CellType, mapping_to_str, family_to_str, MappingType
 
 
 # To possibly be removed

--- a/cpp/basix/__init__.py
+++ b/cpp/basix/__init__.py
@@ -3,7 +3,6 @@ import os
 # Public interface
 from ._basixcpp import __version__
 from ._basixcpp import create_element, CellType, MappingType, mapping_to_str
-from ._basixcpp import apply_mapping
 
 
 # To possibly be removed

--- a/cpp/basix/__init__.py
+++ b/cpp/basix/__init__.py
@@ -2,7 +2,7 @@ import os
 
 # Public interface
 from ._basixcpp import __version__
-from ._basixcpp import create_element, CellType
+from ._basixcpp import create_element, CellType, MappingType
 
 
 # To possibly be removed

--- a/cpp/basix/__init__.py
+++ b/cpp/basix/__init__.py
@@ -3,6 +3,7 @@ import os
 # Public interface
 from ._basixcpp import __version__
 from ._basixcpp import create_element, CellType, MappingType, mapping_to_str
+from ._basixcpp import apply_mapping
 
 
 # To possibly be removed

--- a/cpp/basix/__init__.py
+++ b/cpp/basix/__init__.py
@@ -2,7 +2,7 @@ import os
 
 # Public interface
 from ._basixcpp import __version__
-from ._basixcpp import create_element, CellType, MappingType, mapping_to_str
+from ._basixcpp import create_element, CellType, mapping_to_str, family_to_str
 
 
 # To possibly be removed

--- a/cpp/brezzi-douglas-marini.cpp
+++ b/cpp/brezzi-douglas-marini.cpp
@@ -121,6 +121,7 @@ FiniteElement basix::create_bdm(cell::type celltype, int degree,
   Eigen::MatrixXd coeffs = compute_expansion_coefficients(wcoeffs, dual);
 
   return FiniteElement(name, celltype, degree, {tdim}, coeffs, entity_dofs,
-                       base_permutations, {}, {}, mapping::type::contravariantPiola);
+                       base_permutations, {}, {},
+                       mapping::type::contravariantPiola);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/brezzi-douglas-marini.cpp
+++ b/cpp/brezzi-douglas-marini.cpp
@@ -5,6 +5,7 @@
 #include "brezzi-douglas-marini.h"
 #include "dof-permutations.h"
 #include "lagrange.h"
+#include "mappings.h"
 #include "moments.h"
 #include "nedelec.h"
 #include "polyset.h"
@@ -120,6 +121,6 @@ FiniteElement basix::create_bdm(cell::type celltype, int degree,
   Eigen::MatrixXd coeffs = compute_expansion_coefficients(wcoeffs, dual);
 
   return FiniteElement(name, celltype, degree, {tdim}, coeffs, entity_dofs,
-                       base_permutations, {}, {}, "contravariant piola");
+                       base_permutations, {}, {}, mapping::type::contravariantPiola);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/cell.h
+++ b/cpp/cell.h
@@ -72,6 +72,5 @@ cell::type str_to_type(std::string name);
 /// Convert cell type enum to string
 const std::string& type_to_str(cell::type type);
 
-
 } // namespace cell
 } // namespace basix

--- a/cpp/finite-element.cpp
+++ b/cpp/finite-element.cpp
@@ -81,9 +81,9 @@ FiniteElement::FiniteElement(
     const std::vector<std::vector<int>>& entity_dofs,
     const std::vector<Eigen::MatrixXd>& base_permutations,
     const Eigen::ArrayXXd& points, const Eigen::MatrixXd interpolation_matrix,
-    const std::string mapping_name)
+    mapping::type mapping_type)
     : _cell_type(cell_type), _family_name(name), _degree(degree),
-      _value_shape(value_shape), _mapping_name(mapping_name), _coeffs(coeffs),
+      _value_shape(value_shape), _mapping_type(mapping_type), _coeffs(coeffs),
       _entity_dofs(entity_dofs), _base_permutations(base_permutations),
       _points(points), _interpolation_matrix(interpolation_matrix)
 {
@@ -120,7 +120,7 @@ int FiniteElement::dim() const { return _coeffs.rows(); }
 //-----------------------------------------------------------------------------
 const std::string& FiniteElement::family_name() const { return _family_name; }
 //-----------------------------------------------------------------------------
-const std::string& FiniteElement::mapping_name() const { return _mapping_name; }
+const mapping::type FiniteElement::mapping_type() const { return _mapping_type; }
 //-----------------------------------------------------------------------------
 const Eigen::MatrixXd& FiniteElement::interpolation_matrix() const
 {

--- a/cpp/finite-element.cpp
+++ b/cpp/finite-element.cpp
@@ -19,8 +19,8 @@
 using namespace basix;
 
 //-----------------------------------------------------------------------------
-basix::FiniteElement basix::create_element(std::string family,
-                                             std::string cell, int degree)
+basix::FiniteElement basix::create_element(std::string family, std::string cell,
+                                           int degree)
 {
   if (family == "Lagrange" or family == "P" or family == "Q")
     return create_lagrange(cell::str_to_type(cell), degree, family);
@@ -44,8 +44,8 @@ basix::FiniteElement basix::create_element(std::string family,
 //-----------------------------------------------------------------------------
 Eigen::MatrixXd
 basix::compute_expansion_coefficients(const Eigen::MatrixXd& coeffs,
-                                       const Eigen::MatrixXd& dual,
-                                       bool condition_check)
+                                      const Eigen::MatrixXd& dual,
+                                      bool condition_check)
 {
 #ifndef NDEBUG
   std::cout << "Initial coeffs = \n[" << coeffs << "]\n";
@@ -120,7 +120,10 @@ int FiniteElement::dim() const { return _coeffs.rows(); }
 //-----------------------------------------------------------------------------
 const std::string& FiniteElement::family_name() const { return _family_name; }
 //-----------------------------------------------------------------------------
-const mapping::type FiniteElement::mapping_type() const { return _mapping_type; }
+const mapping::type FiniteElement::mapping_type() const
+{
+  return _mapping_type;
+}
 //-----------------------------------------------------------------------------
 const Eigen::MatrixXd& FiniteElement::interpolation_matrix() const
 {

--- a/cpp/finite-element.cpp
+++ b/cpp/finite-element.cpp
@@ -177,25 +177,6 @@ FiniteElement::apply_mapping(const Eigen::ArrayXd& reference_data,
 {
   return mapping::apply_mapping(reference_data, J, detJ, K, _mapping_type,
                                 _value_shape);
-
-  // Temporary data storage
-  const int vs = value_size();
-  const int d = dim();
-  Eigen::ArrayXd value(vs);
-  Eigen::ArrayXd result(vs);
-
-  // Apply mapping to each tabulated value
-  Eigen::ArrayXd mapped_data(reference_data.size());
-  for (int i = 0; i < d; ++i)
-  {
-    for (int j = 0; j < vs; ++j)
-      value[j] = reference_data(i + j * d);
-    result = mapping::apply_mapping(value, J, detJ, K, _mapping_type,
-                                    _value_shape);
-    for (int j = 0; j < vs; ++j)
-      mapped_data(i + j * d) = result[j];
-  }
-  return mapped_data;
 }
 //-----------------------------------------------------------------------------
 const std::string& basix::version()

--- a/cpp/finite-element.cpp
+++ b/cpp/finite-element.cpp
@@ -179,6 +179,15 @@ FiniteElement::apply_mapping(const Eigen::ArrayXd& reference_data,
                                 _value_shape);
 }
 //-----------------------------------------------------------------------------
+Eigen::ArrayXd
+FiniteElement::apply_inverse_mapping(const Eigen::ArrayXd& physical_data,
+                                     const Eigen::MatrixXd& J, double detJ,
+                                     const Eigen::MatrixXd& K) const
+{
+  return mapping::apply_inverse_mapping(physical_data, J, detJ, K,
+                                        _mapping_type, _value_shape);
+}
+//-----------------------------------------------------------------------------
 const std::string& basix::version()
 {
   static const std::string version_str = str(BASIX_VERSION);

--- a/cpp/finite-element.cpp
+++ b/cpp/finite-element.cpp
@@ -171,21 +171,21 @@ std::vector<Eigen::MatrixXd> FiniteElement::base_permutations() const
 const Eigen::ArrayXXd& FiniteElement::points() const { return _points; }
 //-----------------------------------------------------------------------------
 Eigen::ArrayXd
-FiniteElement::apply_mapping(const Eigen::ArrayXd& reference_data,
-                             const Eigen::MatrixXd& J, double detJ,
-                             const Eigen::MatrixXd& K) const
+FiniteElement::map_push_forward(const Eigen::ArrayXd& reference_data,
+                                const Eigen::MatrixXd& J, double detJ,
+                                const Eigen::MatrixXd& K) const
 {
-  return mapping::apply_mapping(reference_data, J, detJ, K, _mapping_type,
-                                _value_shape);
+  return mapping::map_push_forward(reference_data, J, detJ, K, _mapping_type,
+                                   _value_shape);
 }
 //-----------------------------------------------------------------------------
-Eigen::ArrayXd
-FiniteElement::apply_inverse_mapping(const Eigen::ArrayXd& physical_data,
-                                     const Eigen::MatrixXd& J, double detJ,
-                                     const Eigen::MatrixXd& K) const
+Eigen::ArrayXd FiniteElement::map_pull_back(const Eigen::ArrayXd& physical_data,
+                                            const Eigen::MatrixXd& J,
+                                            double detJ,
+                                            const Eigen::MatrixXd& K) const
 {
-  return mapping::apply_inverse_mapping(physical_data, J, detJ, K,
-                                        _mapping_type, _value_shape);
+  return mapping::map_pull_back(physical_data, J, detJ, K, _mapping_type,
+                                _value_shape);
 }
 //-----------------------------------------------------------------------------
 const std::string& basix::version()

--- a/cpp/finite-element.cpp
+++ b/cpp/finite-element.cpp
@@ -171,10 +171,13 @@ std::vector<Eigen::MatrixXd> FiniteElement::base_permutations() const
 const Eigen::ArrayXXd& FiniteElement::points() const { return _points; }
 //-----------------------------------------------------------------------------
 Eigen::ArrayXd
-FiniteElement::apply_mapping(int order, const Eigen::ArrayXd& reference_data,
+FiniteElement::apply_mapping(const Eigen::ArrayXd& reference_data,
                              const Eigen::MatrixXd& J, double detJ,
                              const Eigen::MatrixXd& K) const
 {
+  return mapping::apply_mapping(reference_data, J, detJ, K, _mapping_type,
+                                _value_shape);
+
   // Temporary data storage
   const int vs = value_size();
   const int d = dim();
@@ -187,7 +190,7 @@ FiniteElement::apply_mapping(int order, const Eigen::ArrayXd& reference_data,
   {
     for (int j = 0; j < vs; ++j)
       value[j] = reference_data(i + j * d);
-    result = mapping::apply_mapping(order, value, J, detJ, K, _mapping_type,
+    result = mapping::apply_mapping(value, J, detJ, K, _mapping_type,
                                     _value_shape);
     for (int j = 0; j < vs; ++j)
       mapped_data(i + j * d) = result[j];

--- a/cpp/finite-element.cpp
+++ b/cpp/finite-element.cpp
@@ -170,6 +170,31 @@ std::vector<Eigen::MatrixXd> FiniteElement::base_permutations() const
 //-----------------------------------------------------------------------------
 const Eigen::ArrayXXd& FiniteElement::points() const { return _points; }
 //-----------------------------------------------------------------------------
+Eigen::ArrayXd
+FiniteElement::apply_mapping(int order, const Eigen::ArrayXd& reference_data,
+                             const Eigen::MatrixXd& J, double detJ,
+                             const Eigen::MatrixXd& K) const
+{
+  // Temporary data storage
+  const int vs = value_size();
+  const int d = dim();
+  Eigen::ArrayXd value(vs);
+  Eigen::ArrayXd result(vs);
+
+  // Apply mapping to each tabulated value
+  Eigen::ArrayXd mapped_data(reference_data.size());
+  for (int i = 0; i < d; ++i)
+  {
+    for (int j = 0; j < vs; ++j)
+      value[j] = reference_data(i + j * d);
+    result = mapping::apply_mapping(order, value, J, detJ, K, _mapping_type,
+                                    _value_shape);
+    for (int j = 0; j < vs; ++j)
+      mapped_data(i + j * d) = result[j];
+  }
+  return mapped_data;
+}
+//-----------------------------------------------------------------------------
 const std::string& basix::version()
 {
   static const std::string version_str = str(BASIX_VERSION);

--- a/cpp/finite-element.h
+++ b/cpp/finite-element.h
@@ -220,6 +220,11 @@ public:
   /// @return The mapping
   const mapping::type mapping_type() const;
 
+  /// Apply mapping
+  Eigen::ArrayXd apply_mapping(int order, const Eigen::ArrayXd& reference_data,
+                               const Eigen::MatrixXd& J, double detJ,
+                               const Eigen::MatrixXd& K) const;
+
   /// Get the number of dofs on each topological entity: (vertices,
   /// edges, faces, cell) in that order. For example, Lagrange degree 2
   /// on a triangle has vertices: [1, 1, 1], edges: [1, 1, 1], cell: [0]

--- a/cpp/finite-element.h
+++ b/cpp/finite-element.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "cell.h"
+#include "mappings.h"
 #include <Eigen/Dense>
 #include <string>
 #include <vector>
@@ -156,7 +157,7 @@ public:
                 const std::vector<Eigen::MatrixXd>& base_permutations,
                 const Eigen::ArrayXXd& points,
                 const Eigen::MatrixXd interpolation_matrix = {},
-                const std::string mapping_name = "identity");
+                mapping::type mapping_type = mapping::type::identity);
 
   /// Copy constructor
   FiniteElement(const FiniteElement& element) = default;
@@ -217,7 +218,7 @@ public:
 
   /// Get the mapping used for this element
   /// @return The mapping
-  const std::string& mapping_name() const;
+  const mapping::type mapping_type() const;
 
   /// Get the number of dofs on each topological entity: (vertices,
   /// edges, faces, cell) in that order. For example, Lagrange degree 2
@@ -333,7 +334,7 @@ private:
   std::vector<int> _value_shape;
 
   /// The mapping used to map this element from the reference to a cell
-  std::string _mapping_name;
+  mapping::type _mapping_type;
 
   // Shape function coefficient of expansion sets on cell. If shape
   // function is given by @f$\psi_i = \sum_{k} \phi_{k} \alpha^{i}_{k}@f$,

--- a/cpp/finite-element.h
+++ b/cpp/finite-element.h
@@ -220,25 +220,25 @@ public:
   /// @return The mapping
   const mapping::type mapping_type() const;
 
-  /// Map a function value from the reference to a cell
+  /// Map a function value from the reference to a physical cell
   /// @param reference_data The function value on the reference
   /// @param J The Jacobian of the mapping
   /// @param detJ The determinant of the Jacobian of the mapping
   /// @param K The inverse of the Jacobian of the mapping
   /// @return The function value on the cell
-  Eigen::ArrayXd apply_mapping(const Eigen::ArrayXd& reference_data,
-                               const Eigen::MatrixXd& J, double detJ,
-                               const Eigen::MatrixXd& K) const;
+  Eigen::ArrayXd map_push_forward(const Eigen::ArrayXd& reference_data,
+                                  const Eigen::MatrixXd& J, double detJ,
+                                  const Eigen::MatrixXd& K) const;
 
-  /// Map a function value from a cell to the reference
+  /// Map a function value from a physical cell to the reference
   /// @param physical_data The function value on the cell
   /// @param J The Jacobian of the mapping
   /// @param detJ The determinant of the Jacobian of the mapping
   /// @param K The inverse of the Jacobian of the mapping
   /// @return The function value on the reference
-  Eigen::ArrayXd apply_inverse_mapping(const Eigen::ArrayXd& physical_data,
-                                       const Eigen::MatrixXd& J, double detJ,
-                                       const Eigen::MatrixXd& K) const;
+  Eigen::ArrayXd map_pull_back(const Eigen::ArrayXd& physical_data,
+                               const Eigen::MatrixXd& J, double detJ,
+                               const Eigen::MatrixXd& K) const;
 
   /// Get the number of dofs on each topological entity: (vertices,
   /// edges, faces, cell) in that order. For example, Lagrange degree 2

--- a/cpp/finite-element.h
+++ b/cpp/finite-element.h
@@ -156,7 +156,7 @@ public:
                 const std::vector<Eigen::MatrixXd>& base_permutations,
                 const Eigen::ArrayXXd& points,
                 const Eigen::MatrixXd interpolation_matrix = {},
-                const std::string mapping_name = "affine");
+                const std::string mapping_name = "identity");
 
   /// Copy constructor
   FiniteElement(const FiniteElement& element) = default;

--- a/cpp/finite-element.h
+++ b/cpp/finite-element.h
@@ -216,14 +216,29 @@ public:
   /// @return The family name
   const std::string& family_name() const;
 
-  /// Get the mapping used for this element
+  /// Get the mapping type used for this element
   /// @return The mapping
   const mapping::type mapping_type() const;
 
-  /// Apply mapping
+  /// Map a function value from the reference to a cell
+  /// @param reference_data The function value on the reference
+  /// @param J The Jacobian of the mapping
+  /// @param detJ The determinant of the Jacobian of the mapping
+  /// @param K The inverse of the Jacobian of the mapping
+  /// @return The function value on the cell
   Eigen::ArrayXd apply_mapping(const Eigen::ArrayXd& reference_data,
                                const Eigen::MatrixXd& J, double detJ,
                                const Eigen::MatrixXd& K) const;
+
+  /// Map a function value from a cell to the reference
+  /// @param physical_data The function value on the cell
+  /// @param J The Jacobian of the mapping
+  /// @param detJ The determinant of the Jacobian of the mapping
+  /// @param K The inverse of the Jacobian of the mapping
+  /// @return The function value on the reference
+  Eigen::ArrayXd apply_inverse_mapping(const Eigen::ArrayXd& physical_data,
+                                       const Eigen::MatrixXd& J, double detJ,
+                                       const Eigen::MatrixXd& K) const;
 
   /// Get the number of dofs on each topological entity: (vertices,
   /// edges, faces, cell) in that order. For example, Lagrange degree 2

--- a/cpp/finite-element.h
+++ b/cpp/finite-element.h
@@ -221,7 +221,7 @@ public:
   const mapping::type mapping_type() const;
 
   /// Apply mapping
-  Eigen::ArrayXd apply_mapping(int order, const Eigen::ArrayXd& reference_data,
+  Eigen::ArrayXd apply_mapping(const Eigen::ArrayXd& reference_data,
                                const Eigen::MatrixXd& J, double detJ,
                                const Eigen::MatrixXd& K) const;
 

--- a/cpp/lagrange.cpp
+++ b/cpp/lagrange.cpp
@@ -14,7 +14,7 @@ using namespace basix;
 
 //----------------------------------------------------------------------------
 FiniteElement basix::create_lagrange(cell::type celltype, int degree,
-                                      const std::string& name)
+                                     const std::string& name)
 {
   if (celltype == cell::type::point)
     throw std::runtime_error("Invalid celltype");
@@ -184,7 +184,7 @@ FiniteElement basix::create_lagrange(cell::type celltype, int degree,
 }
 //-----------------------------------------------------------------------------
 FiniteElement basix::create_dlagrange(cell::type celltype, int degree,
-                                       const std::string& name)
+                                      const std::string& name)
 {
   // Only tabulate for scalar. Vector spaces can easily be built from
   // the scalar space.

--- a/cpp/mappings.cpp
+++ b/cpp/mappings.cpp
@@ -9,8 +9,7 @@
 using namespace basix;
 
 //-----------------------------------------------------------------------------
-Eigen::ArrayXd mapping::apply_mapping(int order,
-                                      const Eigen::ArrayXd& reference_data,
+Eigen::ArrayXd mapping::apply_mapping(const Eigen::ArrayXd& reference_data,
                                       const Eigen::MatrixXd& J, double detJ,
                                       const Eigen::MatrixXd& K,
                                       mapping::type mapping_type,

--- a/cpp/mappings.cpp
+++ b/cpp/mappings.cpp
@@ -9,11 +9,11 @@
 using namespace basix;
 
 //-----------------------------------------------------------------------------
-Eigen::ArrayXd mapping::apply_mapping(const Eigen::ArrayXd& reference_data,
-                                      const Eigen::MatrixXd& J, double detJ,
-                                      const Eigen::MatrixXd& K,
-                                      mapping::type mapping_type,
-                                      const std::vector<int> value_shape)
+Eigen::ArrayXd mapping::map_push_forward(const Eigen::ArrayXd& reference_data,
+                                         const Eigen::MatrixXd& J, double detJ,
+                                         const Eigen::MatrixXd& K,
+                                         mapping::type mapping_type,
+                                         const std::vector<int> value_shape)
 {
   switch (mapping_type)
   {
@@ -43,10 +43,11 @@ Eigen::ArrayXd mapping::apply_mapping(const Eigen::ArrayXd& reference_data,
   }
 }
 //-----------------------------------------------------------------------------
-Eigen::ArrayXd mapping::apply_inverse_mapping(
-    const Eigen::ArrayXd& physical_data, const Eigen::MatrixXd& J, double detJ,
-    const Eigen::MatrixXd& K, mapping::type mapping_type,
-    const std::vector<int> value_shape)
+Eigen::ArrayXd mapping::map_pull_back(const Eigen::ArrayXd& physical_data,
+                                      const Eigen::MatrixXd& J, double detJ,
+                                      const Eigen::MatrixXd& K,
+                                      mapping::type mapping_type,
+                                      const std::vector<int> value_shape)
 {
   switch (mapping_type)
   {

--- a/cpp/mappings.cpp
+++ b/cpp/mappings.cpp
@@ -43,6 +43,38 @@ Eigen::ArrayXd mapping::apply_mapping(const Eigen::ArrayXd& reference_data,
   }
 }
 //-----------------------------------------------------------------------------
+Eigen::ArrayXd mapping::apply_inverse_mapping(
+    const Eigen::ArrayXd& physical_data, const Eigen::MatrixXd& J, double detJ,
+    const Eigen::MatrixXd& K, mapping::type mapping_type,
+    const std::vector<int> value_shape)
+{
+  switch (mapping_type)
+  {
+  case mapping::type::identity:
+    return physical_data;
+  case mapping::type::covariantPiola:
+    return J.transpose() * physical_data.matrix();
+  case mapping::type::contravariantPiola:
+    return detJ * K * physical_data.matrix();
+  case mapping::type::doubleCovariantPiola:
+  {
+    Eigen::Map<const Eigen::MatrixXd> data_matrix(
+        physical_data.data(), value_shape[0], value_shape[1]);
+    Eigen::MatrixXd result = J.transpose() * data_matrix * J;
+    return Eigen::Map<Eigen::ArrayXd>(result.data(), physical_data.size());
+  }
+  case mapping::type::doubleContravariantPiola:
+  {
+    Eigen::Map<const Eigen::MatrixXd> data_matrix(
+        physical_data.data(), value_shape[0], value_shape[1]);
+    Eigen::MatrixXd result = detJ * detJ * K * data_matrix * K.transpose();
+    return Eigen::Map<Eigen::ArrayXd>(result.data(), physical_data.size());
+  }
+  default:
+    throw std::runtime_error("Mapping not yet implemented");
+  }
+}
+//-----------------------------------------------------------------------------
 const std::string& mapping::type_to_str(mapping::type type)
 {
   static const std::map<mapping::type, std::string> type_to_name = {

--- a/cpp/mappings.cpp
+++ b/cpp/mappings.cpp
@@ -1,0 +1,37 @@
+// Copyright (c) 2021 Matthew Scroggs
+// FEniCS Project
+// SPDX-License-Identifier:    MIT
+
+#include "mappings.h"
+#include <map>
+#include <stdexcept>
+
+using namespace basix;
+
+//-----------------------------------------------------------------------------
+Eigen::ArrayXXd mapping::apply_mapping(Eigen::ArrayXXd data, mapping::type mapping_type, int value_size)
+{
+  switch (mapping_type)
+  {
+  case mapping::type::identity:
+    return data;
+  default:
+    throw std::runtime_error("Mapping not yet implemented");
+  }
+}
+//-----------------------------------------------------------------------------
+const std::string& mapping::type_to_str(mapping::type type)
+{
+  static const std::map<mapping::type, std::string> type_to_name
+      = {{mapping::type::identity, "identity"},
+         {mapping::type::covariantPiola, "covariant Piola"},
+         {mapping::type::contravariantPiola, "contravariant Piola"},
+         {mapping::type::doubleCovariantPiola, "double covariant Piola"},
+         {mapping::type::doubleContravariantPiola, "double contravariant Piola"}};
+
+  auto it = type_to_name.find(type);
+  if (it == type_to_name.end())
+    throw std::runtime_error("Can't find type");
+
+  return it->second;
+}

--- a/cpp/mappings.cpp
+++ b/cpp/mappings.cpp
@@ -9,12 +9,32 @@
 using namespace basix;
 
 //-----------------------------------------------------------------------------
-Eigen::ArrayXXd mapping::apply_mapping(Eigen::ArrayXXd data, mapping::type mapping_type, int value_size)
+Eigen::ArrayXd mapping::apply_mapping(int order, const Eigen::ArrayXd& reference_data,
+                                       const Eigen::MatrixXd& J, double detJ,
+                                       const Eigen::MatrixXd& K,
+                                       mapping::type mapping_type,
+                                       const std::vector<int> value_shape)
 {
   switch (mapping_type)
   {
   case mapping::type::identity:
-    return data;
+    return reference_data;
+  case mapping::type::covariantPiola:
+    return K.transpose() * reference_data.matrix();
+  case mapping::type::contravariantPiola:
+    return 1 / detJ * J * reference_data.matrix();
+  case mapping::type::doubleCovariantPiola:
+  {
+    Eigen::Map<const Eigen::MatrixXd> data_matrix(reference_data.data(), value_shape[0], value_shape[1]);
+    Eigen::MatrixXd result = K.transpose() * data_matrix * K;
+    return Eigen::Map<Eigen::ArrayXd>(result.data(), reference_data.size());
+  }
+  case mapping::type::doubleContravariantPiola:
+  {
+    Eigen::Map<const Eigen::MatrixXd> data_matrix(reference_data.data(), value_shape[0], value_shape[1]);
+    Eigen::MatrixXd result = 1 / (detJ * detJ) * J * data_matrix * J.transpose();
+    return Eigen::Map<Eigen::ArrayXd>(result.data(), reference_data.size());
+  }
   default:
     throw std::runtime_error("Mapping not yet implemented");
   }

--- a/cpp/mappings.cpp
+++ b/cpp/mappings.cpp
@@ -9,11 +9,12 @@
 using namespace basix;
 
 //-----------------------------------------------------------------------------
-Eigen::ArrayXd mapping::apply_mapping(int order, const Eigen::ArrayXd& reference_data,
-                                       const Eigen::MatrixXd& J, double detJ,
-                                       const Eigen::MatrixXd& K,
-                                       mapping::type mapping_type,
-                                       const std::vector<int> value_shape)
+Eigen::ArrayXd mapping::apply_mapping(int order,
+                                      const Eigen::ArrayXd& reference_data,
+                                      const Eigen::MatrixXd& J, double detJ,
+                                      const Eigen::MatrixXd& K,
+                                      mapping::type mapping_type,
+                                      const std::vector<int> value_shape)
 {
   switch (mapping_type)
   {
@@ -25,14 +26,17 @@ Eigen::ArrayXd mapping::apply_mapping(int order, const Eigen::ArrayXd& reference
     return 1 / detJ * J * reference_data.matrix();
   case mapping::type::doubleCovariantPiola:
   {
-    Eigen::Map<const Eigen::MatrixXd> data_matrix(reference_data.data(), value_shape[0], value_shape[1]);
+    Eigen::Map<const Eigen::MatrixXd> data_matrix(
+        reference_data.data(), value_shape[0], value_shape[1]);
     Eigen::MatrixXd result = K.transpose() * data_matrix * K;
     return Eigen::Map<Eigen::ArrayXd>(result.data(), reference_data.size());
   }
   case mapping::type::doubleContravariantPiola:
   {
-    Eigen::Map<const Eigen::MatrixXd> data_matrix(reference_data.data(), value_shape[0], value_shape[1]);
-    Eigen::MatrixXd result = 1 / (detJ * detJ) * J * data_matrix * J.transpose();
+    Eigen::Map<const Eigen::MatrixXd> data_matrix(
+        reference_data.data(), value_shape[0], value_shape[1]);
+    Eigen::MatrixXd result
+        = 1 / (detJ * detJ) * J * data_matrix * J.transpose();
     return Eigen::Map<Eigen::ArrayXd>(result.data(), reference_data.size());
   }
   default:
@@ -42,12 +46,12 @@ Eigen::ArrayXd mapping::apply_mapping(int order, const Eigen::ArrayXd& reference
 //-----------------------------------------------------------------------------
 const std::string& mapping::type_to_str(mapping::type type)
 {
-  static const std::map<mapping::type, std::string> type_to_name
-      = {{mapping::type::identity, "identity"},
-         {mapping::type::covariantPiola, "covariant Piola"},
-         {mapping::type::contravariantPiola, "contravariant Piola"},
-         {mapping::type::doubleCovariantPiola, "double covariant Piola"},
-         {mapping::type::doubleContravariantPiola, "double contravariant Piola"}};
+  static const std::map<mapping::type, std::string> type_to_name = {
+      {mapping::type::identity, "identity"},
+      {mapping::type::covariantPiola, "covariant Piola"},
+      {mapping::type::contravariantPiola, "contravariant Piola"},
+      {mapping::type::doubleCovariantPiola, "double covariant Piola"},
+      {mapping::type::doubleContravariantPiola, "double contravariant Piola"}};
 
   auto it = type_to_name.find(type);
   if (it == type_to_name.end())

--- a/cpp/mappings.h
+++ b/cpp/mappings.h
@@ -39,7 +39,7 @@ Eigen::ArrayXd apply_mapping(int order, const Eigen::ArrayXd& reference_data,
                               const Eigen::MatrixXd& J, double detJ,
                               const Eigen::MatrixXd& K,
                               mapping::type mapping_type,
-                                       const std::vector<int> value_shape={1});
+                                       const std::vector<int> value_shape);
 
 /// Convert mapping type enum to string
 const std::string& type_to_str(mapping::type type);

--- a/cpp/mappings.h
+++ b/cpp/mappings.h
@@ -1,8 +1,11 @@
-// Copyright (c) 2020 Matthew Scroggs
+// Copyright (c) 2021 Matthew Scroggs
 // FEniCS Project
 // SPDX-License-Identifier:    MIT
 
 #pragma once
+
+#include <string>
+#include <Eigen/Dense>
 
 namespace basix
 {
@@ -26,12 +29,12 @@ enum class type
 /// @param data The data to apply the mapping to
 /// @param mapping_type Mapping type
 /// @param value_size The value size of the data
-/// @return Set of vertex points of the cell
+/// @return The mapped data
 // TODO: should data be in/out?
 Eigen::ArrayXXd apply_mapping(Eigen::ArrayXXd data, mapping::type mapping_type, int value_size);
 
 /// Convert mapping type enum to string
-const std::string& type_to_str(cell::type type);
+const std::string& type_to_str(mapping::type type);
 
 } // namespace mapping
 } // namespace basix

--- a/cpp/mappings.h
+++ b/cpp/mappings.h
@@ -27,7 +27,6 @@ enum class type
 };
 
 /// Apply mapping
-/// @param order TODO: is this needed?
 /// @param reference_data The data to apply the mapping to
 /// @param J The Jacobian
 /// @param detJ The determinant of the Jacobian
@@ -36,7 +35,7 @@ enum class type
 /// @param value_shape The value shape of the data
 /// @return The mapped data
 // TODO: should data be in/out?
-Eigen::ArrayXd apply_mapping(int order, const Eigen::ArrayXd& reference_data,
+Eigen::ArrayXd apply_mapping(const Eigen::ArrayXd& reference_data,
                              const Eigen::MatrixXd& J, double detJ,
                              const Eigen::MatrixXd& K,
                              mapping::type mapping_type,

--- a/cpp/mappings.h
+++ b/cpp/mappings.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2020 Matthew Scroggs
+// FEniCS Project
+// SPDX-License-Identifier:    MIT
+
+#pragma once
+
+namespace basix
+{
+
+/// Information about mappings.
+
+namespace mapping
+{
+
+/// Cell type
+enum class type
+{
+  identity,
+  covariantPiola,
+  contravariantPiola,
+  doubleCovariantPiola,
+  doubleContravariantPiola,
+};
+
+/// Apply mapping
+/// @param data The data to apply the mapping to
+/// @param mapping_type Mapping type
+/// @param value_size The value size of the data
+/// @return Set of vertex points of the cell
+// TODO: should data be in/out?
+Eigen::ArrayXXd apply_mapping(Eigen::ArrayXXd data, mapping::type mapping_type, int value_size);
+
+/// Convert mapping type enum to string
+const std::string& type_to_str(cell::type type);
+
+} // namespace mapping
+} // namespace basix

--- a/cpp/mappings.h
+++ b/cpp/mappings.h
@@ -26,9 +26,13 @@ enum class type
 };
 
 /// Apply mapping
-/// @param data The data to apply the mapping to
+/// @param order TODO: is this needed?
+/// @param reference_data The data to apply the mapping to
+/// @param J The Jacobian
+/// @param detJ The determinant of the Jacobian
+/// @param K The inverse of the Jacobian
 /// @param mapping_type Mapping type
-/// @param value_size The value size of the data
+/// @param value_shape The value shape of the data
 /// @return The mapped data
 // TODO: should data be in/out?
 Eigen::ArrayXd apply_mapping(int order, const Eigen::ArrayXd& reference_data,

--- a/cpp/mappings.h
+++ b/cpp/mappings.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include <string>
 #include <Eigen/Dense>
+#include <string>
 #include <vector>
 
 namespace basix
@@ -37,10 +37,10 @@ enum class type
 /// @return The mapped data
 // TODO: should data be in/out?
 Eigen::ArrayXd apply_mapping(int order, const Eigen::ArrayXd& reference_data,
-                              const Eigen::MatrixXd& J, double detJ,
-                              const Eigen::MatrixXd& K,
-                              mapping::type mapping_type,
-                              const std::vector<int> value_shape);
+                             const Eigen::MatrixXd& J, double detJ,
+                             const Eigen::MatrixXd& K,
+                             mapping::type mapping_type,
+                             const std::vector<int> value_shape);
 
 /// Convert mapping type enum to string
 const std::string& type_to_str(mapping::type type);

--- a/cpp/mappings.h
+++ b/cpp/mappings.h
@@ -6,6 +6,7 @@
 
 #include <string>
 #include <Eigen/Dense>
+#include <vector>
 
 namespace basix
 {
@@ -39,7 +40,7 @@ Eigen::ArrayXd apply_mapping(int order, const Eigen::ArrayXd& reference_data,
                               const Eigen::MatrixXd& J, double detJ,
                               const Eigen::MatrixXd& K,
                               mapping::type mapping_type,
-                                       const std::vector<int> value_shape);
+                              const std::vector<int> value_shape);
 
 /// Convert mapping type enum to string
 const std::string& type_to_str(mapping::type type);

--- a/cpp/mappings.h
+++ b/cpp/mappings.h
@@ -41,6 +41,21 @@ Eigen::ArrayXd apply_mapping(const Eigen::ArrayXd& reference_data,
                              mapping::type mapping_type,
                              const std::vector<int> value_shape);
 
+/// Apply inverse mapping
+/// @param physical_data The data to apply the inverse mapping to
+/// @param J The Jacobian
+/// @param detJ The determinant of the Jacobian
+/// @param K The inverse of the Jacobian
+/// @param mapping_type Mapping type
+/// @param value_shape The value shape of the data
+/// @return The mapped data
+// TODO: should data be in/out?
+Eigen::ArrayXd apply_inverse_mapping(const Eigen::ArrayXd& physical_data,
+                                     const Eigen::MatrixXd& J, double detJ,
+                                     const Eigen::MatrixXd& K,
+                                     mapping::type mapping_type,
+                                     const std::vector<int> value_shape);
+
 /// Convert mapping type enum to string
 const std::string& type_to_str(mapping::type type);
 

--- a/cpp/mappings.h
+++ b/cpp/mappings.h
@@ -31,7 +31,11 @@ enum class type
 /// @param value_size The value size of the data
 /// @return The mapped data
 // TODO: should data be in/out?
-Eigen::ArrayXXd apply_mapping(Eigen::ArrayXXd data, mapping::type mapping_type, int value_size);
+Eigen::ArrayXd apply_mapping(int order, const Eigen::ArrayXd& reference_data,
+                              const Eigen::MatrixXd& J, double detJ,
+                              const Eigen::MatrixXd& K,
+                              mapping::type mapping_type,
+                                       const std::vector<int> value_shape={1});
 
 /// Convert mapping type enum to string
 const std::string& type_to_str(mapping::type type);

--- a/cpp/mappings.h
+++ b/cpp/mappings.h
@@ -35,11 +35,11 @@ enum class type
 /// @param value_shape The value shape of the data
 /// @return The mapped data
 // TODO: should data be in/out?
-Eigen::ArrayXd apply_mapping(const Eigen::ArrayXd& reference_data,
-                             const Eigen::MatrixXd& J, double detJ,
-                             const Eigen::MatrixXd& K,
-                             mapping::type mapping_type,
-                             const std::vector<int> value_shape);
+Eigen::ArrayXd map_push_forward(const Eigen::ArrayXd& reference_data,
+                                const Eigen::MatrixXd& J, double detJ,
+                                const Eigen::MatrixXd& K,
+                                mapping::type mapping_type,
+                                const std::vector<int> value_shape);
 
 /// Apply inverse mapping
 /// @param physical_data The data to apply the inverse mapping to
@@ -50,11 +50,11 @@ Eigen::ArrayXd apply_mapping(const Eigen::ArrayXd& reference_data,
 /// @param value_shape The value shape of the data
 /// @return The mapped data
 // TODO: should data be in/out?
-Eigen::ArrayXd apply_inverse_mapping(const Eigen::ArrayXd& physical_data,
-                                     const Eigen::MatrixXd& J, double detJ,
-                                     const Eigen::MatrixXd& K,
-                                     mapping::type mapping_type,
-                                     const std::vector<int> value_shape);
+Eigen::ArrayXd map_pull_back(const Eigen::ArrayXd& physical_data,
+                             const Eigen::MatrixXd& J, double detJ,
+                             const Eigen::MatrixXd& K,
+                             mapping::type mapping_type,
+                             const std::vector<int> value_shape);
 
 /// Convert mapping type enum to string
 const std::string& type_to_str(mapping::type type);

--- a/cpp/moments.cpp
+++ b/cpp/moments.cpp
@@ -44,7 +44,8 @@ moments::make_integral_moments(const FiniteElement& moment_space,
 
   const int sub_entity_count = cell::sub_entity_count(celltype, sub_entity_dim);
 
-  auto [Qpts, Qwts] = quadrature::make_quadrature("default", sub_celltype, q_deg);
+  auto [Qpts, Qwts]
+      = quadrature::make_quadrature("default", sub_celltype, q_deg);
   const int tdim = cell::topological_dimension(celltype);
 
   // If this is always true, value_size input can be removed
@@ -88,8 +89,7 @@ moments::make_integral_moments(const FiniteElement& moment_space,
         Eigen::VectorXd axis = axes.row(d);
         for (int k = 0; k < value_size; ++k)
         {
-          Eigen::VectorXd q
-              = phi * Qwts * axis(k);
+          Eigen::VectorXd q = phi * Qwts * axis(k);
           Eigen::RowVectorXd qcoeffs = poly_set_at_Qpts * q;
           assert(qcoeffs.size() == psize);
           dual.block(c, psize * k, 1, psize) = qcoeffs;
@@ -114,7 +114,8 @@ moments::make_integral_moments_interpolation(const FiniteElement& moment_space,
   const int sub_entity_count = cell::sub_entity_count(celltype, sub_entity_dim);
   const int tdim = cell::topological_dimension(celltype);
 
-  auto [Qpts, Qwts] = quadrature::make_quadrature("default", sub_celltype, q_deg);
+  auto [Qpts, Qwts]
+      = quadrature::make_quadrature("default", sub_celltype, q_deg);
 
   // If this is always true, value_size input can be removed
   assert(tdim == value_size);
@@ -185,7 +186,8 @@ Eigen::MatrixXd moments::make_dot_integral_moments(
 
   const int sub_entity_count = cell::sub_entity_count(celltype, sub_entity_dim);
 
-  auto [Qpts, Qwts] = quadrature::make_quadrature("default", sub_celltype, q_deg);
+  auto [Qpts, Qwts]
+      = quadrature::make_quadrature("default", sub_celltype, q_deg);
   const int tdim = cell::topological_dimension(celltype);
 
   // If this is always true, value_size input can be removed
@@ -229,8 +231,7 @@ Eigen::MatrixXd moments::make_dot_integral_moments(
           Eigen::ArrayXd phi
               = moment_space_at_Qpts.col(d * moment_space_size + j);
           Eigen::VectorXd axis = axes.row(d);
-          Eigen::VectorXd qpart
-              = phi * Qwts * axis(k);
+          Eigen::VectorXd qpart = phi * Qwts * axis(k);
           q += qpart;
         }
         Eigen::RowVectorXd qcoeffs = poly_set_at_Qpts * q;
@@ -325,7 +326,8 @@ Eigen::MatrixXd moments::make_tangent_integral_moments(
   if (sub_entity_dim != 1)
     throw std::runtime_error("Tangent is only well-defined on an edge.");
 
-  auto [Qpts, Qwts] = quadrature::make_quadrature("default", cell::type::interval, q_deg);
+  auto [Qpts, Qwts]
+      = quadrature::make_quadrature("default", cell::type::interval, q_deg);
 
   // If this is always true, value_size input can be removed
   assert(tdim == value_size);
@@ -388,7 +390,8 @@ moments::make_tangent_integral_moments_interpolation(
   if (sub_entity_dim != 1)
     throw std::runtime_error("Tangent is only well-defined on an edge.");
 
-  auto [Qpts, Qwts] = quadrature::make_quadrature("default", cell::type::interval, q_deg);
+  auto [Qpts, Qwts]
+      = quadrature::make_quadrature("default", cell::type::interval, q_deg);
 
   // If this is always true, value_size input can be removed
   assert(tdim == value_size);
@@ -452,7 +455,8 @@ Eigen::MatrixXd moments::make_normal_integral_moments(
   if (sub_entity_dim != tdim - 1)
     throw std::runtime_error("Normal is only well-defined on a facet.");
 
-  auto [Qpts, Qwts] = quadrature::make_quadrature("default", sub_celltype, q_deg);
+  auto [Qpts, Qwts]
+      = quadrature::make_quadrature("default", sub_celltype, q_deg);
 
   // If this is always true, value_size input can be removed
   assert(tdim == value_size);
@@ -539,7 +543,8 @@ moments::make_normal_integral_moments_interpolation(
   if (sub_entity_dim != tdim - 1)
     throw std::runtime_error("Normal is only well-defined on a facet.");
 
-  auto [Qpts, Qwts] = quadrature::make_quadrature("default", sub_celltype, q_deg);
+  auto [Qpts, Qwts]
+      = quadrature::make_quadrature("default", sub_celltype, q_deg);
 
   // If this is always true, value_size input can be removed
   assert(tdim == value_size);

--- a/cpp/nce-rtc.cpp
+++ b/cpp/nce-rtc.cpp
@@ -6,6 +6,7 @@
 #include "dof-permutations.h"
 #include "lagrange.h"
 #include "log.h"
+#include "mappings.h"
 #include "moments.h"
 #include "polyset.h"
 #include "quadrature.h"
@@ -186,7 +187,8 @@ FiniteElement basix::create_rtc(cell::type celltype, int degree,
 
   Eigen::MatrixXd coeffs = compute_expansion_coefficients(wcoeffs, dual);
   return FiniteElement(name, celltype, degree, {tdim}, coeffs, entity_dofs,
-                       base_permutations, {}, {}, "contravariant piola");
+                       base_permutations, {}, {},
+                       mapping::type::contravariantPiola);
 }
 //-----------------------------------------------------------------------------
 FiniteElement basix::create_nce(cell::type celltype, int degree,
@@ -398,7 +400,8 @@ FiniteElement basix::create_nce(cell::type celltype, int degree,
 
   Eigen::MatrixXd coeffs = compute_expansion_coefficients(wcoeffs, dual);
   return FiniteElement(name, celltype, degree, {tdim}, coeffs, entity_dofs,
-                       base_permutations, {}, {}, "covariant piola");
+                       base_permutations, {}, {},
+                       mapping::type::covariantPiola);
 }
 //-----------------------------------------------------------------------------
 Eigen::MatrixXd basix::dofperms::quadrilateral_rtc_rotation(int degree)

--- a/cpp/nedelec.cpp
+++ b/cpp/nedelec.cpp
@@ -5,6 +5,7 @@
 #include "nedelec.h"
 #include "dof-permutations.h"
 #include "lagrange.h"
+#include "mappings.h"
 #include "moments.h"
 #include "polyset.h"
 #include "quadrature.h"
@@ -692,7 +693,7 @@ FiniteElement basix::create_nedelec(cell::type celltype, int degree,
 
   const Eigen::MatrixXd coeffs = compute_expansion_coefficients(wcoeffs, dual);
   return FiniteElement(name, celltype, degree, {tdim}, coeffs, entity_dofs,
-                       perms, points, interp_matrix, "covariant piola");
+                       perms, points, interp_matrix, mapping::type::covariantPiola);
 }
 //-----------------------------------------------------------------------------
 FiniteElement basix::create_nedelec2(cell::type celltype, int degree,
@@ -739,6 +740,6 @@ FiniteElement basix::create_nedelec2(cell::type celltype, int degree,
 
   return FiniteElement(name, celltype, degree, {tdim}, coeffs, entity_dofs,
                        base_permutations, points, interp_matrix,
-                       "covariant piola");
+                       mapping::type::covariantPiola);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/nedelec.cpp
+++ b/cpp/nedelec.cpp
@@ -31,8 +31,8 @@ Eigen::MatrixXd create_nedelec_2d_space(int degree)
   const int ns = degree;
 
   // Tabulate polynomial set at quadrature points
-  auto [Qpts, Qwts]
-      = quadrature::make_quadrature("default", cell::type::triangle, 2 * degree);
+  auto [Qpts, Qwts] = quadrature::make_quadrature(
+      "default", cell::type::triangle, 2 * degree);
   Eigen::ArrayXXd Pkp1_at_Qpts
       = polyset::tabulate(cell::type::triangle, degree, 0, Qpts)[0];
 
@@ -190,8 +190,8 @@ Eigen::MatrixXd create_nedelec_3d_space(int degree)
                     + (degree - 2) * (degree - 1) * degree / 2;
 
   // Tabulate polynomial basis at quadrature points
-  auto [Qpts, Qwts]
-    = quadrature::make_quadrature("default", cell::type::tetrahedron, 2 * degree);
+  auto [Qpts, Qwts] = quadrature::make_quadrature(
+      "default", cell::type::tetrahedron, 2 * degree);
   Eigen::ArrayXXd Pkp1_at_Qpts
       = polyset::tabulate(cell::type::tetrahedron, degree, 0, Qpts)[0];
   const int psize = Pkp1_at_Qpts.cols();
@@ -654,7 +654,7 @@ std::vector<Eigen::MatrixXd> create_nedelec2_3d_base_permutations(int degree)
 
 //-----------------------------------------------------------------------------
 FiniteElement basix::create_nedelec(cell::type celltype, int degree,
-                                     const std::string& name)
+                                    const std::string& name)
 {
   Eigen::MatrixXd wcoeffs;
   Eigen::MatrixXd dual;
@@ -693,11 +693,12 @@ FiniteElement basix::create_nedelec(cell::type celltype, int degree,
 
   const Eigen::MatrixXd coeffs = compute_expansion_coefficients(wcoeffs, dual);
   return FiniteElement(name, celltype, degree, {tdim}, coeffs, entity_dofs,
-                       perms, points, interp_matrix, mapping::type::covariantPiola);
+                       perms, points, interp_matrix,
+                       mapping::type::covariantPiola);
 }
 //-----------------------------------------------------------------------------
 FiniteElement basix::create_nedelec2(cell::type celltype, int degree,
-                                      const std::string& name)
+                                     const std::string& name)
 {
   const int tdim = cell::topological_dimension(celltype);
   const int psize = polyset::dim(celltype, degree);

--- a/cpp/raviart-thomas.cpp
+++ b/cpp/raviart-thomas.cpp
@@ -17,7 +17,7 @@ using namespace basix;
 
 //----------------------------------------------------------------------------
 FiniteElement basix::create_rt(cell::type celltype, int degree,
-                                const std::string& name)
+                               const std::string& name)
 {
   if (celltype != cell::type::triangle and celltype != cell::type::tetrahedron)
     throw std::runtime_error("Unsupported cell type");
@@ -36,7 +36,8 @@ FiniteElement basix::create_rt(cell::type celltype, int degree,
   const int ns = polyset::dim(facettype, degree - 1);
 
   // Evaluate the expansion polynomials at the quadrature points
-  auto [Qpts, Qwts] = quadrature::make_quadrature("default", celltype, 2 * degree);
+  auto [Qpts, Qwts]
+      = quadrature::make_quadrature("default", celltype, 2 * degree);
   Eigen::ArrayXXd Pkp1_at_Qpts
       = polyset::tabulate(celltype, degree, 0, Qpts)[0];
 
@@ -115,7 +116,7 @@ FiniteElement basix::create_rt(cell::type celltype, int degree,
     }
 
     Eigen::ArrayXXd edge_dir
-      = dofperms::interval_reflection_tangent_directions(degree);
+        = dofperms::interval_reflection_tangent_directions(degree);
     for (int edge = 0; edge < 3; ++edge)
     {
       Eigen::MatrixXd directions = Eigen::MatrixXd::Identity(ndofs, ndofs);
@@ -138,7 +139,8 @@ FiniteElement basix::create_rt(cell::type celltype, int degree,
         base_permutations[6 + 2 * face](start + i, start + i) = 0;
         base_permutations[6 + 2 * face](start + i, start + face_rot[i]) = 1;
         base_permutations[6 + 2 * face + 1](start + i, start + i) = 0;
-        base_permutations[6 + 2 * face + 1](start + i, start + face_ref[i]) = -1;
+        base_permutations[6 + 2 * face + 1](start + i, start + face_ref[i])
+            = -1;
       }
     }
   }
@@ -152,7 +154,8 @@ FiniteElement basix::create_rt(cell::type celltype, int degree,
 
   Eigen::MatrixXd coeffs = compute_expansion_coefficients(wcoeffs, dual);
   return FiniteElement(name, celltype, degree, {tdim}, coeffs, entity_dofs,
-                       base_permutations, {}, {}, mapping::type::contravariantPiola);
+                       base_permutations, {}, {},
+                       mapping::type::contravariantPiola);
 }
 //-----------------------------------------------------------------------------
 Eigen::MatrixXd basix::dofperms::triangle_rt_rotation(int degree)

--- a/cpp/raviart-thomas.cpp
+++ b/cpp/raviart-thomas.cpp
@@ -5,6 +5,7 @@
 #include "raviart-thomas.h"
 #include "dof-permutations.h"
 #include "lagrange.h"
+#include "mappings.h"
 #include "moments.h"
 #include "polyset.h"
 #include "quadrature.h"
@@ -151,7 +152,7 @@ FiniteElement basix::create_rt(cell::type celltype, int degree,
 
   Eigen::MatrixXd coeffs = compute_expansion_coefficients(wcoeffs, dual);
   return FiniteElement(name, celltype, degree, {tdim}, coeffs, entity_dofs,
-                       base_permutations, {}, {}, "contravariant piola");
+                       base_permutations, {}, {}, mapping::type::contravariantPiola);
 }
 //-----------------------------------------------------------------------------
 Eigen::MatrixXd basix::dofperms::triangle_rt_rotation(int degree)

--- a/cpp/regge.cpp
+++ b/cpp/regge.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier:    MIT
 
 #include "regge.h"
+#include "mappings.h"
 #include "lattice.h"
 #include "polyset.h"
 #include <iostream>
@@ -149,6 +150,6 @@ FiniteElement basix::create_regge(cell::type celltype, int degree,
     entity_dofs[3] = {(degree + 1) * degree * (degree - 1)};
 
   return FiniteElement(name, celltype, degree, {tdim, tdim}, coeffs,
-                       entity_dofs, base_permutations, {}, {}, "double covariant piola");
+                       entity_dofs, base_permutations, {}, {}, mapping::type::doubleCovariantPiola);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/regge.cpp
+++ b/cpp/regge.cpp
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier:    MIT
 
 #include "regge.h"
-#include "mappings.h"
 #include "lattice.h"
+#include "mappings.h"
 #include "polyset.h"
 #include <iostream>
 
@@ -123,7 +123,7 @@ Eigen::MatrixXd create_regge_dual(cell::type celltype, int degree)
 } // namespace
 //-----------------------------------------------------------------------------
 FiniteElement basix::create_regge(cell::type celltype, int degree,
-                                   const std::string& name)
+                                  const std::string& name)
 {
   const int tdim = cell::topological_dimension(celltype);
 
@@ -150,6 +150,7 @@ FiniteElement basix::create_regge(cell::type celltype, int degree,
     entity_dofs[3] = {(degree + 1) * degree * (degree - 1)};
 
   return FiniteElement(name, celltype, degree, {tdim, tdim}, coeffs,
-                       entity_dofs, base_permutations, {}, {}, mapping::type::doubleCovariantPiola);
+                       entity_dofs, base_permutations, {}, {},
+                       mapping::type::doubleCovariantPiola);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/wrapper.cpp
+++ b/cpp/wrapper.cpp
@@ -154,9 +154,8 @@ Each element has a `tabulate` function which returns the basis functions and a n
 
   py::class_<FiniteElement>(m, "FiniteElement", "Finite Element")
       .def("tabulate", &FiniteElement::tabulate, tabdoc.c_str())
-      .def("apply_mapping", &FiniteElement::apply_mapping, mapdoc.c_str())
-      .def("apply_inverse_mapping", &FiniteElement::apply_inverse_mapping,
-           invmapdoc.c_str())
+      .def("map_push_forward", &FiniteElement::map_push_forward, mapdoc.c_str())
+      .def("map_pull_back", &FiniteElement::map_pull_back, invmapdoc.c_str())
       .def_property_readonly("base_permutations",
                              &FiniteElement::base_permutations)
       .def_property_readonly("degree", &FiniteElement::degree)

--- a/cpp/wrapper.cpp
+++ b/cpp/wrapper.cpp
@@ -137,6 +137,17 @@ Each element has a `tabulate` function which returns the basis functions and a n
       },
       "Convert a mapping type to a string.");
 
+  py::enum_<element::family>(m, "ElementFamily")
+      .value("custom", element::family::custom)
+      .value("P", element::family::P)
+      .value("DP", element::family::DP)
+      .value("BDM", element::family::BDM)
+      .value("RT", element::family::RT)
+      .value("N1E", element::family::N1E)
+      .value("N2E", element::family::N2E)
+      .value("Regge", element::family::Regge)
+      .value("CR", element::family::CR);
+
   m.def(
       "family_to_str",
       [](element::family family_type) -> const std::string& {

--- a/cpp/wrapper.cpp
+++ b/cpp/wrapper.cpp
@@ -12,6 +12,7 @@
 #include "finite-element.h"
 #include "indexing.h"
 #include "lattice.h"
+#include "mappings.h"
 #include "polyset.h"
 #include "quadrature.h"
 
@@ -80,18 +81,26 @@ Each element has a `tabulate` function which returns the basis functions and a n
   m.def("create_lattice", &lattice::create,
         "Create a uniform lattice of points on a reference cell");
 
+  py::enum_<mapping::type>(m, "MappingType")
+      .value("identity", mapping::type::identity)
+      .value("covariantPiola", mapping::type::covariantPiola)
+      .value("contravariantPiola", mapping::type::contravariantPiola)
+      .value("doubleCovariantPiola", mapping::type::doubleCovariantPiola)
+      .value("doubleContravariantPiola", mapping::type::doubleContravariantPiola);
+
   m.def(
       "create_new_element",
       [](const std::string family_name, cell::type celltype, int degree,
          std::vector<int>& value_shape, const Eigen::MatrixXd& dualmat,
          const Eigen::MatrixXd& coeffs,
          const std::vector<std::vector<int>>& entity_dofs,
-         const std::vector<Eigen::MatrixXd>& base_permutations)
+         const std::vector<Eigen::MatrixXd>& base_permutations,
+         mapping::type mapping_type=mapping::type::identity)
           -> FiniteElement {
         return FiniteElement(
             family_name, celltype, degree, value_shape,
             compute_expansion_coefficients(coeffs, dualmat, true), entity_dofs,
-            base_permutations, {});
+            base_permutations, {}, {}, mapping_type);
       },
       "Create an element from basic data");
 
@@ -106,7 +115,7 @@ Each element has a `tabulate` function which returns the basis functions and a n
       .def_property_readonly("value_size", &FiniteElement::value_size)
       .def_property_readonly("value_shape", &FiniteElement::value_shape)
       .def_property_readonly("family_name", &FiniteElement::family_name)
-      .def_property_readonly("mapping_name", &FiniteElement::mapping_name)
+      .def_property_readonly("mapping_type", &FiniteElement::mapping_type)
       .def_property_readonly("points", &FiniteElement::points)
       .def_property_readonly("interpolation_matrix",
                              &FiniteElement::interpolation_matrix);

--- a/cpp/wrapper.cpp
+++ b/cpp/wrapper.cpp
@@ -102,7 +102,7 @@ Each element has a `tabulate` function which returns the basis functions and a n
                                        const Eigen::MatrixXd& J, double detJ,
                                        const Eigen::MatrixXd& K,
                                        mapping::type mapping_type,
-                                        std::vector<int> value_shape={1})
+                                        std::vector<int> value_shape)
         -> Eigen::ArrayXd {
             return mapping::apply_mapping(order, reference_data, J, detJ, K, mapping_type, value_shape);
         },

--- a/cpp/wrapper.cpp
+++ b/cpp/wrapper.cpp
@@ -97,6 +97,18 @@ Each element has a `tabulate` function which returns the basis functions and a n
       "Convert a mapping type to a string.");
 
   m.def(
+      "apply_mapping",
+      [](int order, const Eigen::ArrayXd& reference_data,
+                                       const Eigen::MatrixXd& J, double detJ,
+                                       const Eigen::MatrixXd& K,
+                                       mapping::type mapping_type,
+                                        std::vector<int> value_shape={1})
+        -> Eigen::ArrayXd {
+            return mapping::apply_mapping(order, reference_data, J, detJ, K, mapping_type, value_shape);
+        },
+        "Apply a mapping to a piece of data.");
+
+  m.def(
       "create_new_element",
       [](const std::string family_name, cell::type celltype, int degree,
          std::vector<int>& value_shape, const Eigen::MatrixXd& dualmat,

--- a/cpp/wrapper.cpp
+++ b/cpp/wrapper.cpp
@@ -86,12 +86,12 @@ Each element has a `tabulate` function which returns the basis functions and a n
       .value("covariantPiola", mapping::type::covariantPiola)
       .value("contravariantPiola", mapping::type::contravariantPiola)
       .value("doubleCovariantPiola", mapping::type::doubleCovariantPiola)
-      .value("doubleContravariantPiola", mapping::type::doubleContravariantPiola);
+      .value("doubleContravariantPiola",
+             mapping::type::doubleContravariantPiola);
 
   m.def(
       "mapping_to_str",
-      [](mapping::type mapping_type)
-          -> const std::string& {
+      [](mapping::type mapping_type) -> const std::string& {
         return mapping::type_to_str(mapping_type);
       },
       "Convert a mapping type to a string.");
@@ -99,14 +99,13 @@ Each element has a `tabulate` function which returns the basis functions and a n
   m.def(
       "apply_mapping",
       [](int order, const Eigen::ArrayXd& reference_data,
-                                       const Eigen::MatrixXd& J, double detJ,
-                                       const Eigen::MatrixXd& K,
-                                       mapping::type mapping_type,
-                                        std::vector<int> value_shape)
-        -> Eigen::ArrayXd {
-            return mapping::apply_mapping(order, reference_data, J, detJ, K, mapping_type, value_shape);
-        },
-        "Apply a mapping to a piece of data.");
+         const Eigen::MatrixXd& J, double detJ, const Eigen::MatrixXd& K,
+         mapping::type mapping_type,
+         std::vector<int> value_shape) -> Eigen::ArrayXd {
+        return mapping::apply_mapping(order, reference_data, J, detJ, K,
+                                      mapping_type, value_shape);
+      },
+      "Apply a mapping to a piece of data.");
 
   m.def(
       "create_new_element",
@@ -115,8 +114,8 @@ Each element has a `tabulate` function which returns the basis functions and a n
          const Eigen::MatrixXd& coeffs,
          const std::vector<std::vector<int>>& entity_dofs,
          const std::vector<Eigen::MatrixXd>& base_permutations,
-         mapping::type mapping_type=mapping::type::identity)
-          -> FiniteElement {
+         mapping::type mapping_type
+         = mapping::type::identity) -> FiniteElement {
         return FiniteElement(
             family_name, celltype, degree, value_shape,
             compute_expansion_coefficients(coeffs, dualmat, true), entity_dofs,

--- a/cpp/wrapper.cpp
+++ b/cpp/wrapper.cpp
@@ -47,7 +47,43 @@ List[numpy.ndarray]
 )";
 
 const std::string mapdoc = R"(
-TODO: document
+Map a function value from the reference to a cell
+
+Parameters
+==========
+reference_data : numpy.array
+    The function value on the reference
+J : np.ndarray
+    The Jacobian of the mapping
+detJ : int
+    The determinant of the Jacobian of the mapping
+K : np.ndarray
+    The inverse of the Jacobian of the mapping
+
+Returns
+=======
+numpy.ndarray
+    The function value on the cell
+)";
+
+const std::string invmapdoc = R"(
+Map a function value from a cell to the reference
+
+Parameters
+==========
+physical_data : numpy.array
+    The function value on the cell
+J : np.ndarray
+    The Jacobian of the mapping
+detJ : int
+    The determinant of the Jacobian of the mapping
+K : np.ndarray
+    The inverse of the Jacobian of the mapping
+
+Returns
+=======
+numpy.ndarray
+    The function value on the reference
 )";
 
 PYBIND11_MODULE(_basixcpp, m)
@@ -119,6 +155,8 @@ Each element has a `tabulate` function which returns the basis functions and a n
   py::class_<FiniteElement>(m, "FiniteElement", "Finite Element")
       .def("tabulate", &FiniteElement::tabulate, tabdoc.c_str())
       .def("apply_mapping", &FiniteElement::apply_mapping, mapdoc.c_str())
+      .def("apply_inverse_mapping", &FiniteElement::apply_inverse_mapping,
+           invmapdoc.c_str())
       .def_property_readonly("base_permutations",
                              &FiniteElement::base_permutations)
       .def_property_readonly("degree", &FiniteElement::degree)

--- a/cpp/wrapper.cpp
+++ b/cpp/wrapper.cpp
@@ -46,6 +46,10 @@ List[numpy.ndarray]
     where `n` is the number of derivatives and `d` is the topological dimension.
 )";
 
+const std::string mapdoc = R"(
+TODO: document
+)";
+
 PYBIND11_MODULE(_basixcpp, m)
 {
   m.doc() = R"(
@@ -97,17 +101,6 @@ Each element has a `tabulate` function which returns the basis functions and a n
       "Convert a mapping type to a string.");
 
   m.def(
-      "apply_mapping",
-      [](int order, const Eigen::ArrayXd& reference_data,
-         const Eigen::MatrixXd& J, double detJ, const Eigen::MatrixXd& K,
-         mapping::type mapping_type,
-         std::vector<int> value_shape) -> Eigen::ArrayXd {
-        return mapping::apply_mapping(order, reference_data, J, detJ, K,
-                                      mapping_type, value_shape);
-      },
-      "Apply a mapping to a piece of data.");
-
-  m.def(
       "create_new_element",
       [](const std::string family_name, cell::type celltype, int degree,
          std::vector<int>& value_shape, const Eigen::MatrixXd& dualmat,
@@ -125,6 +118,7 @@ Each element has a `tabulate` function which returns the basis functions and a n
 
   py::class_<FiniteElement>(m, "FiniteElement", "Finite Element")
       .def("tabulate", &FiniteElement::tabulate, tabdoc.c_str())
+      .def("apply_mapping", &FiniteElement::apply_mapping, mapdoc.c_str())
       .def_property_readonly("base_permutations",
                              &FiniteElement::base_permutations)
       .def_property_readonly("degree", &FiniteElement::degree)

--- a/cpp/wrapper.cpp
+++ b/cpp/wrapper.cpp
@@ -138,6 +138,13 @@ Each element has a `tabulate` function which returns the basis functions and a n
       "Convert a mapping type to a string.");
 
   m.def(
+      "family_to_str",
+      [](element::family family_type) -> const std::string& {
+        return element::type_to_str(family_type);
+      },
+      "Convert a family type to a string.");
+
+  m.def(
       "create_new_element",
       [](element::family family_type, cell::type celltype, int degree,
          std::vector<int>& value_shape, const Eigen::MatrixXd& dualmat,
@@ -149,7 +156,7 @@ Each element has a `tabulate` function which returns the basis functions and a n
         return FiniteElement(
             family_type, celltype, degree, value_shape,
             compute_expansion_coefficients(coeffs, dualmat, true), entity_dofs,
-            base_permutations, {});
+            base_permutations, {}, {}, mapping_type);
       },
       "Create an element from basic data");
 
@@ -159,8 +166,9 @@ Each element has a `tabulate` function which returns the basis functions and a n
          std::vector<int>& value_shape, const Eigen::MatrixXd& dualmat,
          const Eigen::MatrixXd& coeffs,
          const std::vector<std::vector<int>>& entity_dofs,
-         const std::vector<Eigen::MatrixXd>& base_permutations)
-          -> FiniteElement {
+         const std::vector<Eigen::MatrixXd>& base_permutations,
+         mapping::type mapping_type
+         = mapping::type::identity) -> FiniteElement {
         return FiniteElement(
             element::str_to_type(family_name), cell::str_to_type(cell_name),
             degree, value_shape,

--- a/cpp/wrapper.cpp
+++ b/cpp/wrapper.cpp
@@ -89,6 +89,14 @@ Each element has a `tabulate` function which returns the basis functions and a n
       .value("doubleContravariantPiola", mapping::type::doubleContravariantPiola);
 
   m.def(
+      "mapping_to_str",
+      [](mapping::type mapping_type)
+          -> const std::string& {
+        return mapping::type_to_str(mapping_type);
+      },
+      "Convert a mapping type to a string.");
+
+  m.def(
       "create_new_element",
       [](const std::string family_name, cell::type celltype, int degree,
          std::vector<int>& value_shape, const Eigen::MatrixXd& dualmat,

--- a/test/test_create.py
+++ b/test/test_create.py
@@ -17,7 +17,8 @@ def test_create_simple():
     coeff_space = numpy.identity(points.shape[0])
 
     fe = basix.create_new_element("Custom element", celltype, degree, [1], dualmat, coeff_space,
-                                  [[1, 1, 1], [0, 0, 0], [0]], [numpy.identity(3) for i in range(3)])
+                                  [[1, 1, 1], [0, 0, 0], [0]], [numpy.identity(3) for i in range(3)],
+                                  basix.MappingType.identity)
 
     numpy.set_printoptions(suppress=True, precision=2)
 
@@ -39,7 +40,8 @@ def test_create_custom():
     coeff_space = numpy.identity(points.shape[0])
     fe = basix.create_new_element("Custom element", celltype, degree, [1], dualmat, coeff_space,
                                   [[0, 0, 0], [1, 1, 1], [3]],
-                                  [numpy.identity(5) for i in range(3)])
+                                  [numpy.identity(5) for i in range(3)],
+                                  basix.MappingType.identity)
 
     numpy.set_printoptions(suppress=True, precision=2)
 
@@ -62,4 +64,4 @@ def test_create_invalid():
     with pytest.raises(RuntimeError):
         basix.create_new_element("Custom element", celltype, degree, [1], dualmat, coeff_space,
                                  [[0, 0, 0], [2, 2, 2], [0]],
-                                 [numpy.identity(6) for i in range(3)])
+                                 [numpy.identity(6) for i in range(3)], basix.MappingType.identity)

--- a/test/test_permutations.py
+++ b/test/test_permutations.py
@@ -129,12 +129,10 @@ def test_permutation_of_tabulated_data_triangle(element_name, order):
         J = np.array([[0, 1], [1, 0]])
         detJ = np.linalg.det(J)
         K = np.linalg.inv(J)
-
         mapped_values = np.zeros_like(reflected_values)
         for i, value in enumerate(reflected_values):
-            for j in range(e.dim):
-                mapped_values[i][j::e.dim] = basix.apply_mapping(1, value[j::e.dim], J, detJ, K, e.mapping_type,
-                                                                 e.value_shape)
+            mapped_values[i] = e.apply_mapping(1, value, J, detJ, K)
+
         for i, j in zip(values, mapped_values):
             for d in range(e.value_size):
                 i_slice = i[d * e.dim:(d + 1) * e.dim]

--- a/test/test_permutations.py
+++ b/test/test_permutations.py
@@ -131,7 +131,8 @@ def test_permutation_of_tabulated_data_triangle(element_name, order):
         K = np.linalg.inv(J)
         mapped_values = np.zeros_like(reflected_values)
         for i, value in enumerate(reflected_values):
-            mapped_values[i] = e.apply_mapping(1, value, J, detJ, K)
+            for j in range(e.dim):
+                mapped_values[i, j::e.dim] = e.apply_mapping(value[j::e.dim], J, detJ, K)
 
         for i, j in zip(values, mapped_values):
             for d in range(e.value_size):
@@ -162,7 +163,8 @@ def test_permutation_of_tabulated_data_quadrilateral(element_name, order):
         K = np.linalg.inv(J)
         mapped_values = np.zeros_like(reflected_values)
         for i, value in enumerate(reflected_values):
-            mapped_values[i] = e.apply_mapping(1, value, J, detJ, K)
+            for j in range(e.dim):
+                mapped_values[i, j::e.dim] = e.apply_mapping(value[j::e.dim], J, detJ, K)
 
         for i, j in zip(values, mapped_values):
             for d in range(e.value_size):
@@ -199,7 +201,8 @@ def test_permutation_of_tabulated_data_tetrahedron(element_name, order):
         K = np.linalg.inv(J)
         mapped_values = np.zeros_like(reflected_values)
         for i, value in enumerate(reflected_values):
-            mapped_values[i] = e.apply_mapping(1, value, J, detJ, K)
+            for j in range(e.dim):
+                mapped_values[i, j::e.dim] = e.apply_mapping(value[j::e.dim], J, detJ, K)
 
         for i, j in zip(values, mapped_values):
             for d in range(e.value_size):
@@ -220,7 +223,8 @@ def test_permutation_of_tabulated_data_tetrahedron(element_name, order):
         K = np.linalg.inv(J)
         mapped_values = np.zeros_like(rotated_values)
         for i, value in enumerate(rotated_values):
-            mapped_values[i] = e.apply_mapping(1, value, J, detJ, K)
+            for j in range(e.dim):
+                mapped_values[i, j::e.dim] = e.apply_mapping(value[j::e.dim], J, detJ, K)
 
         for i, j in zip(values, mapped_values):
             for d in range(e.value_size):
@@ -239,7 +243,8 @@ def test_permutation_of_tabulated_data_tetrahedron(element_name, order):
         K = np.linalg.inv(J)
         mapped_values = np.zeros_like(reflected_values)
         for i, value in enumerate(reflected_values):
-            mapped_values[i] = e.apply_mapping(1, value, J, detJ, K)
+            for j in range(e.dim):
+                mapped_values[i, j::e.dim] = e.apply_mapping(value[j::e.dim], J, detJ, K)
 
         for i, j in zip(values, mapped_values):
             for d in range(e.value_size):
@@ -271,7 +276,8 @@ def test_permutation_of_tabulated_data_hexahedron(element_name, order):
         K = np.linalg.inv(J)
         mapped_values = np.zeros_like(reflected_values)
         for i, value in enumerate(reflected_values):
-            mapped_values[i] = e.apply_mapping(1, value, J, detJ, K)
+            for j in range(e.dim):
+                mapped_values[i, j::e.dim] = e.apply_mapping(value[j::e.dim], J, detJ, K)
 
         for i, j in zip(values, mapped_values):
             for d in range(e.value_size):
@@ -292,7 +298,8 @@ def test_permutation_of_tabulated_data_hexahedron(element_name, order):
         K = np.linalg.inv(J)
         mapped_values = np.zeros_like(rotated_values)
         for i, value in enumerate(rotated_values):
-            mapped_values[i] = e.apply_mapping(1, value, J, detJ, K)
+            for j in range(e.dim):
+                mapped_values[i, j::e.dim] = e.apply_mapping(value[j::e.dim], J, detJ, K)
 
         for i, j in zip(values, mapped_values):
             for d in range(e.value_size):
@@ -311,7 +318,8 @@ def test_permutation_of_tabulated_data_hexahedron(element_name, order):
         K = np.linalg.inv(J)
         mapped_values = np.zeros_like(reflected_values)
         for i, value in enumerate(reflected_values):
-            mapped_values[i] = e.apply_mapping(1, value, J, detJ, K)
+            for j in range(e.dim):
+                mapped_values[i, j::e.dim] = e.apply_mapping(value[j::e.dim], J, detJ, K)
 
         for i, j in zip(values, mapped_values):
             for d in range(e.value_size):

--- a/test/test_permutations.py
+++ b/test/test_permutations.py
@@ -110,6 +110,8 @@ def test_hexahedron_permutation_orders(element_name, order):
 def test_permutation_of_tabulated_data_triangle(element_name, order):
     if element_name == "Crouzeix-Raviart" and order != 1:
         pytest.xfail()
+    if element_name == "Regge":
+        pytest.skip("Permutations not yet implemented for Regge elements.")
 
     e = basix.create_element(element_name, "triangle", order)
 
@@ -124,22 +126,16 @@ def test_permutation_of_tabulated_data_triangle(element_name, order):
         reflected_points = np.array([[p[1], p[0]] for p in points])
         reflected_values = e.tabulate(0, reflected_points)[0]
 
-        if e.mapping_type == basix.MappingType.identity:
-            pass
-        elif e.mapping_type == basix.MappingType.covariantPiola:
-            for i, r in enumerate(reflected_values):
-                for j in range(e.dim):
-                    reflected_values[i][j::e.dim] = r[j::e.dim][::-1]
-        elif e.mapping_type == basix.MappingType.contravariantPiola:
-            for i, r in enumerate(reflected_values):
-                for j in range(e.dim):
-                    reflected_values[i][j::e.dim] = -r[j::e.dim][::-1]
-        elif e.mapping_type == basix.MappingType.doubleCovariantPiola:
-            pytest.skip()  # TODO: implement double covariant piola
-        else:
-            raise ValueError(f"Unknown mapping: {e.mapping_type}")
+        J = np.array([[0, 1], [1, 0]])
+        detJ = np.linalg.det(J)
+        K = np.linalg.inv(J)
 
-        for i, j in zip(values, reflected_values):
+        mapped_values = np.zeros_like(reflected_values)
+        for i, value in enumerate(reflected_values):
+            for j in range(e.dim):
+                mapped_values[i][j::e.dim] = basix.apply_mapping(1, value[j::e.dim], J, detJ, K, e.mapping_type,
+                                                                 e.value_shape)
+        for i, j in zip(values, mapped_values):
             for d in range(e.value_size):
                 i_slice = i[d * e.dim:(d + 1) * e.dim]
                 j_slice = j[d * e.dim:(d + 1) * e.dim]
@@ -163,20 +159,16 @@ def test_permutation_of_tabulated_data_quadrilateral(element_name, order):
         reflected_points = np.array([[1 - p[0], p[1]] for p in points])
         reflected_values = e.tabulate(0, reflected_points)[0]
 
-        if e.mapping_type == basix.MappingType.identity:
-            pass
-        elif e.mapping_type == basix.MappingType.covariantPiola:
-            for i, r in enumerate(reflected_values):
-                reflected_values[i][::e.dim] *= -1
-        elif e.mapping_type == basix.MappingType.contravariantPiola:
-            for i, r in enumerate(reflected_values):
-                reflected_values[i][1::e.dim] *= -1
-        elif e.mapping_type == basix.MappingType.doubleCovariantPiola:
-            pytest.skip()  # TODO: implement double covariant piola
-        else:
-            raise ValueError(f"Unknown mapping: {e.mapping_type}")
+        J = np.array([[-1, 0], [0, 1]])
+        detJ = np.linalg.det(J)
+        K = np.linalg.inv(J)
 
-        for i, j in zip(values, reflected_values):
+        mapped_values = np.zeros_like(reflected_values)
+        for i, value in enumerate(reflected_values):
+            for j in range(e.dim):
+                mapped_values[i][j::e.dim] = basix.apply_mapping(1, value[j::e.dim], J, detJ, K, e.mapping_type,
+                                                                 e.value_shape)
+        for i, j in zip(values, mapped_values):
             for d in range(e.value_size):
                 i_slice = i[d * e.dim:(d + 1) * e.dim]
                 j_slice = j[d * e.dim:(d + 1) * e.dim]
@@ -189,6 +181,8 @@ def test_permutation_of_tabulated_data_quadrilateral(element_name, order):
 def test_permutation_of_tabulated_data_tetrahedron(element_name, order):
     if element_name == "Crouzeix-Raviart" and order != 1:
         pytest.xfail()
+    if element_name == "Regge":
+        pytest.skip("Permutations not yet implemented for Regge elements.")
 
     e = basix.create_element(element_name, "tetrahedron", order)
 
@@ -204,23 +198,16 @@ def test_permutation_of_tabulated_data_tetrahedron(element_name, order):
         reflected_points = np.array([[p[0], p[2], p[1]] for p in points])
         reflected_values = e.tabulate(0, reflected_points)[0]
 
-        if e.mapping_type == basix.MappingType.identity:
-            pass
-        elif e.mapping_type == basix.MappingType.covariantPiola:
-            for i, r in enumerate(reflected_values):
-                for j in range(e.dim):
-                    reflected_values[i][j + e.dim::e.dim] = r[j + e.dim::e.dim][::-1]
-        elif e.mapping_type == basix.MappingType.contravariantPiola:
-            for i, r in enumerate(reflected_values):
-                for j in range(e.dim):
-                    reflected_values[i][j] = -r[j]
-                    reflected_values[i][j + e.dim::e.dim] = -r[j + e.dim::e.dim][::-1]
-        elif e.mapping_type == basix.MappingType.doubleCovariantPiola:
-            pytest.skip()  # TODO: implement double covariant piola
-        else:
-            raise ValueError(f"Unknown mapping: {e.mapping_type}")
+        J = np.array([[1, 0, 0], [0, 0, 1], [0, 1, 0]])
+        detJ = np.linalg.det(J)
+        K = np.linalg.inv(J)
 
-        for i, j in zip(values, reflected_values):
+        mapped_values = np.zeros_like(reflected_values)
+        for i, value in enumerate(reflected_values):
+            for j in range(e.dim):
+                mapped_values[i][j::e.dim] = basix.apply_mapping(1, value[j::e.dim], J, detJ, K, e.mapping_type,
+                                                                 e.value_shape)
+        for i, j in zip(values, mapped_values):
             for d in range(e.value_size):
                 i_slice = i[d * e.dim:(d + 1) * e.dim]
                 j_slice = j[d * e.dim:(d + 1) * e.dim]
@@ -234,22 +221,16 @@ def test_permutation_of_tabulated_data_tetrahedron(element_name, order):
         rotated_points = np.array([[p[2], p[0], p[1]] for p in points])
         rotated_values = e.tabulate(0, rotated_points)[0]
 
-        if e.mapping_type == basix.MappingType.identity:
-            pass
-        elif e.mapping_type == basix.MappingType.covariantPiola:
-            for i, r in enumerate(rotated_values):
-                for j in range(e.dim):
-                    rotated_values[i][j::e.dim] = (r[j + e.dim], r[j + 2 * e.dim], r[j])
-        elif e.mapping_type == basix.MappingType.contravariantPiola:
-            for i, r in enumerate(rotated_values):
-                for j in range(e.dim):
-                    rotated_values[i][j::e.dim] = (r[j + e.dim], r[j + 2 * e.dim], r[j])
-        elif e.mapping_type == basix.MappingType.doubleCovariantPiola:
-            pytest.skip()  # TODO: implement double covariant piola
-        else:
-            raise ValueError(f"Unknown mapping: {e.mapping_type}")
+        J = np.array([[0, 1, 0], [0, 0, 1], [1, 0, 0]])
+        detJ = np.linalg.det(J)
+        K = np.linalg.inv(J)
 
-        for i, j in zip(values, rotated_values):
+        mapped_values = np.zeros_like(rotated_values)
+        for i, value in enumerate(rotated_values):
+            for j in range(e.dim):
+                mapped_values[i][j::e.dim] = basix.apply_mapping(1, value[j::e.dim], J, detJ, K, e.mapping_type,
+                                                                 e.value_shape)
+        for i, j in zip(values, mapped_values):
             for d in range(e.value_size):
                 i_slice = i[d * e.dim:(d + 1) * e.dim]
                 j_slice = j[d * e.dim:(d + 1) * e.dim]
@@ -261,23 +242,16 @@ def test_permutation_of_tabulated_data_tetrahedron(element_name, order):
         reflected_points = np.array([[p[0], p[2], p[1]] for p in points])
         reflected_values = e.tabulate(0, reflected_points)[0]
 
-        if e.mapping_type == basix.MappingType.identity:
-            pass
-        elif e.mapping_type == basix.MappingType.covariantPiola:
-            for i, r in enumerate(reflected_values):
-                for j in range(e.dim):
-                    reflected_values[i][j + e.dim::e.dim] = r[j + e.dim::e.dim][::-1]
-        elif e.mapping_type == basix.MappingType.contravariantPiola:
-            for i, r in enumerate(reflected_values):
-                for j in range(e.dim):
-                    reflected_values[i][j] = -r[j]
-                    reflected_values[i][j + e.dim::e.dim] = -r[j + e.dim::e.dim][::-1]
-        elif e.mapping_type == basix.MappingType.doubleCovariantPiola:
-            pytest.skip()  # TODO: implement double covariant piola
-        else:
-            raise ValueError(f"Unknown mapping: {e.mapping_type}")
+        J = np.array([[1, 0, 0], [0, 0, 1], [0, 1, 0]])
+        detJ = np.linalg.det(J)
+        K = np.linalg.inv(J)
 
-        for i, j in zip(values, reflected_values):
+        mapped_values = np.zeros_like(reflected_values)
+        for i, value in enumerate(reflected_values):
+            for j in range(e.dim):
+                mapped_values[i][j::e.dim] = basix.apply_mapping(1, value[j::e.dim], J, detJ, K, e.mapping_type,
+                                                                 e.value_shape)
+        for i, j in zip(values, mapped_values):
             for d in range(e.value_size):
                 i_slice = i[d * e.dim:(d + 1) * e.dim]
                 j_slice = j[d * e.dim:(d + 1) * e.dim]
@@ -302,21 +276,16 @@ def test_permutation_of_tabulated_data_hexahedron(element_name, order):
         reflected_points = np.array([[1 - p[0], p[1], p[2]] for p in points])
         reflected_values = e.tabulate(0, reflected_points)[0]
 
-        if e.mapping_type == basix.MappingType.identity:
-            pass
-        elif e.mapping_type == basix.MappingType.covariantPiola:
-            for i, r in enumerate(reflected_values):
-                reflected_values[i][::e.dim] *= -1
-        elif e.mapping_type == basix.MappingType.contravariantPiola:
-            for i, r in enumerate(reflected_values):
-                reflected_values[i][1::e.dim] *= -1
-                reflected_values[i][2::e.dim] *= -1
-        elif e.mapping_type == basix.MappingType.doubleCovariantPiola:
-            pytest.skip()  # TODO: implement double covariant piola
-        else:
-            raise ValueError(f"Unknown mapping: {e.mapping_type}")
+        J = np.array([[-1, 0, 0], [0, 1, 0], [0, 0, 1]])
+        detJ = np.linalg.det(J)
+        K = np.linalg.inv(J)
 
-        for i, j in zip(values, reflected_values):
+        mapped_values = np.zeros_like(reflected_values)
+        for i, value in enumerate(reflected_values):
+            for j in range(e.dim):
+                mapped_values[i][j::e.dim] = basix.apply_mapping(1, value[j::e.dim], J, detJ, K, e.mapping_type,
+                                                                 e.value_shape)
+        for i, j in zip(values, mapped_values):
             for d in range(e.value_size):
                 i_slice = i[d * e.dim:(d + 1) * e.dim]
                 j_slice = j[d * e.dim:(d + 1) * e.dim]
@@ -330,26 +299,16 @@ def test_permutation_of_tabulated_data_hexahedron(element_name, order):
         rotated_points = np.array([[1 - p[1], p[0], p[2]] for p in points])
         rotated_values = e.tabulate(0, rotated_points)[0]
 
-        if e.mapping_type == basix.MappingType.identity:
-            pass
-        elif e.mapping_type == basix.MappingType.covariantPiola:
-            for i, r in enumerate(rotated_values):
-                for j in range(e.dim):
-                    (rotated_values[i][j],
-                     rotated_values[i][j + e.dim],
-                     rotated_values[i][j + 2 * e.dim]) = (r[j + e.dim], r[j + 2 * e.dim], r[j])
-        elif e.mapping_type == basix.MappingType.contravariantPiola:
-            for i, r in enumerate(rotated_values):
-                for j in range(e.dim):
-                    (rotated_values[i][j],
-                     rotated_values[i][j + e.dim],
-                     rotated_values[i][j + 2 * e.dim]) = (r[j + e.dim], r[j + 2 * e.dim], r[j])
-        elif e.mapping_type == basix.MappingType.doubleCovariantPiola:
-            pytest.skip()  # TODO: implement double covariant piola
-        else:
-            raise ValueError(f"Unknown mapping: {e.mapping_type}")
+        J = np.array([[0, 1, 0], [-1, 0, 0], [0, 0, 1]])
+        detJ = np.linalg.det(J)
+        K = np.linalg.inv(J)
 
-        for i, j in zip(values, rotated_values):
+        mapped_values = np.zeros_like(rotated_values)
+        for i, value in enumerate(rotated_values):
+            for j in range(e.dim):
+                mapped_values[i][j::e.dim] = basix.apply_mapping(1, value[j::e.dim], J, detJ, K, e.mapping_type,
+                                                                 e.value_shape)
+        for i, j in zip(values, mapped_values):
             for d in range(e.value_size):
                 i_slice = i[d * e.dim:(d + 1) * e.dim]
                 j_slice = j[d * e.dim:(d + 1) * e.dim]
@@ -361,23 +320,16 @@ def test_permutation_of_tabulated_data_hexahedron(element_name, order):
         reflected_points = np.array([[p[1], p[0], p[2]] for p in points])
         reflected_values = e.tabulate(0, reflected_points)[0]
 
-        if e.mapping_type == basix.MappingType.identity:
-            pass
-        elif e.mapping_type == basix.MappingType.covariantPiola:
-            for i, r in enumerate(reflected_values):
-                for j in range(e.dim):
-                    reflected_values[i][j:-e.dim:e.dim] = r[j:-e.dim:e.dim][::-1]
-        elif e.mapping_type == basix.MappingType.contravariantPiola:
-            for i, r in enumerate(reflected_values):
-                for j in range(e.dim):
-                    reflected_values[i][j + 2 * e.dim] *= -1
-                    reflected_values[i][j:-e.dim:e.dim] = -r[j:-e.dim:e.dim][::-1]
-        elif e.mapping_type == basix.MappingType.doubleCovariantPiola:
-            pytest.skip()  # TODO: implement double covariant piola
-        else:
-            raise ValueError(f"Unknown mapping: {e.mapping_type}")
+        J = np.array([[0, 1, 0], [1, 0, 0], [0, 0, 1]])
+        detJ = np.linalg.det(J)
+        K = np.linalg.inv(J)
 
-        for i, j in zip(values, reflected_values):
+        mapped_values = np.zeros_like(reflected_values)
+        for i, value in enumerate(reflected_values):
+            for j in range(e.dim):
+                mapped_values[i][j::e.dim] = basix.apply_mapping(1, value[j::e.dim], J, detJ, K, e.mapping_type,
+                                                                 e.value_shape)
+        for i, j in zip(values, mapped_values):
             for d in range(e.value_size):
                 i_slice = i[d * e.dim:(d + 1) * e.dim]
                 j_slice = j[d * e.dim:(d + 1) * e.dim]

--- a/test/test_permutations.py
+++ b/test/test_permutations.py
@@ -160,12 +160,10 @@ def test_permutation_of_tabulated_data_quadrilateral(element_name, order):
         J = np.array([[-1, 0], [0, 1]])
         detJ = np.linalg.det(J)
         K = np.linalg.inv(J)
-
         mapped_values = np.zeros_like(reflected_values)
         for i, value in enumerate(reflected_values):
-            for j in range(e.dim):
-                mapped_values[i][j::e.dim] = basix.apply_mapping(1, value[j::e.dim], J, detJ, K, e.mapping_type,
-                                                                 e.value_shape)
+            mapped_values[i] = e.apply_mapping(1, value, J, detJ, K)
+
         for i, j in zip(values, mapped_values):
             for d in range(e.value_size):
                 i_slice = i[d * e.dim:(d + 1) * e.dim]
@@ -199,12 +197,10 @@ def test_permutation_of_tabulated_data_tetrahedron(element_name, order):
         J = np.array([[1, 0, 0], [0, 0, 1], [0, 1, 0]])
         detJ = np.linalg.det(J)
         K = np.linalg.inv(J)
-
         mapped_values = np.zeros_like(reflected_values)
         for i, value in enumerate(reflected_values):
-            for j in range(e.dim):
-                mapped_values[i][j::e.dim] = basix.apply_mapping(1, value[j::e.dim], J, detJ, K, e.mapping_type,
-                                                                 e.value_shape)
+            mapped_values[i] = e.apply_mapping(1, value, J, detJ, K)
+
         for i, j in zip(values, mapped_values):
             for d in range(e.value_size):
                 i_slice = i[d * e.dim:(d + 1) * e.dim]
@@ -222,12 +218,10 @@ def test_permutation_of_tabulated_data_tetrahedron(element_name, order):
         J = np.array([[0, 1, 0], [0, 0, 1], [1, 0, 0]])
         detJ = np.linalg.det(J)
         K = np.linalg.inv(J)
-
         mapped_values = np.zeros_like(rotated_values)
         for i, value in enumerate(rotated_values):
-            for j in range(e.dim):
-                mapped_values[i][j::e.dim] = basix.apply_mapping(1, value[j::e.dim], J, detJ, K, e.mapping_type,
-                                                                 e.value_shape)
+            mapped_values[i] = e.apply_mapping(1, value, J, detJ, K)
+
         for i, j in zip(values, mapped_values):
             for d in range(e.value_size):
                 i_slice = i[d * e.dim:(d + 1) * e.dim]
@@ -243,12 +237,10 @@ def test_permutation_of_tabulated_data_tetrahedron(element_name, order):
         J = np.array([[1, 0, 0], [0, 0, 1], [0, 1, 0]])
         detJ = np.linalg.det(J)
         K = np.linalg.inv(J)
-
         mapped_values = np.zeros_like(reflected_values)
         for i, value in enumerate(reflected_values):
-            for j in range(e.dim):
-                mapped_values[i][j::e.dim] = basix.apply_mapping(1, value[j::e.dim], J, detJ, K, e.mapping_type,
-                                                                 e.value_shape)
+            mapped_values[i] = e.apply_mapping(1, value, J, detJ, K)
+
         for i, j in zip(values, mapped_values):
             for d in range(e.value_size):
                 i_slice = i[d * e.dim:(d + 1) * e.dim]
@@ -277,12 +269,10 @@ def test_permutation_of_tabulated_data_hexahedron(element_name, order):
         J = np.array([[-1, 0, 0], [0, 1, 0], [0, 0, 1]])
         detJ = np.linalg.det(J)
         K = np.linalg.inv(J)
-
         mapped_values = np.zeros_like(reflected_values)
         for i, value in enumerate(reflected_values):
-            for j in range(e.dim):
-                mapped_values[i][j::e.dim] = basix.apply_mapping(1, value[j::e.dim], J, detJ, K, e.mapping_type,
-                                                                 e.value_shape)
+            mapped_values[i] = e.apply_mapping(1, value, J, detJ, K)
+
         for i, j in zip(values, mapped_values):
             for d in range(e.value_size):
                 i_slice = i[d * e.dim:(d + 1) * e.dim]
@@ -300,12 +290,10 @@ def test_permutation_of_tabulated_data_hexahedron(element_name, order):
         J = np.array([[0, 1, 0], [-1, 0, 0], [0, 0, 1]])
         detJ = np.linalg.det(J)
         K = np.linalg.inv(J)
-
         mapped_values = np.zeros_like(rotated_values)
         for i, value in enumerate(rotated_values):
-            for j in range(e.dim):
-                mapped_values[i][j::e.dim] = basix.apply_mapping(1, value[j::e.dim], J, detJ, K, e.mapping_type,
-                                                                 e.value_shape)
+            mapped_values[i] = e.apply_mapping(1, value, J, detJ, K)
+
         for i, j in zip(values, mapped_values):
             for d in range(e.value_size):
                 i_slice = i[d * e.dim:(d + 1) * e.dim]
@@ -321,12 +309,10 @@ def test_permutation_of_tabulated_data_hexahedron(element_name, order):
         J = np.array([[0, 1, 0], [1, 0, 0], [0, 0, 1]])
         detJ = np.linalg.det(J)
         K = np.linalg.inv(J)
-
         mapped_values = np.zeros_like(reflected_values)
         for i, value in enumerate(reflected_values):
-            for j in range(e.dim):
-                mapped_values[i][j::e.dim] = basix.apply_mapping(1, value[j::e.dim], J, detJ, K, e.mapping_type,
-                                                                 e.value_shape)
+            mapped_values[i] = e.apply_mapping(1, value, J, detJ, K)
+
         for i, j in zip(values, mapped_values):
             for d in range(e.value_size):
                 i_slice = i[d * e.dim:(d + 1) * e.dim]

--- a/test/test_permutations.py
+++ b/test/test_permutations.py
@@ -124,7 +124,7 @@ def test_permutation_of_tabulated_data_triangle(element_name, order):
         reflected_points = np.array([[p[1], p[0]] for p in points])
         reflected_values = e.tabulate(0, reflected_points)[0]
 
-        if e.mapping_name == "affine":
+        if e.mapping_name == "identity":
             pass
         elif e.mapping_name == "covariant piola":
             for i, r in enumerate(reflected_values):
@@ -163,7 +163,7 @@ def test_permutation_of_tabulated_data_quadrilateral(element_name, order):
         reflected_points = np.array([[1 - p[0], p[1]] for p in points])
         reflected_values = e.tabulate(0, reflected_points)[0]
 
-        if e.mapping_name == "affine":
+        if e.mapping_name == "identity":
             pass
         elif e.mapping_name == "covariant piola":
             for i, r in enumerate(reflected_values):
@@ -204,7 +204,7 @@ def test_permutation_of_tabulated_data_tetrahedron(element_name, order):
         reflected_points = np.array([[p[0], p[2], p[1]] for p in points])
         reflected_values = e.tabulate(0, reflected_points)[0]
 
-        if e.mapping_name == "affine":
+        if e.mapping_name == "identity":
             pass
         elif e.mapping_name == "covariant piola":
             for i, r in enumerate(reflected_values):
@@ -234,7 +234,7 @@ def test_permutation_of_tabulated_data_tetrahedron(element_name, order):
         rotated_points = np.array([[p[2], p[0], p[1]] for p in points])
         rotated_values = e.tabulate(0, rotated_points)[0]
 
-        if e.mapping_name == "affine":
+        if e.mapping_name == "identity":
             pass
         elif e.mapping_name == "covariant piola":
             for i, r in enumerate(rotated_values):
@@ -261,7 +261,7 @@ def test_permutation_of_tabulated_data_tetrahedron(element_name, order):
         reflected_points = np.array([[p[0], p[2], p[1]] for p in points])
         reflected_values = e.tabulate(0, reflected_points)[0]
 
-        if e.mapping_name == "affine":
+        if e.mapping_name == "identity":
             pass
         elif e.mapping_name == "covariant piola":
             for i, r in enumerate(reflected_values):
@@ -302,7 +302,7 @@ def test_permutation_of_tabulated_data_hexahedron(element_name, order):
         reflected_points = np.array([[1 - p[0], p[1], p[2]] for p in points])
         reflected_values = e.tabulate(0, reflected_points)[0]
 
-        if e.mapping_name == "affine":
+        if e.mapping_name == "identity":
             pass
         elif e.mapping_name == "covariant piola":
             for i, r in enumerate(reflected_values):
@@ -330,7 +330,7 @@ def test_permutation_of_tabulated_data_hexahedron(element_name, order):
         rotated_points = np.array([[1 - p[1], p[0], p[2]] for p in points])
         rotated_values = e.tabulate(0, rotated_points)[0]
 
-        if e.mapping_name == "affine":
+        if e.mapping_name == "identity":
             pass
         elif e.mapping_name == "covariant piola":
             for i, r in enumerate(rotated_values):
@@ -361,7 +361,7 @@ def test_permutation_of_tabulated_data_hexahedron(element_name, order):
         reflected_points = np.array([[p[1], p[0], p[2]] for p in points])
         reflected_values = e.tabulate(0, reflected_points)[0]
 
-        if e.mapping_name == "affine":
+        if e.mapping_name == "identity":
             pass
         elif e.mapping_name == "covariant piola":
             for i, r in enumerate(reflected_values):

--- a/test/test_permutations.py
+++ b/test/test_permutations.py
@@ -132,7 +132,7 @@ def test_permutation_of_tabulated_data_triangle(element_name, order):
         mapped_values = np.zeros_like(reflected_values)
         for i, value in enumerate(reflected_values):
             for j in range(e.dim):
-                mapped_values[i, j::e.dim] = e.apply_mapping(value[j::e.dim], J, detJ, K)
+                mapped_values[i, j::e.dim] = e.map_push_forward(value[j::e.dim], J, detJ, K)
 
         for i, j in zip(values, mapped_values):
             for d in range(e.value_size):
@@ -164,7 +164,7 @@ def test_permutation_of_tabulated_data_quadrilateral(element_name, order):
         mapped_values = np.zeros_like(reflected_values)
         for i, value in enumerate(reflected_values):
             for j in range(e.dim):
-                mapped_values[i, j::e.dim] = e.apply_mapping(value[j::e.dim], J, detJ, K)
+                mapped_values[i, j::e.dim] = e.map_push_forward(value[j::e.dim], J, detJ, K)
 
         for i, j in zip(values, mapped_values):
             for d in range(e.value_size):
@@ -202,7 +202,7 @@ def test_permutation_of_tabulated_data_tetrahedron(element_name, order):
         mapped_values = np.zeros_like(reflected_values)
         for i, value in enumerate(reflected_values):
             for j in range(e.dim):
-                mapped_values[i, j::e.dim] = e.apply_mapping(value[j::e.dim], J, detJ, K)
+                mapped_values[i, j::e.dim] = e.map_push_forward(value[j::e.dim], J, detJ, K)
 
         for i, j in zip(values, mapped_values):
             for d in range(e.value_size):
@@ -224,7 +224,7 @@ def test_permutation_of_tabulated_data_tetrahedron(element_name, order):
         mapped_values = np.zeros_like(rotated_values)
         for i, value in enumerate(rotated_values):
             for j in range(e.dim):
-                mapped_values[i, j::e.dim] = e.apply_mapping(value[j::e.dim], J, detJ, K)
+                mapped_values[i, j::e.dim] = e.map_push_forward(value[j::e.dim], J, detJ, K)
 
         for i, j in zip(values, mapped_values):
             for d in range(e.value_size):
@@ -244,7 +244,7 @@ def test_permutation_of_tabulated_data_tetrahedron(element_name, order):
         mapped_values = np.zeros_like(reflected_values)
         for i, value in enumerate(reflected_values):
             for j in range(e.dim):
-                mapped_values[i, j::e.dim] = e.apply_mapping(value[j::e.dim], J, detJ, K)
+                mapped_values[i, j::e.dim] = e.map_push_forward(value[j::e.dim], J, detJ, K)
 
         for i, j in zip(values, mapped_values):
             for d in range(e.value_size):
@@ -277,7 +277,7 @@ def test_permutation_of_tabulated_data_hexahedron(element_name, order):
         mapped_values = np.zeros_like(reflected_values)
         for i, value in enumerate(reflected_values):
             for j in range(e.dim):
-                mapped_values[i, j::e.dim] = e.apply_mapping(value[j::e.dim], J, detJ, K)
+                mapped_values[i, j::e.dim] = e.map_push_forward(value[j::e.dim], J, detJ, K)
 
         for i, j in zip(values, mapped_values):
             for d in range(e.value_size):
@@ -299,7 +299,7 @@ def test_permutation_of_tabulated_data_hexahedron(element_name, order):
         mapped_values = np.zeros_like(rotated_values)
         for i, value in enumerate(rotated_values):
             for j in range(e.dim):
-                mapped_values[i, j::e.dim] = e.apply_mapping(value[j::e.dim], J, detJ, K)
+                mapped_values[i, j::e.dim] = e.map_push_forward(value[j::e.dim], J, detJ, K)
 
         for i, j in zip(values, mapped_values):
             for d in range(e.value_size):
@@ -319,7 +319,7 @@ def test_permutation_of_tabulated_data_hexahedron(element_name, order):
         mapped_values = np.zeros_like(reflected_values)
         for i, value in enumerate(reflected_values):
             for j in range(e.dim):
-                mapped_values[i, j::e.dim] = e.apply_mapping(value[j::e.dim], J, detJ, K)
+                mapped_values[i, j::e.dim] = e.map_push_forward(value[j::e.dim], J, detJ, K)
 
         for i, j in zip(values, mapped_values):
             for d in range(e.value_size):

--- a/test/test_permutations.py
+++ b/test/test_permutations.py
@@ -124,20 +124,20 @@ def test_permutation_of_tabulated_data_triangle(element_name, order):
         reflected_points = np.array([[p[1], p[0]] for p in points])
         reflected_values = e.tabulate(0, reflected_points)[0]
 
-        if e.mapping_name == "identity":
+        if e.mapping_type == basix.MappingType.identity:
             pass
-        elif e.mapping_name == "covariant piola":
+        elif e.mapping_type == basix.MappingType.covariantPiola:
             for i, r in enumerate(reflected_values):
                 for j in range(e.dim):
                     reflected_values[i][j::e.dim] = r[j::e.dim][::-1]
-        elif e.mapping_name == "contravariant piola":
+        elif e.mapping_type == basix.MappingType.contravariantPiola:
             for i, r in enumerate(reflected_values):
                 for j in range(e.dim):
                     reflected_values[i][j::e.dim] = -r[j::e.dim][::-1]
-        elif e.mapping_name == "double covariant piola":
+        elif e.mapping_type == basix.MappingType.doubleCovariantPiola:
             pytest.skip()  # TODO: implement double covariant piola
         else:
-            raise ValueError(f"Unknown mapping: {e.mapping_name}")
+            raise ValueError(f"Unknown mapping: {e.mapping_type}")
 
         for i, j in zip(values, reflected_values):
             for d in range(e.value_size):
@@ -163,18 +163,18 @@ def test_permutation_of_tabulated_data_quadrilateral(element_name, order):
         reflected_points = np.array([[1 - p[0], p[1]] for p in points])
         reflected_values = e.tabulate(0, reflected_points)[0]
 
-        if e.mapping_name == "identity":
+        if e.mapping_type == basix.MappingType.identity:
             pass
-        elif e.mapping_name == "covariant piola":
+        elif e.mapping_type == basix.MappingType.covariantPiola:
             for i, r in enumerate(reflected_values):
                 reflected_values[i][::e.dim] *= -1
-        elif e.mapping_name == "contravariant piola":
+        elif e.mapping_type == basix.MappingType.contravariantPiola:
             for i, r in enumerate(reflected_values):
                 reflected_values[i][1::e.dim] *= -1
-        elif e.mapping_name == "double covariant piola":
+        elif e.mapping_type == basix.MappingType.doubleCovariantPiola:
             pytest.skip()  # TODO: implement double covariant piola
         else:
-            raise ValueError(f"Unknown mapping: {e.mapping_name}")
+            raise ValueError(f"Unknown mapping: {e.mapping_type}")
 
         for i, j in zip(values, reflected_values):
             for d in range(e.value_size):
@@ -204,21 +204,21 @@ def test_permutation_of_tabulated_data_tetrahedron(element_name, order):
         reflected_points = np.array([[p[0], p[2], p[1]] for p in points])
         reflected_values = e.tabulate(0, reflected_points)[0]
 
-        if e.mapping_name == "identity":
+        if e.mapping_type == basix.MappingType.identity:
             pass
-        elif e.mapping_name == "covariant piola":
+        elif e.mapping_type == basix.MappingType.covariantPiola:
             for i, r in enumerate(reflected_values):
                 for j in range(e.dim):
                     reflected_values[i][j + e.dim::e.dim] = r[j + e.dim::e.dim][::-1]
-        elif e.mapping_name == "contravariant piola":
+        elif e.mapping_type == basix.MappingType.contravariantPiola:
             for i, r in enumerate(reflected_values):
                 for j in range(e.dim):
                     reflected_values[i][j] = -r[j]
                     reflected_values[i][j + e.dim::e.dim] = -r[j + e.dim::e.dim][::-1]
-        elif e.mapping_name == "double covariant piola":
+        elif e.mapping_type == basix.MappingType.doubleCovariantPiola:
             pytest.skip()  # TODO: implement double covariant piola
         else:
-            raise ValueError(f"Unknown mapping: {e.mapping_name}")
+            raise ValueError(f"Unknown mapping: {e.mapping_type}")
 
         for i, j in zip(values, reflected_values):
             for d in range(e.value_size):
@@ -234,20 +234,20 @@ def test_permutation_of_tabulated_data_tetrahedron(element_name, order):
         rotated_points = np.array([[p[2], p[0], p[1]] for p in points])
         rotated_values = e.tabulate(0, rotated_points)[0]
 
-        if e.mapping_name == "identity":
+        if e.mapping_type == basix.MappingType.identity:
             pass
-        elif e.mapping_name == "covariant piola":
+        elif e.mapping_type == basix.MappingType.covariantPiola:
             for i, r in enumerate(rotated_values):
                 for j in range(e.dim):
                     rotated_values[i][j::e.dim] = (r[j + e.dim], r[j + 2 * e.dim], r[j])
-        elif e.mapping_name == "contravariant piola":
+        elif e.mapping_type == basix.MappingType.contravariantPiola:
             for i, r in enumerate(rotated_values):
                 for j in range(e.dim):
                     rotated_values[i][j::e.dim] = (r[j + e.dim], r[j + 2 * e.dim], r[j])
-        elif e.mapping_name == "double covariant piola":
+        elif e.mapping_type == basix.MappingType.doubleCovariantPiola:
             pytest.skip()  # TODO: implement double covariant piola
         else:
-            raise ValueError(f"Unknown mapping: {e.mapping_name}")
+            raise ValueError(f"Unknown mapping: {e.mapping_type}")
 
         for i, j in zip(values, rotated_values):
             for d in range(e.value_size):
@@ -261,21 +261,21 @@ def test_permutation_of_tabulated_data_tetrahedron(element_name, order):
         reflected_points = np.array([[p[0], p[2], p[1]] for p in points])
         reflected_values = e.tabulate(0, reflected_points)[0]
 
-        if e.mapping_name == "identity":
+        if e.mapping_type == basix.MappingType.identity:
             pass
-        elif e.mapping_name == "covariant piola":
+        elif e.mapping_type == basix.MappingType.covariantPiola:
             for i, r in enumerate(reflected_values):
                 for j in range(e.dim):
                     reflected_values[i][j + e.dim::e.dim] = r[j + e.dim::e.dim][::-1]
-        elif e.mapping_name == "contravariant piola":
+        elif e.mapping_type == basix.MappingType.contravariantPiola:
             for i, r in enumerate(reflected_values):
                 for j in range(e.dim):
                     reflected_values[i][j] = -r[j]
                     reflected_values[i][j + e.dim::e.dim] = -r[j + e.dim::e.dim][::-1]
-        elif e.mapping_name == "double covariant piola":
+        elif e.mapping_type == basix.MappingType.doubleCovariantPiola:
             pytest.skip()  # TODO: implement double covariant piola
         else:
-            raise ValueError(f"Unknown mapping: {e.mapping_name}")
+            raise ValueError(f"Unknown mapping: {e.mapping_type}")
 
         for i, j in zip(values, reflected_values):
             for d in range(e.value_size):
@@ -302,19 +302,19 @@ def test_permutation_of_tabulated_data_hexahedron(element_name, order):
         reflected_points = np.array([[1 - p[0], p[1], p[2]] for p in points])
         reflected_values = e.tabulate(0, reflected_points)[0]
 
-        if e.mapping_name == "identity":
+        if e.mapping_type == basix.MappingType.identity:
             pass
-        elif e.mapping_name == "covariant piola":
+        elif e.mapping_type == basix.MappingType.covariantPiola:
             for i, r in enumerate(reflected_values):
                 reflected_values[i][::e.dim] *= -1
-        elif e.mapping_name == "contravariant piola":
+        elif e.mapping_type == basix.MappingType.contravariantPiola:
             for i, r in enumerate(reflected_values):
                 reflected_values[i][1::e.dim] *= -1
                 reflected_values[i][2::e.dim] *= -1
-        elif e.mapping_name == "double covariant piola":
+        elif e.mapping_type == basix.MappingType.doubleCovariantPiola:
             pytest.skip()  # TODO: implement double covariant piola
         else:
-            raise ValueError(f"Unknown mapping: {e.mapping_name}")
+            raise ValueError(f"Unknown mapping: {e.mapping_type}")
 
         for i, j in zip(values, reflected_values):
             for d in range(e.value_size):
@@ -330,24 +330,24 @@ def test_permutation_of_tabulated_data_hexahedron(element_name, order):
         rotated_points = np.array([[1 - p[1], p[0], p[2]] for p in points])
         rotated_values = e.tabulate(0, rotated_points)[0]
 
-        if e.mapping_name == "identity":
+        if e.mapping_type == basix.MappingType.identity:
             pass
-        elif e.mapping_name == "covariant piola":
+        elif e.mapping_type == basix.MappingType.covariantPiola:
             for i, r in enumerate(rotated_values):
                 for j in range(e.dim):
                     (rotated_values[i][j],
                      rotated_values[i][j + e.dim],
                      rotated_values[i][j + 2 * e.dim]) = (r[j + e.dim], r[j + 2 * e.dim], r[j])
-        elif e.mapping_name == "contravariant piola":
+        elif e.mapping_type == basix.MappingType.contravariantPiola:
             for i, r in enumerate(rotated_values):
                 for j in range(e.dim):
                     (rotated_values[i][j],
                      rotated_values[i][j + e.dim],
                      rotated_values[i][j + 2 * e.dim]) = (r[j + e.dim], r[j + 2 * e.dim], r[j])
-        elif e.mapping_name == "double covariant piola":
+        elif e.mapping_type == basix.MappingType.doubleCovariantPiola:
             pytest.skip()  # TODO: implement double covariant piola
         else:
-            raise ValueError(f"Unknown mapping: {e.mapping_name}")
+            raise ValueError(f"Unknown mapping: {e.mapping_type}")
 
         for i, j in zip(values, rotated_values):
             for d in range(e.value_size):
@@ -361,21 +361,21 @@ def test_permutation_of_tabulated_data_hexahedron(element_name, order):
         reflected_points = np.array([[p[1], p[0], p[2]] for p in points])
         reflected_values = e.tabulate(0, reflected_points)[0]
 
-        if e.mapping_name == "identity":
+        if e.mapping_type == basix.MappingType.identity:
             pass
-        elif e.mapping_name == "covariant piola":
+        elif e.mapping_type == basix.MappingType.covariantPiola:
             for i, r in enumerate(reflected_values):
                 for j in range(e.dim):
                     reflected_values[i][j:-e.dim:e.dim] = r[j:-e.dim:e.dim][::-1]
-        elif e.mapping_name == "contravariant piola":
+        elif e.mapping_type == basix.MappingType.contravariantPiola:
             for i, r in enumerate(reflected_values):
                 for j in range(e.dim):
                     reflected_values[i][j + 2 * e.dim] *= -1
                     reflected_values[i][j:-e.dim:e.dim] = -r[j:-e.dim:e.dim][::-1]
-        elif e.mapping_name == "double covariant piola":
+        elif e.mapping_type == basix.MappingType.doubleCovariantPiola:
             pytest.skip()  # TODO: implement double covariant piola
         else:
-            raise ValueError(f"Unknown mapping: {e.mapping_name}")
+            raise ValueError(f"Unknown mapping: {e.mapping_type}")
 
         for i, j in zip(values, reflected_values):
             for d in range(e.value_size):


### PR DESCRIPTION
- Added `mapping::type` enum to use instead of string identifier.
- Implemented Piola mappings.
- Will allow us to remove `transform_reference_basis` from ffc and use these mappings directly.

Fixes #102. Fixes #99.

Progress towards #97 (type_to_str is now wrapped)

This PR is coupled with FEniCS/ffcx#304 and FEniCS/dolfinx#1369