### PR TITLE
Rename base permutations -> base transformations

### DIFF
--- a/.github/workflows/dolfin-tests.yml
+++ b/.github/workflows/dolfin-tests.yml
@@ -34,14 +34,14 @@ jobs:
       - name: Install FEniCS Python components
         run: |
           python3 -m pip install git+https://github.com/FEniCS/ufl.git
-          python3 -m pip install git+https://github.com/FEniCS/ffcx.git
+          python3 -m pip install git+https://github.com/FEniCS/ffcx.git@mscroggs/base_trans
 
       - name: Get DOLFINX
         uses: actions/checkout@v2
         with:
           path: ./dolfinx
           repository: FEniCS/dolfinx
-          ref: garth/basix-cmake
+          ref: mscroggs/base_trans
 
       - name: Install DOLFINX
         run: |

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -280,7 +280,7 @@ void FiniteElement::tabulate(int nd, const Eigen::ArrayXXd& x,
   }
 }
 //-----------------------------------------------------------------------------
-std::vector<Eigen::MatrixXd> FiniteElement::base_permutations() const
+std::vector<Eigen::MatrixXd> FiniteElement::base_transformations() const
 {
   return _base_transformations;
 }

--- a/cpp/basix/finite-element.h
+++ b/cpp/basix/finite-element.h
@@ -417,7 +417,7 @@ public:
   ///   reflection: [[0, 1],
   ///                [1, 0]]
   /// ~~~~~~~~~~~~~~~~
-  std::vector<Eigen::MatrixXd> base_permutations() const;
+  std::vector<Eigen::MatrixXd> base_transformations() const;
 
   /// Return a set of interpolation points
   const Eigen::ArrayXXd& points() const;

--- a/python/wrapper.cpp
+++ b/python/wrapper.cpp
@@ -254,8 +254,8 @@ Each element has a `tabulate` function which returns the basis functions and a n
                                       tcb::span(detJ.data(), detJ.size()), K);
           },
           invmapdoc.c_str())
-      .def_property_readonly("base_permutations",
-                             &FiniteElement::base_permutations)
+      .def_property_readonly("base_transformations",
+                             &FiniteElement::base_transformations)
       .def_property_readonly("degree", &FiniteElement::degree)
       .def_property_readonly("cell_type", &FiniteElement::cell_type)
       .def_property_readonly("dim", &FiniteElement::dim)

--- a/test/test_dof_transformations.py
+++ b/test/test_dof_transformations.py
@@ -12,78 +12,78 @@ from .utils import parametrize_over_elements
 def test_non_zero(cell_name, element_name, order):
     e = basix.create_element(element_name, cell_name, order)
 
-    for perm in e.base_permutations:
-        for row in perm:
+    for t in e.base_transformations:
+        for row in t:
             assert max(abs(i) for i in row) > 1e-6
 
 
 @parametrize_over_elements(5, "interval")
-def test_interval_permutation_size(element_name, order):
+def test_interval_transformation_size(element_name, order):
     e = basix.create_element(element_name, "interval", order)
-    assert len(e.base_permutations) == 0
+    assert len(e.base_transformations) == 0
 
 
 @parametrize_over_elements(5, "triangle")
-def test_triangle_permutation_orders(element_name, order):
+def test_triangle_transformation_orders(element_name, order):
     if element_name == "Crouzeix-Raviart" and order != 1:
         pytest.xfail()
 
     e = basix.create_element(element_name, "triangle", order)
-    assert len(e.base_permutations) == 3
+    assert len(e.base_transformations) == 3
 
     identity = np.identity(e.dim)
     for i, order in enumerate([2, 2, 2]):
         assert np.allclose(
-            np.linalg.matrix_power(e.base_permutations[i], order),
+            np.linalg.matrix_power(e.base_transformations[i], order),
             identity)
 
 
 @parametrize_over_elements(5, "tetrahedron")
-def test_tetrahedron_permutation_orders(element_name, order):
+def test_tetrahedron_transformation_orders(element_name, order):
     if element_name == "Crouzeix-Raviart" and order != 1:
         pytest.xfail()
 
     e = basix.create_element(element_name, "tetrahedron", order)
-    assert len(e.base_permutations) == 14
+    assert len(e.base_transformations) == 14
 
     identity = np.identity(e.dim)
     for i, order in enumerate([2, 2, 2, 2, 2, 2, 3, 2, 3, 2, 3, 2, 3, 2]):
         assert np.allclose(
-            np.linalg.matrix_power(e.base_permutations[i], order),
+            np.linalg.matrix_power(e.base_transformations[i], order),
             identity)
 
 
 @parametrize_over_elements(5, "quadrilateral")
-def test_quadrilateral_permutation_orders(element_name, order):
+def test_quadrilateral_transformation_orders(element_name, order):
     e = basix.create_element(element_name, "quadrilateral", order)
-    assert len(e.base_permutations) == 4
+    assert len(e.base_transformations) == 4
 
     identity = np.identity(e.dim)
     for i, order in enumerate([2, 2, 2, 2]):
         assert np.allclose(
-            np.linalg.matrix_power(e.base_permutations[i], order),
+            np.linalg.matrix_power(e.base_transformations[i], order),
             identity)
 
 
 @parametrize_over_elements(5, "hexahedron")
-def test_hexahedron_permutation_orders(element_name, order):
+def test_hexahedron_transformation_orders(element_name, order):
     e = basix.create_element(element_name, "hexahedron", order)
-    assert len(e.base_permutations) == 24
+    assert len(e.base_transformations) == 24
 
     identity = np.identity(e.dim)
     for i, order in enumerate([2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
                                4, 2, 4, 2, 4, 2, 4, 2, 4, 2, 4, 2]):
         assert np.allclose(
-            np.linalg.matrix_power(e.base_permutations[i], order),
+            np.linalg.matrix_power(e.base_transformations[i], order),
             identity)
 
 
 @parametrize_over_elements(5, "triangle")
-def test_permutation_of_tabulated_data_triangle(element_name, order):
+def test_transformation_of_tabulated_data_triangle(element_name, order):
     if element_name == "Crouzeix-Raviart" and order != 1:
         pytest.xfail()
     if element_name == "Regge":
-        pytest.skip("DOF permutations not yet implemented for Regge elements.")
+        pytest.skip("DOF transformations not yet implemented for Regge elements.")
 
     e = basix.create_element(element_name, "triangle", order)
 
@@ -94,7 +94,7 @@ def test_permutation_of_tabulated_data_triangle(element_name, order):
     start = sum(e.entity_dofs[0])
     ndofs = e.entity_dofs[1][0]
     if ndofs != 0:
-        # Check that the 0th permutation undoes the effect of reflecting edge 0
+        # Check that the 0th transformation undoes the effect of reflecting edge 0
         reflected_points = np.array([[p[1], p[0]] for p in points])
         reflected_values = e.tabulate(0, reflected_points)[0]
 
@@ -108,12 +108,12 @@ def test_permutation_of_tabulated_data_triangle(element_name, order):
             for d in range(e.value_size):
                 i_slice = i[d * e.dim:(d + 1) * e.dim]
                 j_slice = j[d * e.dim:(d + 1) * e.dim]
-                assert np.allclose((e.base_permutations[0].dot(i_slice))[start: start + ndofs],
+                assert np.allclose((e.base_transformations[0].dot(i_slice))[start: start + ndofs],
                                    j_slice[start: start + ndofs])
 
 
 @parametrize_over_elements(5, "quadrilateral")
-def test_permutation_of_tabulated_data_quadrilateral(element_name, order):
+def test_transformation_of_tabulated_data_quadrilateral(element_name, order):
     e = basix.create_element(element_name, "quadrilateral", order)
 
     N = 4
@@ -123,7 +123,7 @@ def test_permutation_of_tabulated_data_quadrilateral(element_name, order):
     start = sum(e.entity_dofs[0])
     ndofs = e.entity_dofs[1][0]
     if ndofs != 0:
-        # Check that the 0th permutation undoes the effect of reflecting edge 0
+        # Check that the 0th transformation undoes the effect of reflecting edge 0
         reflected_points = np.array([[1 - p[0], p[1]] for p in points])
         reflected_values = e.tabulate(0, reflected_points)[0]
 
@@ -137,14 +137,14 @@ def test_permutation_of_tabulated_data_quadrilateral(element_name, order):
             for d in range(e.value_size):
                 i_slice = i[d * e.dim:(d + 1) * e.dim]
                 j_slice = j[d * e.dim:(d + 1) * e.dim]
-                assert np.allclose((e.base_permutations[0].dot(i_slice))[start: start + ndofs],
+                assert np.allclose((e.base_transformations[0].dot(i_slice))[start: start + ndofs],
                                    j_slice[start: start + ndofs])
 
 
 @parametrize_over_elements(5, "tetrahedron")
-def test_permutation_of_tabulated_data_tetrahedron(element_name, order):
+def test_transformation_of_tabulated_data_tetrahedron(element_name, order):
     if element_name == "Regge":
-        pytest.skip("DOF permutations not yet implemented for Regge elements.")
+        pytest.skip("DOF transformations not yet implemented for Regge elements.")
 
     e = basix.create_element(element_name, "tetrahedron", order)
 
@@ -156,7 +156,7 @@ def test_permutation_of_tabulated_data_tetrahedron(element_name, order):
     start = sum(e.entity_dofs[0])
     ndofs = e.entity_dofs[1][0]
     if ndofs != 0:
-        # Check that the 0th permutation undoes the effect of reflecting edge 0
+        # Check that the 0th transformation undoes the effect of reflecting edge 0
         reflected_points = np.array([[p[0], p[2], p[1]] for p in points])
         reflected_values = e.tabulate(0, reflected_points)[0]
 
@@ -170,13 +170,13 @@ def test_permutation_of_tabulated_data_tetrahedron(element_name, order):
             for d in range(e.value_size):
                 i_slice = i[d * e.dim:(d + 1) * e.dim]
                 j_slice = j[d * e.dim:(d + 1) * e.dim]
-                assert np.allclose((e.base_permutations[0].dot(i_slice))[start: start + ndofs],
+                assert np.allclose((e.base_transformations[0].dot(i_slice))[start: start + ndofs],
                                    j_slice[start: start + ndofs])
 
     start = sum(e.entity_dofs[0]) + sum(e.entity_dofs[1])
     ndofs = e.entity_dofs[2][0]
     if ndofs != 0:
-        # Check that the 6th permutation undoes the effect of rotating face 0
+        # Check that the 6th transformation undoes the effect of rotating face 0
         rotated_points = np.array([[p[2], p[0], p[1]] for p in points])
         rotated_values = e.tabulate(0, rotated_points)[0]
 
@@ -190,11 +190,11 @@ def test_permutation_of_tabulated_data_tetrahedron(element_name, order):
             for d in range(e.value_size):
                 i_slice = i[d * e.dim:(d + 1) * e.dim]
                 j_slice = j[d * e.dim:(d + 1) * e.dim]
-                assert np.allclose(e.base_permutations[6].dot(i_slice)[start: start + ndofs],
+                assert np.allclose(e.base_transformations[6].dot(i_slice)[start: start + ndofs],
                                    j_slice[start: start + ndofs])
 
     if ndofs != 0:
-        # Check that the 7th permutation undoes the effect of reflecting face 0
+        # Check that the 7th transformation undoes the effect of reflecting face 0
         reflected_points = np.array([[p[0], p[2], p[1]] for p in points])
         reflected_values = e.tabulate(0, reflected_points)[0]
 
@@ -208,13 +208,13 @@ def test_permutation_of_tabulated_data_tetrahedron(element_name, order):
             for d in range(e.value_size):
                 i_slice = i[d * e.dim:(d + 1) * e.dim]
                 j_slice = j[d * e.dim:(d + 1) * e.dim]
-                assert np.allclose((e.base_permutations[7].dot(i_slice))[start: start + ndofs],
+                assert np.allclose((e.base_transformations[7].dot(i_slice))[start: start + ndofs],
                                    j_slice[start: start + ndofs])
 
 
 # @parametrize_over_elements(5, "hexahedron")
 @parametrize_over_elements(2, "hexahedron")
-def test_permutation_of_tabulated_data_hexahedron(element_name, order):
+def test_transformation_of_tabulated_data_hexahedron(element_name, order):
     if order > 4 and element_name in ["Raviart-Thomas", "Nedelec 1st kind H(curl)"]:
         pytest.xfail("High order Hdiv and Hcurl spaces on hexes based on "
                      "Lagrange spaces equally spaced points are unstable.")
@@ -229,7 +229,7 @@ def test_permutation_of_tabulated_data_hexahedron(element_name, order):
     start = sum(e.entity_dofs[0])
     ndofs = e.entity_dofs[1][0]
     if ndofs != 0:
-        # Check that the 0th permutation undoes the effect of reflecting edge 0
+        # Check that the 0th transformation undoes the effect of reflecting edge 0
         reflected_points = np.array([[1 - p[0], p[1], p[2]] for p in points])
         reflected_values = e.tabulate(0, reflected_points)[0]
 
@@ -243,13 +243,13 @@ def test_permutation_of_tabulated_data_hexahedron(element_name, order):
             for d in range(e.value_size):
                 i_slice = i[d * e.dim:(d + 1) * e.dim]
                 j_slice = j[d * e.dim:(d + 1) * e.dim]
-                assert np.allclose((e.base_permutations[0].dot(i_slice))[start: start + ndofs],
+                assert np.allclose((e.base_transformations[0].dot(i_slice))[start: start + ndofs],
                                    j_slice[start: start + ndofs])
 
     start = sum(e.entity_dofs[0]) + sum(e.entity_dofs[1])
     ndofs = e.entity_dofs[2][0]
     if ndofs != 0:
-        # Check that the 12th permutation undoes the effect of rotating face 0
+        # Check that the 12th transformation undoes the effect of rotating face 0
         rotated_points = np.array([[1 - p[1], p[0], p[2]] for p in points])
         rotated_values = e.tabulate(0, rotated_points)[0]
 
@@ -263,11 +263,11 @@ def test_permutation_of_tabulated_data_hexahedron(element_name, order):
             for d in range(e.value_size):
                 i_slice = i[d * e.dim:(d + 1) * e.dim]
                 j_slice = j[d * e.dim:(d + 1) * e.dim]
-                assert np.allclose(e.base_permutations[12].dot(i_slice)[start: start + ndofs],
+                assert np.allclose(e.base_transformations[12].dot(i_slice)[start: start + ndofs],
                                    j_slice[start: start + ndofs])
 
     if ndofs != 0:
-        # Check that the 13th permutation undoes the effect of reflecting face 0
+        # Check that the 13th transformation undoes the effect of reflecting face 0
         reflected_points = np.array([[p[1], p[0], p[2]] for p in points])
         reflected_values = e.tabulate(0, reflected_points)[0]
 
@@ -281,5 +281,5 @@ def test_permutation_of_tabulated_data_hexahedron(element_name, order):
             for d in range(e.value_size):
                 i_slice = i[d * e.dim:(d + 1) * e.dim]
                 j_slice = j[d * e.dim:(d + 1) * e.dim]
-                assert np.allclose((e.base_permutations[13].dot(i_slice))[start: start + ndofs],
+                assert np.allclose((e.base_transformations[13].dot(i_slice))[start: start + ndofs],
                                    j_slice[start: start + ndofs])

--- a/test/test_lagrange.py
+++ b/test/test_lagrange.py
@@ -220,13 +220,13 @@ def test_lagrange(celltype, order):
 
 
 @pytest.mark.parametrize("order", [1, 2, 3, 4])
-def test_dof_permutations_interval(order):
+def test_dof_transformations_interval(order):
     lagrange = basix.create_element("Lagrange", "interval", order)
     assert len(lagrange.base_transformations) == 0
 
 
 @pytest.mark.parametrize("order", [1, 2, 3, 4])
-def test_dof_permutations_triangle(order):
+def test_dof_transformations_triangle(order):
     lagrange = basix.create_element("Lagrange", "triangle", order)
 
     permuted = {}
@@ -241,21 +241,21 @@ def test_dof_permutations_triangle(order):
         permuted[1] = {6: 8, 8: 6}
         permuted[2] = {9: 11, 11: 9}
 
-    base_perms = lagrange.base_transformations
-    assert len(base_perms) == 3
+    base_transformations = lagrange.base_transformations
+    assert len(base_transformations) == 3
 
-    for i, perm in enumerate(base_perms):
-        actual = numpy.zeros_like(perm)
-        for j, row in enumerate(perm):
+    for i, t in enumerate(base_transformations):
+        actual = numpy.zeros_like(t)
+        for j, row in enumerate(t):
             if i in permuted and j in permuted[i]:
                 actual[j, permuted[i][j]] = 1
             else:
                 actual[j, j] = 1
-        assert numpy.allclose(perm, actual)
+        assert numpy.allclose(t, actual)
 
 
 @pytest.mark.parametrize("order", [1, 2, 3, 4])
-def test_dof_permutations_tetrahedron(order):
+def test_dof_transformations_tetrahedron(order):
     lagrange = basix.create_element("Lagrange", "tetrahedron", order)
 
     permuted = {}
@@ -285,17 +285,17 @@ def test_dof_permutations_tetrahedron(order):
         permuted[12] = {31: 33, 32: 31, 33: 32}
         permuted[13] = {32: 33, 33: 32}
 
-    base_perms = lagrange.base_transformations
-    assert len(base_perms) == 14
+    base_transformations = lagrange.base_transformations
+    assert len(base_transformations) == 14
 
-    for i, perm in enumerate(base_perms):
-        actual = numpy.zeros_like(perm)
-        for j, row in enumerate(perm):
+    for i, t in enumerate(base_transformations):
+        actual = numpy.zeros_like(t)
+        for j, row in enumerate(t):
             if i in permuted and j in permuted[i]:
                 actual[j, permuted[i][j]] = 1
             else:
                 actual[j, j] = 1
-        assert numpy.allclose(perm, actual)
+        assert numpy.allclose(t, actual)
 
 
 @pytest.mark.parametrize("order", [1, 2, 3, 4])

--- a/test/test_lagrange.py
+++ b/test/test_lagrange.py
@@ -222,7 +222,7 @@ def test_lagrange(celltype, order):
 @pytest.mark.parametrize("order", [1, 2, 3, 4])
 def test_dof_permutations_interval(order):
     lagrange = basix.create_element("Lagrange", "interval", order)
-    assert len(lagrange.base_permutations) == 0
+    assert len(lagrange.base_transformations) == 0
 
 
 @pytest.mark.parametrize("order", [1, 2, 3, 4])
@@ -241,7 +241,7 @@ def test_dof_permutations_triangle(order):
         permuted[1] = {6: 8, 8: 6}
         permuted[2] = {9: 11, 11: 9}
 
-    base_perms = lagrange.base_permutations
+    base_perms = lagrange.base_transformations
     assert len(base_perms) == 3
 
     for i, perm in enumerate(base_perms):
@@ -285,7 +285,7 @@ def test_dof_permutations_tetrahedron(order):
         permuted[12] = {31: 33, 32: 31, 33: 32}
         permuted[13] = {32: 33, 33: 32}
 
-    base_perms = lagrange.base_permutations
+    base_perms = lagrange.base_transformations
     assert len(base_perms) == 14
 
     for i, perm in enumerate(base_perms):


### PR DESCRIPTION
Fixes #131.

This is coupled with FEniCS/ffcx#315 and FEniCS/dolfinx#1439.