### PR TITLE
Use row major for external data in tabulate (multiple points/ multiple derivatives)

### DIFF
--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -279,7 +279,7 @@ FiniteElement::tabulate(int nd, const xt::xarray<double>& x) const
   {
     std::size_t offset = i * x.shape(0) * ndofs * vs;
     std::array<std::size_t, 2> shape = {_x.shape(0), ndofs * vs};
-    auto mat = xt::adapt<xt::layout_type::column_major>(
+    auto mat = xt::adapt<xt::layout_type::row_major>(
         basis_data.data() + offset, x.shape(0) * ndofs * vs, xt::no_ownership(),
         shape);
     xt::view(d, i, xt::all(), xt::all()) = mat;

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -358,7 +358,7 @@ void FiniteElement::tabulate(int nd, const xt::xarray<double>& x,
     // Map block for current derivative
     std::array<std::size_t, 2> shape = {_x.shape(0), ndofs * vs};
     std::size_t offset = p * x.shape(0) * ndofs * vs;
-    auto dresult = xt::adapt<xt::layout_type::column_major>(
+    auto dresult = xt::adapt<xt::layout_type::row_major>(
         basis_data + offset, x.shape(0) * ndofs * vs, xt::no_ownership(),
         shape);
     for (int j = 0; j < vs; ++j)


### PR DESCRIPTION
with @jorgensd ...
```
#include <Eigen/Core>
#include <basix.h>
#include <iostream>

int main()
{
  int handle = basix::register_element("Lagrange", "triangle", 1);
  int tdim = 2;
  int num_points = 2;
  int d = 3;
  Eigen::Array<double, -1, -1, Eigen::RowMajor> basis_values(
      (tdim + 1) * num_points, d);

  Eigen::Array<double, -1, -1, Eigen::RowMajor> x(num_points, tdim);
  x.row(0) << 0, 0;
  x.row(1) << 0.5, 0.5;

  basix::tabulate(handle, basis_values.data(), 1, x.data(), num_points);

  std::cout << basis_values;

  for (int i = 0; i < num_points; i++)
  {
    Eigen::Array<double, -1, -1, Eigen::RowMajor> basis_values_i((tdim + 1), d);
    basix::tabulate(handle, basis_values_i.data(), 1, x.row(i).data(), 1);
    std::cout << " \n\n" << basis_values_i;
  }

  return 0;
}

```

Main:

```
# All points
          1 1.38778e-17           0
        0.5           0         0.5
         -1          -1           1
          1           0           0
         -1          -1           0
          0           1           1 

# point 0
 1  0  0
-1  1  0
-1  0  1 


# point 1
1.38778e-17         0.5         0.5
         -1           1           0
         -1           0           1
```


This branch:

```
# All points
         1           0           0
1.38778e-17         0.5         0.5
         -1           1           0
         -1           1           0
         -1           0           1
         -1           0           1 

# point 0
 1  0  0
-1  1  0
-1  0  1 

# point 1
1.38778e-17         0.5         0.5
         -1           1           0
         -1           0           1
```