### PR TITLE
Improve mappings

### DIFF
--- a/cpp/basix.cpp
+++ b/cpp/basix.cpp
@@ -62,9 +62,10 @@ void basix::tabulate(int handle, double* basis_values, int nd, const double* x,
 
 void basix::map_push_forward(int handle, double* physical_data,
                              const double* reference_data, const double* J,
-                             const double detJ, const double* K,
+                             const double* detJ, const double* K,
                              const int physical_dim,
-                             const int physical_value_size, const int nresults)
+                             const int physical_value_size, const int nresults,
+                             const int npoints)
 {
   check_handle(handle);
   const int tdim = cell::topological_dimension(_registry[handle]->cell_type());
@@ -72,20 +73,20 @@ void basix::map_push_forward(int handle, double* physical_data,
   Eigen::Map<Eigen::ArrayXXd>(physical_data, physical_value_size, nresults)
       = _registry[handle]->map_push_forward(
           Eigen::Map<const Eigen::ArrayXXd>(reference_data, vs, nresults),
-          Eigen::Map<const Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic,
-                                         Eigen::RowMajor>>(J, physical_dim,
-                                                           tdim),
-          detJ,
-          Eigen::Map<const Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic,
-                                         Eigen::RowMajor>>(K, tdim,
-                                                           physical_dim));
+          Eigen::Map<const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
+                                        Eigen::RowMajor>>(J, npoints,
+                                                          physical_dim * tdim),
+          Eigen::Map<const Eigen::ArrayXd>(detJ, npoints),
+          Eigen::Map<const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
+                                        Eigen::RowMajor>>(K, npoints,
+                                                          physical_dim * tdim));
 }
 
 void basix::map_pull_back(int handle, double* reference_data,
                           const double* physical_data, const double* J,
-                          const double detJ, const double* K,
+                          const double* detJ, const double* K,
                           const int physical_dim, const int physical_value_size,
-                          const int nresults)
+                          const int nresults, const int npoints)
 {
   check_handle(handle);
   const int tdim = cell::topological_dimension(_registry[handle]->cell_type());
@@ -94,13 +95,13 @@ void basix::map_pull_back(int handle, double* reference_data,
       = _registry[handle]->map_push_forward(
           Eigen::Map<const Eigen::ArrayXXd>(physical_data, physical_value_size,
                                             nresults),
-          Eigen::Map<const Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic,
-                                         Eigen::RowMajor>>(J, physical_dim,
-                                                           tdim),
-          detJ,
-          Eigen::Map<const Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic,
-                                         Eigen::RowMajor>>(K, tdim,
-                                                           physical_dim));
+          Eigen::Map<const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
+                                        Eigen::RowMajor>>(J, npoints,
+                                                          physical_dim * tdim),
+          Eigen::Map<const Eigen::ArrayXd>(detJ, npoints),
+          Eigen::Map<const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
+                                        Eigen::RowMajor>>(K, npoints,
+                                                          physical_dim * tdim));
 }
 
 const char* basix::cell_type(int handle)

--- a/cpp/basix.cpp
+++ b/cpp/basix.cpp
@@ -70,16 +70,18 @@ void basix::map_push_forward(int handle, double* physical_data,
   check_handle(handle);
   const int tdim = cell::topological_dimension(_registry[handle]->cell_type());
   const int vs = _registry[handle]->value_size();
-  Eigen::Map<Eigen::ArrayXXd>(physical_data, physical_value_size, nresults)
-      = _registry[handle]->map_push_forward(
-          Eigen::Map<const Eigen::ArrayXXd>(reference_data, vs, nresults),
-          Eigen::Map<const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
-                                        Eigen::RowMajor>>(J, npoints,
-                                                          physical_dim * tdim),
-          Eigen::Map<const Eigen::ArrayXd>(detJ, npoints),
-          Eigen::Map<const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
-                                        Eigen::RowMajor>>(K, npoints,
-                                                          physical_dim * tdim));
+  _registry[handle]->map_push_forward_to_memory(
+      Eigen::Map<const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
+                                    Eigen::RowMajor>>(reference_data, npoints,
+                                                      vs * nresults),
+      Eigen::Map<const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
+                                    Eigen::RowMajor>>(J, npoints,
+                                                      physical_dim * tdim),
+      Eigen::Map<const Eigen::ArrayXd>(detJ, npoints),
+      Eigen::Map<const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
+                                    Eigen::RowMajor>>(K, npoints,
+                                                      physical_dim * tdim),
+      physical_data);
 }
 
 void basix::map_pull_back(int handle, double* reference_data,
@@ -90,18 +92,18 @@ void basix::map_pull_back(int handle, double* reference_data,
 {
   check_handle(handle);
   const int tdim = cell::topological_dimension(_registry[handle]->cell_type());
-  const int vs = _registry[handle]->value_size();
-  Eigen::Map<Eigen::ArrayXXd>(reference_data, vs, nresults)
-      = _registry[handle]->map_push_forward(
-          Eigen::Map<const Eigen::ArrayXXd>(physical_data, physical_value_size,
-                                            nresults),
-          Eigen::Map<const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
-                                        Eigen::RowMajor>>(J, npoints,
-                                                          physical_dim * tdim),
-          Eigen::Map<const Eigen::ArrayXd>(detJ, npoints),
-          Eigen::Map<const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
-                                        Eigen::RowMajor>>(K, npoints,
-                                                          physical_dim * tdim));
+  _registry[handle]->map_pull_back_to_memory(
+      Eigen::Map<const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
+                                    Eigen::RowMajor>>(
+          physical_data, npoints, physical_value_size * nresults),
+      Eigen::Map<const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
+                                    Eigen::RowMajor>>(J, npoints,
+                                                      physical_dim * tdim),
+      Eigen::Map<const Eigen::ArrayXd>(detJ, npoints),
+      Eigen::Map<const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
+                                    Eigen::RowMajor>>(K, npoints,
+                                                      physical_dim * tdim),
+      reference_data);
 }
 
 const char* basix::cell_type(int handle)

--- a/cpp/basix.h
+++ b/cpp/basix.h
@@ -76,9 +76,9 @@ void tabulate(int handle, double* basis_values, int nd, const double* x,
 /// @param[in] nresults The number of data points
 void map_push_forward(int handle, double* physical_data,
                       const double* reference_data, const double* J,
-                      const double detJ, const double* K,
+                      const double* detJ, const double* K,
                       const int physical_dim, const int physical_value_size,
-                      const int nresults);
+                      const int nresults, const int npoints);
 
 /// Map a function value from a physical cell to the reference
 ///
@@ -116,8 +116,9 @@ void map_push_forward(int handle, double* physical_data,
 /// @param[in] nresults The number of data points
 void map_pull_back(int handle, double* reference_data,
                    const double* physical_data, const double* J,
-                   const double detJ, const double* K, const int physical_dim,
-                   const int physical_value_size, const int nresults);
+                   const double* detJ, const double* K, const int physical_dim,
+                   const int physical_value_size, const int nresults,
+                   const int npoints);
 
 /// String representation of the cell type of the finite element
 /// @param handle

--- a/cpp/basix.h
+++ b/cpp/basix.h
@@ -41,26 +41,28 @@ void release_element(int handle);
 void tabulate(int handle, double* basis_values, int nd, const double* x,
               int npoints);
 
-/// Map a function value from the reference to a physical cell.
+/// Map function values from the reference to a physical cell.
 ///
-/// The memory for "physical_data" must be allocated by the user, and is a two
+/// The memory for "physical_data" must be allocated by the user, and is a three
 /// dimensional (row-major) ndarray with dimensions
-/// [nresults, physical_value_size]
-/// where "physical_value_size" and "nresults" are given as function inputs.
+/// [npoints, nresults, physical_value_size]
+/// where "physical_value_size", "nresults", and "npoints" are given as function
+/// inputs.
 ///
 /// "reference_data" points to the memory for
-/// a two dimensional (row-major) ndarray with dimensions [nresults, value_size]
-/// where "nresults" is given as a function input, and
+/// a three dimensional (row-major) ndarray with dimensions [npoints, nresults,
+/// value_size] where "nresults" and "npoints" are given as function inputs, and
 /// "value_size" is the value size of the finite element (the product of the
 /// values in `value_shape()`).
 ///
-/// "J" points to the memory for a two dimensional (row-major) ndarray with
-/// dimensions [physical_dim, tdim], where "physical_dim" is given as a function
-/// input, and "tdim" is the topological dimension of the cell for this element.
+/// "J" points to the memory for a three dimensional (row-major) ndarray with
+/// dimensions [npoints, physical_dim, tdim], where "npoints" and "physical_dim"
+/// are given as function inputs, and "tdim" is the topological dimension of the
+/// cell for this element.
 ///
 /// "K" points
-/// to the memory for a two dimensional (row-major) ndarray with dimensions
-/// [tdim, physical_dim].
+/// to the memory for a three dimensional (row-major) ndarray with dimensions
+/// [npoints, tdim, physical_dim].
 ///
 /// @param[in] handle The handle of the basix element
 /// @param[out] physical_data The data on the physical cell at the corresponding
@@ -73,34 +75,35 @@ void tabulate(int handle, double* basis_values, int nd, const double* x,
 /// at the point)
 /// @param[in] physical_dim The geometric dimension of the physical domain
 /// @param[in] physical_value_size The value size of the physical element
-/// @param[in] nresults The number of data points
+/// @param[in] nresults The number of data values per point
+/// @param[in] npoints The number of points
 void map_push_forward(int handle, double* physical_data,
                       const double* reference_data, const double* J,
                       const double* detJ, const double* K,
                       const int physical_dim, const int physical_value_size,
                       const int nresults, const int npoints);
 
-/// Map a function value from a physical cell to the reference
+/// Map function values from a physical cell to the reference
 ///
-/// The memory for "reference_data" must be allocated by the user, and is a two
-/// dimensional (row-major) ndarray with dimensions
-/// [nresults, value_size]
-/// where "nresults" is given as a function input, and
+/// The memory for "reference_data" must be allocated by the user, and is a
+/// three dimensional (row-major) ndarray with dimensions [npoints, nresults,
+/// value_size] where "npoints" and "nresults" are given as function inputs, and
 /// "value_size" is the value size of the finite element (the product of the
 /// values in `value_shape()`).
 ///
 /// "reference_data" points to the memory for
-/// a two dimensional (row-major) ndarray with dimensions [nresults,
-/// physical_value_size] where "physical_value_size" and "nresults" are given as
-/// function inputs.
+/// a three dimensional (row-major) ndarray with dimensions [npoints, nresults,
+/// physical_value_size] where "physical_value_size", "nresults", and "npoints"
+/// are given as function inputs.
 ///
-/// "J" points to the memory for a two dimensional (row-major) ndarray with
-/// dimensions [physical_dim, tdim], where "physical_dim" is given as a function
-/// input, and "tdim" is the topological dimension of the cell for this element.
+/// "J" points to the memory for a three dimensional (row-major) ndarray with
+/// dimensions [npoints, physical_dim, tdim], where "physical_dim" and "npoints"
+/// are given as function inputs, and "tdim" is the topological dimension of the
+/// cell for this element.
 ///
 /// "K" points
 /// to the memory for a two dimensional (row-major) ndarray with dimensions
-/// [tdim, physical_dim].
+/// [npoints, tdim, physical_dim].
 ///
 /// @param[in] handle The handle of the basix element
 /// @param[out] reference_data The data on the physical cell at the
@@ -113,7 +116,8 @@ void map_push_forward(int handle, double* physical_data,
 /// at the point)
 /// @param[in] physical_dim The geometric dimension of the physical domain
 /// @param[in] physical_value_size The value size of the physical element
-/// @param[in] nresults The number of data points
+/// @param[in] nresults The number of data values per point
+/// @param[in] npoints The number of points
 void map_pull_back(int handle, double* reference_data,
                    const double* physical_data, const double* J,
                    const double* detJ, const double* K, const int physical_dim,

--- a/cpp/finite-element.cpp
+++ b/cpp/finite-element.cpp
@@ -138,6 +138,7 @@ FiniteElement::FiniteElement(
     throw std::runtime_error(
         "Number of entity dofs does not match total number of dofs");
   }
+  _map_push_forward = mapping::get_forward_map(mapping_type);
 }
 //-----------------------------------------------------------------------------
 cell::type FiniteElement::cell_type() const { return _cell_type; }
@@ -273,9 +274,8 @@ FiniteElement::map_push_forward(
                                    Eigen::RowMajor>>
         current_K(K.row(pt).data(), reference_dim, physical_dim);
     for (int i = 0; i < reference_block.cols(); ++i)
-      physical_block.col(i)
-          = mapping::map_push_forward(reference_block.col(i), current_J,
-                                      detJ[pt], current_K, _mapping_type);
+      physical_block.col(i) = _map_push_forward(reference_block.col(i),
+                                                current_J, detJ[pt], current_K);
   }
   return physical_data;
 }
@@ -315,9 +315,8 @@ void FiniteElement::map_push_forward_to_memory(
                                    Eigen::RowMajor>>
         current_K(K.row(pt).data(), reference_dim, physical_dim);
     for (int i = 0; i < reference_block.cols(); ++i)
-      physical_block.col(i)
-          = mapping::map_push_forward(reference_block.col(i), current_J,
-                                      detJ[pt], current_K, _mapping_type);
+      physical_block.col(i) = _map_push_forward(reference_block.col(i),
+                                                current_J, detJ[pt], current_K);
   }
 }
 //-----------------------------------------------------------------------------
@@ -358,9 +357,8 @@ FiniteElement::map_pull_back(
                                    Eigen::RowMajor>>
         current_K(K.row(pt).data(), reference_dim, physical_dim);
     for (int i = 0; i < physical_block.cols(); ++i)
-      reference_block.col(i)
-          = mapping::map_push_forward(physical_block.col(i), current_K,
-                                      1 / detJ[pt], current_J, _mapping_type);
+      reference_block.col(i) = _map_push_forward(
+          physical_block.col(i), current_K, 1 / detJ[pt], current_J);
   }
   return reference_data;
 }
@@ -400,9 +398,8 @@ void FiniteElement::map_pull_back_to_memory(
                                    Eigen::RowMajor>>
         current_K(K.row(pt).data(), reference_dim, physical_dim);
     for (int i = 0; i < physical_block.cols(); ++i)
-      reference_block.col(i)
-          = mapping::map_push_forward(physical_block.col(i), current_K,
-                                      1 / detJ[pt], current_J, _mapping_type);
+      reference_block.col(i) = _map_push_forward(
+          physical_block.col(i), current_K, 1 / detJ[pt], current_J);
   }
 }
 //-----------------------------------------------------------------------------

--- a/cpp/finite-element.cpp
+++ b/cpp/finite-element.cpp
@@ -256,8 +256,8 @@ FiniteElement::map_pull_back(const Eigen::ArrayXXd& physical_data,
 {
   Eigen::ArrayXXd reference_data(value_size(), physical_data.cols());
   for (int i = 0; i < physical_data.cols(); ++i)
-    reference_data.col(i) = mapping::map_pull_back(physical_data.col(i), J,
-                                                   detJ, K, _mapping_type);
+    reference_data.col(i) = mapping::map_push_forward(
+        physical_data.col(i), K, 1 / detJ, J, _mapping_type);
   return reference_data;
 }
 //-----------------------------------------------------------------------------

--- a/cpp/finite-element.cpp
+++ b/cpp/finite-element.cpp
@@ -244,8 +244,8 @@ FiniteElement::map_push_forward(const Eigen::ArrayXXd& reference_data,
   const int physical_value_size = compute_value_size(_mapping_type, J);
   Eigen::ArrayXXd physical_data(physical_value_size, reference_data.cols());
   for (int i = 0; i < reference_data.cols(); ++i)
-    physical_data.col(i) = mapping::map_push_forward(reference_data.col(i), J, detJ, K,
-                                              _mapping_type);
+    physical_data.col(i) = mapping::map_push_forward(reference_data.col(i), J,
+                                                     detJ, K, _mapping_type);
   return physical_data;
 }
 //-----------------------------------------------------------------------------
@@ -256,8 +256,8 @@ FiniteElement::map_pull_back(const Eigen::ArrayXXd& physical_data,
 {
   Eigen::ArrayXXd reference_data(value_size(), physical_data.cols());
   for (int i = 0; i < physical_data.cols(); ++i)
-    reference_data.col(i) = mapping::map_pull_back(physical_data.col(i), J, detJ, K,
-                                              _mapping_type);
+    reference_data.col(i) = mapping::map_pull_back(physical_data.col(i), J,
+                                                   detJ, K, _mapping_type);
   return reference_data;
 }
 //-----------------------------------------------------------------------------

--- a/cpp/finite-element.cpp
+++ b/cpp/finite-element.cpp
@@ -197,8 +197,7 @@ FiniteElement::map_push_forward(const Eigen::ArrayXd& reference_data,
                                 const Eigen::MatrixXd& J, double detJ,
                                 const Eigen::MatrixXd& K) const
 {
-  return mapping::map_push_forward(reference_data, J, detJ, K, _mapping_type,
-                                   _value_shape);
+  return mapping::map_push_forward(reference_data, J, detJ, K, _mapping_type);
 }
 //-----------------------------------------------------------------------------
 Eigen::ArrayXd FiniteElement::map_pull_back(const Eigen::ArrayXd& physical_data,
@@ -206,8 +205,7 @@ Eigen::ArrayXd FiniteElement::map_pull_back(const Eigen::ArrayXd& physical_data,
                                             double detJ,
                                             const Eigen::MatrixXd& K) const
 {
-  return mapping::map_pull_back(physical_data, J, detJ, K, _mapping_type,
-                                _value_shape);
+  return mapping::map_pull_back(physical_data, J, detJ, K, _mapping_type);
 }
 //-----------------------------------------------------------------------------
 const std::string& basix::version()

--- a/cpp/finite-element.h
+++ b/cpp/finite-element.h
@@ -238,9 +238,11 @@ public:
   /// @param detJ The determinant of the Jacobian of the mapping
   /// @param K The inverse of the Jacobian of the mapping
   /// @return The function values on the cell
-  Eigen::ArrayXXd map_push_forward(const Eigen::ArrayXXd& reference_data,
-                                   const Eigen::MatrixXd& J, double detJ,
-                                   const Eigen::MatrixXd& K) const;
+  Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
+  map_push_forward(const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
+                                      Eigen::RowMajor>& reference_data,
+                   const Eigen::MatrixXd& J, double detJ,
+                   const Eigen::MatrixXd& K) const;
 
   /// Map function values from a physical cell to the reference
   /// @param physical_data The function values on the cell
@@ -248,9 +250,11 @@ public:
   /// @param detJ The determinant of the Jacobian of the mapping
   /// @param K The inverse of the Jacobian of the mapping
   /// @return The function values on the reference
-  Eigen::ArrayXXd map_pull_back(const Eigen::ArrayXXd& physical_data,
-                                const Eigen::MatrixXd& J, double detJ,
-                                const Eigen::MatrixXd& K) const;
+  Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
+  map_pull_back(const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
+                                   Eigen::RowMajor>& physical_data,
+                const Eigen::MatrixXd& J, double detJ,
+                const Eigen::MatrixXd& K) const;
 
   /// Get the number of dofs on each topological entity: (vertices,
   /// edges, faces, cell) in that order. For example, Lagrange degree 2

--- a/cpp/finite-element.h
+++ b/cpp/finite-element.h
@@ -436,6 +436,11 @@ private:
 
   /// The interpolation weights and points
   Eigen::MatrixXd _interpolation_matrix;
+
+  // The mapping that maps values on the reference to values on a physical cell
+  std::function<Eigen::ArrayXd(const Eigen::ArrayXd&, const Eigen::MatrixXd&,
+                               const double, const Eigen::MatrixXd&)>
+      _map_push_forward;
 };
 
 /// Create an element by name

--- a/cpp/finite-element.h
+++ b/cpp/finite-element.h
@@ -247,6 +247,22 @@ public:
                    const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
                                       Eigen::RowMajor>& K) const;
 
+  /// Direct to memory push forward
+  /// @param reference_data The function values on the reference
+  /// @param J The Jacobian of the mapping
+  /// @param detJ The determinant of the Jacobian of the mapping
+  /// @param K The inverse of the Jacobian of the mapping
+  /// @param physical_data Memory location to fill
+  void map_push_forward_to_memory(
+      const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
+                         Eigen::RowMajor>& reference_data,
+      const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
+                         Eigen::RowMajor>& J,
+      const Eigen::ArrayXd& detJ,
+      const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
+                         Eigen::RowMajor>& K,
+      double* physical_data) const;
+
   /// Map function values from a physical cell to the reference
   /// @param physical_data The function values on the cell
   /// @param J The Jacobian of the mapping
@@ -261,6 +277,22 @@ public:
                 const Eigen::ArrayXd& detJ,
                 const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
                                    Eigen::RowMajor>& K) const;
+
+  /// Map function values from a physical cell to the reference
+  /// @param physical_data The function values on the cell
+  /// @param J The Jacobian of the mapping
+  /// @param detJ The determinant of the Jacobian of the mapping
+  /// @param K The inverse of the Jacobian of the mapping
+  /// @param reference_data Memory location to fill
+  void map_pull_back_to_memory(
+      const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
+                         Eigen::RowMajor>& physical_data,
+      const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
+                         Eigen::RowMajor>& J,
+      const Eigen::ArrayXd& detJ,
+      const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
+                         Eigen::RowMajor>& K,
+      double* reference_data) const;
 
   /// Get the number of dofs on each topological entity: (vertices,
   /// edges, faces, cell) in that order. For example, Lagrange degree 2

--- a/cpp/finite-element.h
+++ b/cpp/finite-element.h
@@ -241,8 +241,11 @@ public:
   Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
   map_push_forward(const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
                                       Eigen::RowMajor>& reference_data,
-                   const Eigen::MatrixXd& J, double detJ,
-                   const Eigen::MatrixXd& K) const;
+                   const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
+                                      Eigen::RowMajor>& J,
+                   const Eigen::ArrayXd& detJ,
+                   const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
+                                      Eigen::RowMajor>& K) const;
 
   /// Map function values from a physical cell to the reference
   /// @param physical_data The function values on the cell
@@ -253,8 +256,11 @@ public:
   Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
   map_pull_back(const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
                                    Eigen::RowMajor>& physical_data,
-                const Eigen::MatrixXd& J, double detJ,
-                const Eigen::MatrixXd& K) const;
+                const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
+                                   Eigen::RowMajor>& J,
+                const Eigen::ArrayXd& detJ,
+                const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
+                                   Eigen::RowMajor>& K) const;
 
   /// Get the number of dofs on each topological entity: (vertices,
   /// edges, faces, cell) in that order. For example, Lagrange degree 2

--- a/cpp/mappings.cpp
+++ b/cpp/mappings.cpp
@@ -3,44 +3,75 @@
 // SPDX-License-Identifier:    MIT
 
 #include "mappings.h"
+#include <functional>
 #include <map>
 #include <stdexcept>
 
-using namespace basix;
-
-//-----------------------------------------------------------------------------
-Eigen::ArrayXd mapping::map_push_forward(const Eigen::ArrayXd& reference_data,
-                                         const Eigen::MatrixXd& J, double detJ,
-                                         const Eigen::MatrixXd& K,
-                                         mapping::type mapping_type)
+namespace
 {
-  switch (mapping_type)
-  {
-  case mapping::type::identity:
+Eigen::ArrayXd identity(const Eigen::ArrayXd& reference_data,
+                        const Eigen::MatrixXd& J, const double detJ,
+                        const Eigen::MatrixXd& K)
+{
     return reference_data;
-  case mapping::type::covariantPiola:
-    return K.transpose() * reference_data.matrix();
-  case mapping::type::contravariantPiola:
-    return 1 / detJ * J * reference_data.matrix();
-  case mapping::type::doubleCovariantPiola:
-  {
-    Eigen::Map<const Eigen::MatrixXd> data_matrix(reference_data.data(),
-                                                  J.cols(), J.cols());
-    Eigen::MatrixXd result = K.transpose() * data_matrix * K;
-    return Eigen::Map<Eigen::ArrayXd>(result.data(), J.rows() * J.rows());
-  }
-  case mapping::type::doubleContravariantPiola:
-  {
-    Eigen::Map<const Eigen::MatrixXd> data_matrix(reference_data.data(),
-                                                  J.cols(), J.cols());
-    Eigen::MatrixXd result
-        = 1 / (detJ * detJ) * J * data_matrix * J.transpose();
-    return Eigen::Map<Eigen::ArrayXd>(result.data(), J.rows() * J.rows());
-  }
-  default:
-    throw std::runtime_error("Mapping not yet implemented");
-  }
 }
+Eigen::ArrayXd covariant_piola(const Eigen::ArrayXd& reference_data,
+                               const Eigen::MatrixXd& J, const double detJ,
+                               const Eigen::MatrixXd& K)
+{
+  return K.transpose() * reference_data.matrix();
+}
+Eigen::ArrayXd contravariant_piola(const Eigen::ArrayXd& reference_data,
+                                   const Eigen::MatrixXd& J, const double detJ,
+                                   const Eigen::MatrixXd& K)
+{
+  return 1 / detJ * J * reference_data.matrix();
+}
+Eigen::ArrayXd double_covariant_piola(const Eigen::ArrayXd& reference_data,
+                                      const Eigen::MatrixXd& J,
+                                      const double detJ,
+                                      const Eigen::MatrixXd& K)
+{
+  Eigen::Map<const Eigen::MatrixXd> data_matrix(reference_data.data(), J.cols(),
+                                                J.cols());
+  Eigen::MatrixXd result = K.transpose() * data_matrix * K;
+  return Eigen::Map<Eigen::ArrayXd>(result.data(), J.rows() * J.rows());
+}
+Eigen::ArrayXd double_contravariant_piola(const Eigen::ArrayXd& reference_data,
+                                          const Eigen::MatrixXd& J,
+                                          const double detJ,
+                                          const Eigen::MatrixXd& K)
+{
+  Eigen::Map<const Eigen::MatrixXd> data_matrix(reference_data.data(), J.cols(),
+                                                J.cols());
+  Eigen::MatrixXd result = 1 / (detJ * detJ) * J * data_matrix * J.transpose();
+  return Eigen::Map<Eigen::ArrayXd>(result.data(), J.rows() * J.rows());
+  }
+  } // namespace
+
+  using namespace basix;
+
+  //-----------------------------------------------------------------------------
+  std::function<Eigen::ArrayXd(const Eigen::ArrayXd&, const Eigen::MatrixXd&,
+                               const double, const Eigen::MatrixXd&)>
+  mapping::get_forward_map(mapping::type mapping_type)
+  {
+    switch (mapping_type)
+    {
+    case mapping::type::identity:
+      return identity;
+    case mapping::type::covariantPiola:
+      return covariant_piola;
+    case mapping::type::contravariantPiola:
+      return contravariant_piola;
+    case mapping::type::doubleCovariantPiola:
+      return double_covariant_piola;
+    case mapping::type::doubleContravariantPiola:
+      return double_contravariant_piola;
+    default:
+      throw std::runtime_error("Mapping not yet implemented");
+    }
+  }
 //-----------------------------------------------------------------------------
 const std::string& mapping::type_to_str(mapping::type type)
 {

--- a/cpp/mappings.cpp
+++ b/cpp/mappings.cpp
@@ -42,38 +42,6 @@ Eigen::ArrayXd mapping::map_push_forward(const Eigen::ArrayXd& reference_data,
   }
 }
 //-----------------------------------------------------------------------------
-Eigen::ArrayXd mapping::map_pull_back(const Eigen::ArrayXd& physical_data,
-                                      const Eigen::MatrixXd& J, double detJ,
-                                      const Eigen::MatrixXd& K,
-                                      mapping::type mapping_type)
-{
-  switch (mapping_type)
-  {
-  case mapping::type::identity:
-    return physical_data;
-  case mapping::type::covariantPiola:
-    return J.transpose() * physical_data.matrix();
-  case mapping::type::contravariantPiola:
-    return detJ * K * physical_data.matrix();
-  case mapping::type::doubleCovariantPiola:
-  {
-    Eigen::Map<const Eigen::MatrixXd> data_matrix(physical_data.data(),
-                                                  J.rows(), J.rows());
-    Eigen::MatrixXd result = J.transpose() * data_matrix * J;
-    return Eigen::Map<Eigen::ArrayXd>(result.data(), J.cols() * J.cols());
-  }
-  case mapping::type::doubleContravariantPiola:
-  {
-    Eigen::Map<const Eigen::MatrixXd> data_matrix(physical_data.data(),
-                                                  J.rows(), J.rows());
-    Eigen::MatrixXd result = detJ * detJ * K * data_matrix * K.transpose();
-    return Eigen::Map<Eigen::ArrayXd>(result.data(), J.cols() * J.cols());
-  }
-  default:
-    throw std::runtime_error("Mapping not yet implemented");
-  }
-}
-//-----------------------------------------------------------------------------
 const std::string& mapping::type_to_str(mapping::type type)
 {
   static const std::map<mapping::type, std::string> type_to_name = {

--- a/cpp/mappings.cpp
+++ b/cpp/mappings.cpp
@@ -12,8 +12,7 @@ using namespace basix;
 Eigen::ArrayXd mapping::map_push_forward(const Eigen::ArrayXd& reference_data,
                                          const Eigen::MatrixXd& J, double detJ,
                                          const Eigen::MatrixXd& K,
-                                         mapping::type mapping_type,
-                                         const std::vector<int> value_shape)
+                                         mapping::type mapping_type)
 {
   switch (mapping_type)
   {
@@ -25,18 +24,18 @@ Eigen::ArrayXd mapping::map_push_forward(const Eigen::ArrayXd& reference_data,
     return 1 / detJ * J * reference_data.matrix();
   case mapping::type::doubleCovariantPiola:
   {
-    Eigen::Map<const Eigen::MatrixXd> data_matrix(
-        reference_data.data(), value_shape[0], value_shape[1]);
+    Eigen::Map<const Eigen::MatrixXd> data_matrix(reference_data.data(),
+                                                  J.cols(), J.cols());
     Eigen::MatrixXd result = K.transpose() * data_matrix * K;
-    return Eigen::Map<Eigen::ArrayXd>(result.data(), reference_data.size());
+    return Eigen::Map<Eigen::ArrayXd>(result.data(), J.rows() * J.rows());
   }
   case mapping::type::doubleContravariantPiola:
   {
-    Eigen::Map<const Eigen::MatrixXd> data_matrix(
-        reference_data.data(), value_shape[0], value_shape[1]);
+    Eigen::Map<const Eigen::MatrixXd> data_matrix(reference_data.data(),
+                                                  J.cols(), J.cols());
     Eigen::MatrixXd result
         = 1 / (detJ * detJ) * J * data_matrix * J.transpose();
-    return Eigen::Map<Eigen::ArrayXd>(result.data(), reference_data.size());
+    return Eigen::Map<Eigen::ArrayXd>(result.data(), J.rows() * J.rows());
   }
   default:
     throw std::runtime_error("Mapping not yet implemented");
@@ -46,8 +45,7 @@ Eigen::ArrayXd mapping::map_push_forward(const Eigen::ArrayXd& reference_data,
 Eigen::ArrayXd mapping::map_pull_back(const Eigen::ArrayXd& physical_data,
                                       const Eigen::MatrixXd& J, double detJ,
                                       const Eigen::MatrixXd& K,
-                                      mapping::type mapping_type,
-                                      const std::vector<int> value_shape)
+                                      mapping::type mapping_type)
 {
   switch (mapping_type)
   {
@@ -59,17 +57,17 @@ Eigen::ArrayXd mapping::map_pull_back(const Eigen::ArrayXd& physical_data,
     return detJ * K * physical_data.matrix();
   case mapping::type::doubleCovariantPiola:
   {
-    Eigen::Map<const Eigen::MatrixXd> data_matrix(
-        physical_data.data(), value_shape[0], value_shape[1]);
+    Eigen::Map<const Eigen::MatrixXd> data_matrix(physical_data.data(),
+                                                  J.rows(), J.rows());
     Eigen::MatrixXd result = J.transpose() * data_matrix * J;
-    return Eigen::Map<Eigen::ArrayXd>(result.data(), physical_data.size());
+    return Eigen::Map<Eigen::ArrayXd>(result.data(), J.cols() * J.cols());
   }
   case mapping::type::doubleContravariantPiola:
   {
-    Eigen::Map<const Eigen::MatrixXd> data_matrix(
-        physical_data.data(), value_shape[0], value_shape[1]);
+    Eigen::Map<const Eigen::MatrixXd> data_matrix(physical_data.data(),
+                                                  J.rows(), J.rows());
     Eigen::MatrixXd result = detJ * detJ * K * data_matrix * K.transpose();
-    return Eigen::Map<Eigen::ArrayXd>(result.data(), physical_data.size());
+    return Eigen::Map<Eigen::ArrayXd>(result.data(), J.cols() * J.cols());
   }
   default:
     throw std::runtime_error("Mapping not yet implemented");

--- a/cpp/mappings.h
+++ b/cpp/mappings.h
@@ -32,14 +32,12 @@ enum class type
 /// @param detJ The determinant of the Jacobian
 /// @param K The inverse of the Jacobian
 /// @param mapping_type Mapping type
-/// @param value_shape The value shape of the data
 /// @return The mapped data
 // TODO: should data be in/out?
 Eigen::ArrayXd map_push_forward(const Eigen::ArrayXd& reference_data,
                                 const Eigen::MatrixXd& J, double detJ,
                                 const Eigen::MatrixXd& K,
-                                mapping::type mapping_type,
-                                const std::vector<int> value_shape);
+                                mapping::type mapping_type);
 
 /// Apply inverse mapping
 /// @param physical_data The data to apply the inverse mapping to
@@ -47,14 +45,12 @@ Eigen::ArrayXd map_push_forward(const Eigen::ArrayXd& reference_data,
 /// @param detJ The determinant of the Jacobian
 /// @param K The inverse of the Jacobian
 /// @param mapping_type Mapping type
-/// @param value_shape The value shape of the data
 /// @return The mapped data
 // TODO: should data be in/out?
 Eigen::ArrayXd map_pull_back(const Eigen::ArrayXd& physical_data,
                              const Eigen::MatrixXd& J, double detJ,
                              const Eigen::MatrixXd& K,
-                             mapping::type mapping_type,
-                             const std::vector<int> value_shape);
+                             mapping::type mapping_type);
 
 /// Convert mapping type enum to string
 const std::string& type_to_str(mapping::type type);

--- a/cpp/mappings.h
+++ b/cpp/mappings.h
@@ -39,19 +39,6 @@ Eigen::ArrayXd map_push_forward(const Eigen::ArrayXd& reference_data,
                                 const Eigen::MatrixXd& K,
                                 mapping::type mapping_type);
 
-/// Apply inverse mapping
-/// @param physical_data The data to apply the inverse mapping to
-/// @param J The Jacobian
-/// @param detJ The determinant of the Jacobian
-/// @param K The inverse of the Jacobian
-/// @param mapping_type Mapping type
-/// @return The mapped data
-// TODO: should data be in/out?
-Eigen::ArrayXd map_pull_back(const Eigen::ArrayXd& physical_data,
-                             const Eigen::MatrixXd& J, double detJ,
-                             const Eigen::MatrixXd& K,
-                             mapping::type mapping_type);
-
 /// Convert mapping type enum to string
 const std::string& type_to_str(mapping::type type);
 

--- a/cpp/mappings.h
+++ b/cpp/mappings.h
@@ -26,18 +26,12 @@ enum class type
   doubleContravariantPiola,
 };
 
-/// Apply mapping
-/// @param reference_data The data to apply the mapping to
-/// @param J The Jacobian
-/// @param detJ The determinant of the Jacobian
-/// @param K The inverse of the Jacobian
+/// Get the function that maps data from the reference to the physical cell.
 /// @param mapping_type Mapping type
-/// @return The mapped data
-// TODO: should data be in/out?
-Eigen::ArrayXd map_push_forward(const Eigen::ArrayXd& reference_data,
-                                const Eigen::MatrixXd& J, double detJ,
-                                const Eigen::MatrixXd& K,
-                                mapping::type mapping_type);
+/// @return The mapping function
+std::function<Eigen::ArrayXd(const Eigen::ArrayXd&, const Eigen::MatrixXd&,
+                             const double, const Eigen::MatrixXd&)>
+get_forward_map(mapping::type mapping_type);
 
 /// Convert mapping type enum to string
 const std::string& type_to_str(mapping::type type);

--- a/test/test_mappings.py
+++ b/test/test_mappings.py
@@ -16,9 +16,6 @@ elements = [
 
 
 def run_map_test(e, J, detJ, K, reference_value_size, physical_value_size):
-    print(K @ J)
-    assert np.allclose(K @ J, np.identity(J.shape[1]))
-
     tdim = len(basix.topology(e.cell_type)) - 1
     N = 5
     if tdim == 1:

--- a/test/test_mappings.py
+++ b/test/test_mappings.py
@@ -27,11 +27,16 @@ def run_map_test(e, J, detJ, K, reference_value_size, physical_value_size):
                            for i in range(N + 1) for j in range(N + 1 - i) for k in range(N + 1 - i - j)])
     values = e.tabulate(0, points)[0]
 
+    _J = np.array([J.reshape(J.shape[0] * J.shape[1]) for p in points])
+    _detJ = np.array([detJ for p in points])
+    _K = np.array([K.reshape(K.shape[0] * K.shape[1]) for p in points])
+
     assert values.shape[1] == reference_value_size * e.dim
-    mapped = e.map_push_forward(values, J, detJ, K)
+    mapped = e.map_push_forward(values, _J, _detJ, _K)
     assert mapped.shape[0] == values.shape[0]
     assert mapped.shape[1] == physical_value_size * e.dim
-    unmapped = e.map_pull_back(mapped, J, detJ, K)
+    unmapped = e.map_pull_back(mapped, _J, _detJ, _K)
+
     assert np.allclose(values, unmapped)
 
 

--- a/test/test_mappings.py
+++ b/test/test_mappings.py
@@ -27,13 +27,12 @@ def run_map_test(e, J, detJ, K, reference_value_size, physical_value_size):
                            for i in range(N + 1) for j in range(N + 1 - i) for k in range(N + 1 - i - j)])
     values = e.tabulate(0, points)[0]
 
-    for value in values:
-        assert len(value) == reference_value_size * e.dim
-        mapped = e.map_push_forward(value.reshape((reference_value_size, e.dim)), J, detJ, K)
-        assert mapped.shape[0] == physical_value_size
-        assert mapped.shape[1] == e.dim
-        unmapped = e.map_pull_back(mapped, J, detJ, K).reshape(reference_value_size * e.dim)
-        assert np.allclose(value, unmapped)
+    assert values.shape[1] == reference_value_size * e.dim
+    mapped = e.map_push_forward(values, J, detJ, K)
+    assert mapped.shape[0] == values.shape[0]
+    assert mapped.shape[1] == physical_value_size * e.dim
+    unmapped = e.map_pull_back(mapped, J, detJ, K)
+    assert np.allclose(values, unmapped)
 
 
 @pytest.mark.parametrize("element_name", elements)

--- a/test/test_mappings.py
+++ b/test/test_mappings.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2020 Matthew Scroggs
+# FEniCS Project
+# SPDX-License-Identifier: MIT
+
+import random
+import basix
+import pytest
+import numpy as np
+
+elements = [
+    "Lagrange",  # identity
+    "Nedelec 1st kind H(curl)",  # covariant Piola
+    "Raviart-Thomas",  # contravariant Piola
+    "Regge",  # double covariant Piola
+]
+
+
+def run_map_test(e, J, detJ, K, reference_value_size, physical_value_size):
+    print(K @ J)
+    assert np.allclose(K @ J, np.identity(J.shape[1]))
+
+    tdim = len(basix.topology(e.cell_type)) - 1
+    N = 5
+    if tdim == 1:
+        points = np.array([[i / N] for i in range(N + 1)])
+    elif tdim == 2:
+        points = np.array([[i / N, j / N] for i in range(N + 1) for j in range(N + 1 - i)])
+    elif tdim == 3:
+        points = np.array([[i / N, j / N, k / N]
+                           for i in range(N + 1) for j in range(N + 1 - i) for k in range(N + 1 - i - j)])
+    values = e.tabulate(0, points)[0]
+
+    for value in values:
+        for j in range(e.dim):
+            assert len(value[j::e.dim]) == reference_value_size
+            mapped = e.map_push_forward(value[j::e.dim], J, detJ, K)
+            assert len(mapped) == physical_value_size
+            unmapped = e.map_pull_back(mapped, J, detJ, K)
+            assert np.allclose(value[j::e.dim], unmapped)
+
+
+@pytest.mark.parametrize("element_name", elements)
+def test_mappings_2d_to_2d(element_name):
+    e = basix.create_element(element_name, "triangle", 1)
+
+    J = np.array([[random.random() + 1, random.random()],
+                  [random.random(), random.random()]])
+    detJ = np.linalg.det(J)
+    K = np.linalg.inv(J)
+
+    run_map_test(e, J, detJ, K, e.value_size, e.value_size)
+
+
+@pytest.mark.parametrize("element_name", elements)
+def test_mappings_2d_to_3d(element_name):
+    e = basix.create_element(element_name, "triangle", 1)
+
+    # Map from (0,0)--(1,0)--(0,1) to (1,0,1)--(2,1,0)--(0,1,1)
+    J = np.array([[1., -1.], [1., 1.], [-1., 0.]])
+    detJ = np.sqrt(6)
+    K = np.array([[0.5, 0.5, 0.], [-0.5, 0.5, 0.]])
+
+    if e.value_size == 1:
+        physical_vs = 1
+    elif e.value_size == 2:
+        physical_vs = 3
+    elif e.value_size == 4:
+        physical_vs = 9
+    run_map_test(e, J, detJ, K, e.value_size, physical_vs)
+
+
+@pytest.mark.parametrize("element_name", elements)
+def test_mappings_3d_to_3d(element_name):
+    e = basix.create_element(element_name, "tetrahedron", 1)
+
+    J = np.array([[random.random() + 2, random.random(), random.random()],
+                  [random.random(), random.random() + 1, random.random()],
+                  [random.random(), random.random(), random.random()]])
+    detJ = np.linalg.det(J)
+    K = np.linalg.inv(J)
+
+    run_map_test(e, J, detJ, K, e.value_size, e.value_size)

--- a/test/test_permutations.py
+++ b/test/test_permutations.py
@@ -128,9 +128,10 @@ def test_permutation_of_tabulated_data_triangle(element_name, order):
         reflected_points = np.array([[p[1], p[0]] for p in points])
         reflected_values = e.tabulate(0, reflected_points)[0]
 
-        J = np.array([[0, 1], [1, 0]])
-        detJ = np.linalg.det(J)
-        K = np.linalg.inv(J)
+        _J = np.array([[0, 1], [1, 0]])
+        J = np.array([_J.reshape(4) for p in points])
+        detJ = np.array([np.linalg.det(_J) for p in points])
+        K = np.array([np.linalg.inv(_J).reshape(4) for p in points])
         mapped_values = e.map_push_forward(reflected_values, J, detJ, K)
 
         for i, j in zip(values, mapped_values):
@@ -157,9 +158,10 @@ def test_permutation_of_tabulated_data_quadrilateral(element_name, order):
         reflected_points = np.array([[1 - p[0], p[1]] for p in points])
         reflected_values = e.tabulate(0, reflected_points)[0]
 
-        J = np.array([[-1, 0], [0, 1]])
-        detJ = np.linalg.det(J)
-        K = np.linalg.inv(J)
+        _J = np.array([[-1, 0], [0, 1]])
+        J = np.array([_J.reshape(4) for p in points])
+        detJ = np.array([np.linalg.det(_J) for p in points])
+        K = np.array([np.linalg.inv(_J).reshape(4) for p in points])
         mapped_values = e.map_push_forward(reflected_values, J, detJ, K)
 
         for i, j in zip(values, mapped_values):
@@ -192,9 +194,10 @@ def test_permutation_of_tabulated_data_tetrahedron(element_name, order):
         reflected_points = np.array([[p[0], p[2], p[1]] for p in points])
         reflected_values = e.tabulate(0, reflected_points)[0]
 
-        J = np.array([[1, 0, 0], [0, 0, 1], [0, 1, 0]])
-        detJ = np.linalg.det(J)
-        K = np.linalg.inv(J)
+        _J = np.array([[1, 0, 0], [0, 0, 1], [0, 1, 0]])
+        J = np.array([_J.reshape(9) for p in points])
+        detJ = np.array([np.linalg.det(_J) for p in points])
+        K = np.array([np.linalg.inv(_J).reshape(9) for p in points])
         mapped_values = e.map_push_forward(reflected_values, J, detJ, K)
 
         for i, j in zip(values, mapped_values):
@@ -211,9 +214,10 @@ def test_permutation_of_tabulated_data_tetrahedron(element_name, order):
         rotated_points = np.array([[p[2], p[0], p[1]] for p in points])
         rotated_values = e.tabulate(0, rotated_points)[0]
 
-        J = np.array([[0, 1, 0], [0, 0, 1], [1, 0, 0]])
-        detJ = np.linalg.det(J)
-        K = np.linalg.inv(J)
+        _J = np.array([[0, 1, 0], [0, 0, 1], [1, 0, 0]])
+        J = np.array([_J.reshape(9) for p in points])
+        detJ = np.array([np.linalg.det(_J) for p in points])
+        K = np.array([np.linalg.inv(_J).reshape(9) for p in points])
         mapped_values = e.map_push_forward(rotated_values, J, detJ, K)
 
         for i, j in zip(values, mapped_values):
@@ -228,9 +232,10 @@ def test_permutation_of_tabulated_data_tetrahedron(element_name, order):
         reflected_points = np.array([[p[0], p[2], p[1]] for p in points])
         reflected_values = e.tabulate(0, reflected_points)[0]
 
-        J = np.array([[1, 0, 0], [0, 0, 1], [0, 1, 0]])
-        detJ = np.linalg.det(J)
-        K = np.linalg.inv(J)
+        _J = np.array([[1, 0, 0], [0, 0, 1], [0, 1, 0]])
+        J = np.array([_J.reshape(9) for p in points])
+        detJ = np.array([np.linalg.det(_J) for p in points])
+        K = np.array([np.linalg.inv(_J).reshape(9) for p in points])
         mapped_values = e.map_push_forward(reflected_values, J, detJ, K)
 
         for i, j in zip(values, mapped_values):
@@ -262,9 +267,10 @@ def test_permutation_of_tabulated_data_hexahedron(element_name, order):
         reflected_points = np.array([[1 - p[0], p[1], p[2]] for p in points])
         reflected_values = e.tabulate(0, reflected_points)[0]
 
-        J = np.array([[-1, 0, 0], [0, 1, 0], [0, 0, 1]])
-        detJ = np.linalg.det(J)
-        K = np.linalg.inv(J)
+        _J = np.array([[-1, 0, 0], [0, 1, 0], [0, 0, 1]])
+        J = np.array([_J.reshape(9) for p in points])
+        detJ = np.array([np.linalg.det(_J) for p in points])
+        K = np.array([np.linalg.inv(_J).reshape(9) for p in points])
         mapped_values = e.map_push_forward(reflected_values, J, detJ, K)
 
         for i, j in zip(values, mapped_values):
@@ -281,9 +287,10 @@ def test_permutation_of_tabulated_data_hexahedron(element_name, order):
         rotated_points = np.array([[1 - p[1], p[0], p[2]] for p in points])
         rotated_values = e.tabulate(0, rotated_points)[0]
 
-        J = np.array([[0, 1, 0], [-1, 0, 0], [0, 0, 1]])
-        detJ = np.linalg.det(J)
-        K = np.linalg.inv(J)
+        _J = np.array([[0, 1, 0], [-1, 0, 0], [0, 0, 1]])
+        J = np.array([_J.reshape(9) for p in points])
+        detJ = np.array([np.linalg.det(_J) for p in points])
+        K = np.array([np.linalg.inv(_J).reshape(9) for p in points])
         mapped_values = e.map_push_forward(rotated_values, J, detJ, K)
 
         for i, j in zip(values, mapped_values):
@@ -298,9 +305,10 @@ def test_permutation_of_tabulated_data_hexahedron(element_name, order):
         reflected_points = np.array([[p[1], p[0], p[2]] for p in points])
         reflected_values = e.tabulate(0, reflected_points)[0]
 
-        J = np.array([[0, 1, 0], [1, 0, 0], [0, 0, 1]])
-        detJ = np.linalg.det(J)
-        K = np.linalg.inv(J)
+        _J = np.array([[0, 1, 0], [1, 0, 0], [0, 0, 1]])
+        J = np.array([_J.reshape(9) for p in points])
+        detJ = np.array([np.linalg.det(_J) for p in points])
+        K = np.array([np.linalg.inv(_J).reshape(9) for p in points])
         mapped_values = e.map_push_forward(reflected_values, J, detJ, K)
 
         for i, j in zip(values, mapped_values):

--- a/test/test_permutations.py
+++ b/test/test_permutations.py
@@ -131,10 +131,7 @@ def test_permutation_of_tabulated_data_triangle(element_name, order):
         J = np.array([[0, 1], [1, 0]])
         detJ = np.linalg.det(J)
         K = np.linalg.inv(J)
-        mapped_values = np.zeros_like(reflected_values)
-        for i, value in enumerate(reflected_values):
-            mapped_values[i] = e.map_push_forward(
-                value.reshape((e.value_size, e.dim)), J, detJ, K).reshape(e.value_size * e.dim)
+        mapped_values = e.map_push_forward(reflected_values, J, detJ, K)
 
         for i, j in zip(values, mapped_values):
             for d in range(e.value_size):
@@ -163,10 +160,7 @@ def test_permutation_of_tabulated_data_quadrilateral(element_name, order):
         J = np.array([[-1, 0], [0, 1]])
         detJ = np.linalg.det(J)
         K = np.linalg.inv(J)
-        mapped_values = np.zeros_like(reflected_values)
-        for i, value in enumerate(reflected_values):
-            mapped_values[i] = e.map_push_forward(
-                value.reshape((e.value_size, e.dim)), J, detJ, K).reshape(e.value_size * e.dim)
+        mapped_values = e.map_push_forward(reflected_values, J, detJ, K)
 
         for i, j in zip(values, mapped_values):
             for d in range(e.value_size):
@@ -201,10 +195,7 @@ def test_permutation_of_tabulated_data_tetrahedron(element_name, order):
         J = np.array([[1, 0, 0], [0, 0, 1], [0, 1, 0]])
         detJ = np.linalg.det(J)
         K = np.linalg.inv(J)
-        mapped_values = np.zeros_like(reflected_values)
-        for i, value in enumerate(reflected_values):
-            mapped_values[i] = e.map_push_forward(
-                value.reshape((e.value_size, e.dim)), J, detJ, K).reshape(e.value_size * e.dim)
+        mapped_values = e.map_push_forward(reflected_values, J, detJ, K)
 
         for i, j in zip(values, mapped_values):
             for d in range(e.value_size):
@@ -223,10 +214,7 @@ def test_permutation_of_tabulated_data_tetrahedron(element_name, order):
         J = np.array([[0, 1, 0], [0, 0, 1], [1, 0, 0]])
         detJ = np.linalg.det(J)
         K = np.linalg.inv(J)
-        mapped_values = np.zeros_like(rotated_values)
-        for i, value in enumerate(rotated_values):
-            mapped_values[i] = e.map_push_forward(
-                value.reshape((e.value_size, e.dim)), J, detJ, K).reshape(e.value_size * e.dim)
+        mapped_values = e.map_push_forward(rotated_values, J, detJ, K)
 
         for i, j in zip(values, mapped_values):
             for d in range(e.value_size):
@@ -243,10 +231,7 @@ def test_permutation_of_tabulated_data_tetrahedron(element_name, order):
         J = np.array([[1, 0, 0], [0, 0, 1], [0, 1, 0]])
         detJ = np.linalg.det(J)
         K = np.linalg.inv(J)
-        mapped_values = np.zeros_like(reflected_values)
-        for i, value in enumerate(reflected_values):
-            mapped_values[i] = e.map_push_forward(
-                value.reshape((e.value_size, e.dim)), J, detJ, K).reshape(e.value_size * e.dim)
+        mapped_values = e.map_push_forward(reflected_values, J, detJ, K)
 
         for i, j in zip(values, mapped_values):
             for d in range(e.value_size):
@@ -280,10 +265,7 @@ def test_permutation_of_tabulated_data_hexahedron(element_name, order):
         J = np.array([[-1, 0, 0], [0, 1, 0], [0, 0, 1]])
         detJ = np.linalg.det(J)
         K = np.linalg.inv(J)
-        mapped_values = np.zeros_like(reflected_values)
-        for i, value in enumerate(reflected_values):
-            mapped_values[i] = e.map_push_forward(
-                value.reshape((e.value_size, e.dim)), J, detJ, K).reshape(e.value_size * e.dim)
+        mapped_values = e.map_push_forward(reflected_values, J, detJ, K)
 
         for i, j in zip(values, mapped_values):
             for d in range(e.value_size):
@@ -302,10 +284,7 @@ def test_permutation_of_tabulated_data_hexahedron(element_name, order):
         J = np.array([[0, 1, 0], [-1, 0, 0], [0, 0, 1]])
         detJ = np.linalg.det(J)
         K = np.linalg.inv(J)
-        mapped_values = np.zeros_like(rotated_values)
-        for i, value in enumerate(rotated_values):
-            mapped_values[i] = e.map_push_forward(
-                value.reshape((e.value_size, e.dim)), J, detJ, K).reshape(e.value_size * e.dim)
+        mapped_values = e.map_push_forward(rotated_values, J, detJ, K)
 
         for i, j in zip(values, mapped_values):
             for d in range(e.value_size):
@@ -322,10 +301,7 @@ def test_permutation_of_tabulated_data_hexahedron(element_name, order):
         J = np.array([[0, 1, 0], [1, 0, 0], [0, 0, 1]])
         detJ = np.linalg.det(J)
         K = np.linalg.inv(J)
-        mapped_values = np.zeros_like(reflected_values)
-        for i, value in enumerate(reflected_values):
-            mapped_values[i] = e.map_push_forward(
-                value.reshape((e.value_size, e.dim)), J, detJ, K).reshape(e.value_size * e.dim)
+        mapped_values = e.map_push_forward(reflected_values, J, detJ, K)
 
         for i, j in zip(values, mapped_values):
             for d in range(e.value_size):


### PR DESCRIPTION
- Data from multiple points can now be passed into mapping
- The mapping function is stored inside `FiniteElement` instead of querying `_mapping_type` for every function value
- `map_push_forward` now writes directly to memory instead of copying

Currently, a copy of `map_push_forward` exists for the Python interface. This can use `map_push_forward_to_memory` instead of being an almost duplicate of it once #120 is resolved.

Fixes #119. This PR is coupled with FEniCS/dolfinx#1407