### PR TITLE
Reduce amount stored for DOF transformations

### DIFF
--- a/.github/workflows/dolfin-tests.yml
+++ b/.github/workflows/dolfin-tests.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install FEniCS Python components
         run: |
           python3 -m pip install git+https://github.com/FEniCS/ufl.git
-          python3 -m pip install git+https://github.com/FEniCS/ffcx.git
+          python3 -m pip install git+https://github.com/FEniCS/ffcx.git@mscroggs/base-transformations
 
       - name: Get DOLFINX
         uses: actions/checkout@v2

--- a/.github/workflows/dolfin-tests.yml
+++ b/.github/workflows/dolfin-tests.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install FEniCS Python components
         run: |
           python3 -m pip install git+https://github.com/FEniCS/ufl.git
-          python3 -m pip install git+https://github.com/FEniCS/ffcx.git@mscroggs/base-transformations
+          python3 -m pip install git+https://github.com/FEniCS/ffcx.git@mscroggs/dof-transformations
 
       - name: Get DOLFINX
         uses: actions/checkout@v2

--- a/cpp/basix/bubble.cpp
+++ b/cpp/basix/bubble.cpp
@@ -143,8 +143,9 @@ FiniteElement basix::create_bubble(cell::type celltype, int degree)
   M[tdim].push_back(xt::xtensor<double, 3>({ndofs, 1, ndofs}));
   xt::view(M[tdim][0], xt::all(), 0, xt::all()) = xt::eye<double>(ndofs);
 
+  const int num_transformations = tdim * (tdim - 1) / 2;
   std::vector<xt::xtensor<double, 2>> entity_transformations(
-      tdim == 2 ? 1 : (tdim == 3 ? 3 : 0), xt::xtensor<double, 2>({0, 0}));
+      num_transformations);
 
   xt::xtensor<double, 3> coeffs = compute_expansion_coefficients(
       celltype, wcoeffs, {M[tdim]}, {x[tdim]}, degree);

--- a/cpp/basix/bubble.cpp
+++ b/cpp/basix/bubble.cpp
@@ -140,18 +140,15 @@ FiniteElement basix::create_bubble(cell::type celltype, int degree)
   const std::vector<std::vector<std::vector<int>>> topology
       = cell::topology(celltype);
 
-  std::size_t transform_count = 0;
-  for (std::size_t i = 1; i < topology.size() - 1; ++i)
-    transform_count += topology[i].size() * i;
-
   M[tdim].push_back(xt::xtensor<double, 3>({ndofs, 1, ndofs}));
   xt::view(M[tdim][0], xt::all(), 0, xt::all()) = xt::eye<double>(ndofs);
 
-  auto base_transformations
-      = xt::tile(xt::expand_dims(xt::eye<double>(ndofs), 0), transform_count);
+  std::vector<xt::xtensor<double, 2>> entity_transformations(
+      tdim == 2 ? 1 : (tdim == 3 ? 3 : 0), xt::xtensor<double, 2>({0, 0}));
+
   xt::xtensor<double, 3> coeffs = compute_expansion_coefficients(
       celltype, wcoeffs, {M[tdim]}, {x[tdim]}, degree);
   return FiniteElement(element::family::Bubble, celltype, degree, {1}, coeffs,
-                       base_transformations, x, M, maps::type::identity);
+                       entity_transformations, x, M, maps::type::identity);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/basix/crouzeix-raviart.cpp
+++ b/cpp/basix/crouzeix-raviart.cpp
@@ -45,8 +45,9 @@ FiniteElement basix::create_cr(cell::type celltype, int degree)
     xt::row(x[tdim - 1][f], 0) = xt::mean(v, 0);
   }
 
+  const int num_transformations = tdim * (tdim - 1) / 2;
   std::vector<xt::xtensor<double, 2>> entity_transformations(
-      tdim == 2 ? 1 : 3, xt::xtensor<double, 2>({0, 0}));
+      num_transformations);
 
   M[tdim - 1].resize(facet_topology.size(), xt::ones<double>({1, 1, 1}));
   const xt::xtensor<double, 3> coeffs = compute_expansion_coefficients(

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -462,7 +462,7 @@ xt::xtensor<double, 3> FiniteElement::base_transformations() const
   if (tdim > 1)
   {
     // Base transformations for edges
-    for (std::size_t i = 0; i < cell::sub_entity_count(_cell_type, 1); ++i)
+    for (int i = 0; i < cell::sub_entity_count(_cell_type, 1); ++i)
     {
       xt::view(bt, transform_n++,
                xt::range(dof_start, dof_start + _entity_dofs[1][i]),
@@ -473,7 +473,7 @@ xt::xtensor<double, 3> FiniteElement::base_transformations() const
 
     if (tdim > 2)
     {
-      for (std::size_t i = 0; i < cell::sub_entity_count(_cell_type, 2); ++i)
+      for (int i = 0; i < cell::sub_entity_count(_cell_type, 2); ++i)
       {
         // TODO: This assumes that every face has the same shape
         //       _entity_transformations should be replaced with a map from a

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -45,6 +45,31 @@ constexpr int compute_value_size(maps::type map_type, int dim)
     throw std::runtime_error("Mapping not yet implemented");
   }
 }
+//-----------------------------------------------------------------------------
+int num_transformations(cell::type cell_type)
+{
+  switch (cell_type)
+  {
+  case cell::type::point:
+    return 0;
+  case cell::type::interval:
+    return 0;
+  case cell::type::triangle:
+    return 3;
+  case cell::type::quadrilateral:
+    return 4;
+  case cell::type::tetrahedron:
+    return 14;
+  case cell::type::hexahedron:
+    return 24;
+  case cell::type::prism:
+    return 19;
+  case cell::type::pyramid:
+    return 18;
+  default:
+    throw std::runtime_error("Cell type not yet supported");
+  }
+}
 } // namespace
 //-----------------------------------------------------------------------------
 basix::FiniteElement basix::create_element(std::string family, std::string cell,
@@ -214,7 +239,7 @@ FiniteElement::FiniteElement(
     element::family family, cell::type cell_type, int degree,
     const std::vector<std::size_t>& value_shape,
     const xt::xtensor<double, 3>& coeffs,
-    const xt::xtensor<double, 3>& base_transformations,
+    const std::vector<xt::xtensor<double, 2>>& entity_transformations,
     const std::array<std::vector<xt::xtensor<double, 2>>, 4>& x,
     const std::array<std::vector<xt::xtensor<double, 3>>, 4>& M,
     maps::type map_type)
@@ -222,7 +247,7 @@ FiniteElement::FiniteElement(
       _degree(degree), _map_type(map_type),
       _coeffs(xt::reshape_view(
           coeffs, {coeffs.shape(0), coeffs.shape(1) * coeffs.shape(2)})),
-      _base_transformations(base_transformations), _x(x), _matM_new(M)
+      _entity_transformations(entity_transformations), _x(x), _matM_new(M)
 {
   // if (points.dimension() == 1)
   //   throw std::runtime_error("Problem with points");
@@ -416,9 +441,58 @@ void FiniteElement::tabulate(int nd, const xt::xarray<double>& x,
   }
 }
 //-----------------------------------------------------------------------------
-const xt::xtensor<double, 3>& FiniteElement::base_transformations() const
+xt::xtensor<double, 3> FiniteElement::base_transformations() const
 {
-  return _base_transformations;
+  const std::size_t tdim = cell::topological_dimension(_cell_type);
+  const std::size_t nt = num_transformations(cell_type());
+  const std::size_t ndofs = dim();
+
+  xt::xtensor<double, 3> bt({nt, ndofs, ndofs});
+  for (std::size_t i = 0; i < nt; ++i)
+    xt::view(bt, i, xt::all(), xt::all()) = xt::eye<double>(ndofs);
+
+  std::size_t dof_start = 0;
+  int transform_n = 0;
+  if (tdim > 0)
+  {
+    for (std::size_t i = 0; i < _entity_dofs[0].size(); ++i)
+      dof_start += _entity_dofs[0][i];
+  }
+
+  if (tdim > 1)
+  {
+    // Base transformations for edges
+    for (std::size_t i = 0; i < cell::sub_entity_count(_cell_type, 1); ++i)
+    {
+      xt::view(bt, transform_n++,
+               xt::range(dof_start, dof_start + _entity_dofs[1][i]),
+               xt::range(dof_start, dof_start + _entity_dofs[1][i]))
+          = _entity_transformations[0];
+      dof_start += _entity_dofs[1][i];
+    }
+
+    if (tdim > 2)
+    {
+      for (std::size_t i = 0; i < cell::sub_entity_count(_cell_type, 2); ++i)
+      {
+        // TODO: This assumes that every face has the same shape
+        //       _entity_transformations should be replaced with a map from a
+        //       subentity type to a matrix to allow for prisms and pyramids.
+        xt::view(bt, transform_n++,
+                 xt::range(dof_start, dof_start + _entity_dofs[2][i]),
+                 xt::range(dof_start, dof_start + _entity_dofs[2][i]))
+            = _entity_transformations[1];
+        xt::view(bt, transform_n++,
+                 xt::range(dof_start, dof_start + _entity_dofs[2][i]),
+                 xt::range(dof_start, dof_start + _entity_dofs[2][i]))
+            = _entity_transformations[2];
+
+        dof_start += _entity_dofs[2][i];
+      }
+    }
+  }
+
+  return bt;
 }
 //-----------------------------------------------------------------------------
 int FiniteElement::num_points() const { return _points.shape(0); }

--- a/cpp/basix/finite-element.h
+++ b/cpp/basix/finite-element.h
@@ -199,19 +199,20 @@ public:
   /// @param[in] value_shape
   /// @param[in] coeffs Expansion coefficients. The shape is (num_dofs,
   /// value_size, basis_dim)
-  /// @param[in] base_transformations Base transformations
+  /// @param[in] entity_transformations Entity transformations
   /// @param[in] x Interpolation points. Shape is (tdim, entity index,
   /// point index, dim)
   /// @param[in] M The interpolation matrices. Indices are (tdim, entity
   /// index, dof, vs, point_index)
   /// @param[in] map_type
-  FiniteElement(element::family family, cell::type cell_type, int degree,
-                const std::vector<std::size_t>& value_shape,
-                const xt::xtensor<double, 3>& coeffs,
-                const xt::xtensor<double, 3>& base_transformations,
-                const std::array<std::vector<xt::xtensor<double, 2>>, 4>& x,
-                const std::array<std::vector<xt::xtensor<double, 3>>, 4>& M,
-                maps::type map_type = maps::type::identity);
+  FiniteElement(
+      element::family family, cell::type cell_type, int degree,
+      const std::vector<std::size_t>& value_shape,
+      const xt::xtensor<double, 3>& coeffs,
+      const std::vector<xt::xtensor<double, 2>>& entity_transformations,
+      const std::array<std::vector<xt::xtensor<double, 2>>, 4>& x,
+      const std::array<std::vector<xt::xtensor<double, 3>>, 4>& M,
+      maps::type map_type = maps::type::identity);
 
   /// Copy constructor
   FiniteElement(const FiniteElement& element) = default;
@@ -418,7 +419,7 @@ public:
   ///   reflection: [[0, 1],
   ///                [1, 0]]
   /// ~~~~~~~~~~~~~~~~
-  const xt::xtensor<double, 3>& base_transformations() const;
+  xt::xtensor<double, 3> base_transformations() const;
 
   /// Return the interpolation points, i.e. the coordinates on the
   /// reference element where a function need to be evaluated in order
@@ -471,8 +472,8 @@ private:
   // count on the associated entity, as listed by cell::topology.
   std::vector<std::vector<int>> _entity_dofs;
 
-  // Base transformations
-  xt::xtensor<double, 3> _base_transformations;
+  // Entity transformations
+  std::vector<xt::xtensor<double, 2>> _entity_transformations;
 
   // Set of points used for point evaluation
   // Experimental - currently used for an implementation of

--- a/cpp/basix/lagrange.cpp
+++ b/cpp/basix/lagrange.cpp
@@ -103,128 +103,61 @@ FiniteElement basix::create_lagrange(cell::type celltype, int degree)
     }
   }
 
-  std::size_t transform_count = 0;
-  for (std::size_t i = 1; i < topology.size() - 1; ++i)
-    transform_count += topology[i].size() * i;
-  auto base_transformations
-      = xt::tile(xt::expand_dims(xt::eye<double>(ndofs), 0), transform_count);
-  switch (celltype)
-  {
-  case cell::type::interval:
-    assert(transform_count == 0);
-    break;
-  case cell::type::triangle:
+  std::vector<xt::xtensor<double, 2>> entity_transformations;
+  if (tdim > 1)
   {
     const std::vector<int> edge_ref
         = doftransforms::interval_reflection(degree - 1);
-    for (int edge = 0; edge < 3; ++edge)
-    {
-      auto bt = xt::view(base_transformations, edge, xt::all(), xt::all());
-      const int start = 3 + edge_ref.size() * edge;
-      for (std::size_t i = 0; i < edge_ref.size(); ++i)
-      {
-        bt(start + i, start + i) = 0;
-        bt(start + i, start + edge_ref[i]) = 1;
-      }
-    }
-    break;
+    xt::xtensor<double, 2> et
+        = xt::zeros<double>({edge_ref.size(), edge_ref.size()});
+    for (std::size_t i = 0; i < edge_ref.size(); ++i)
+      et(i, edge_ref[i]) = 1;
+    entity_transformations.push_back(et);
   }
-  case cell::type::quadrilateral:
+  if (celltype == cell::type::tetrahedron)
   {
-    const std::vector<int> edge_ref
-        = doftransforms::interval_reflection(degree - 1);
-    for (int edge = 0; edge < 4; ++edge)
-    {
-      auto bt = xt::view(base_transformations, edge, xt::all(), xt::all());
-      const int start = 4 + edge_ref.size() * edge;
-      for (std::size_t i = 0; i < edge_ref.size(); ++i)
-      {
-        bt(start + i, start + i) = 0;
-        bt(start + i, start + edge_ref[i]) = 1;
-      }
-    }
-    break;
-  }
-  case cell::type::tetrahedron:
-  {
-    const std::vector<int> edge_ref
-        = doftransforms::interval_reflection(degree - 1);
-    for (int edge = 0; edge < 6; ++edge)
-    {
-      auto bt = xt::view(base_transformations, edge, xt::all(), xt::all());
-      const int start = 4 + edge_ref.size() * edge;
-      for (std::size_t i = 0; i < edge_ref.size(); ++i)
-      {
-        bt(start + i, start + i) = 0;
-        bt(start + i, start + edge_ref[i]) = 1;
-      }
-    }
-    const std::vector<int> face_ref
-        = doftransforms::triangle_reflection(degree - 2);
     const std::vector<int> face_rot
         = doftransforms::triangle_rotation(degree - 2);
-    for (int face = 0; face < 4; ++face)
-    {
-      auto bt0
-          = xt::view(base_transformations, 6 + 2 * face, xt::all(), xt::all());
-      auto bt1 = xt::view(base_transformations, 6 + 2 * face + 1, xt::all(),
-                          xt::all());
-      const int start = 4 + edge_ref.size() * 6 + face_ref.size() * face;
-      for (std::size_t i = 0; i < face_rot.size(); ++i)
-      {
-        bt0(start + i, start + i) = 0;
-        bt0(start + i, start + face_rot[i]) = 1;
-        bt1(start + i, start + i) = 0;
-        bt1(start + i, start + face_ref[i]) = 1;
-      }
-    }
-    break;
-  }
-  case cell::type::hexahedron:
-  {
-    const std::vector<int> edge_ref
-        = doftransforms::interval_reflection(degree - 1);
-    for (int edge = 0; edge < 12; ++edge)
-    {
-      auto bt = xt::view(base_transformations, edge, xt::all(), xt::all());
-      const int start = 8 + edge_ref.size() * edge;
-      for (std::size_t i = 0; i < edge_ref.size(); ++i)
-      {
-        bt(start + i, start + i) = 0;
-        bt(start + i, start + edge_ref[i]) = 1;
-      }
-    }
-
     const std::vector<int> face_ref
-        = doftransforms::quadrilateral_reflection(degree - 1);
-    const std::vector<int> face_rot
-        = doftransforms::quadrilateral_rotation(degree - 1);
-    for (int face = 0; face < 6; ++face)
+        = doftransforms::triangle_reflection(degree - 2);
+    xt::xtensor<double, 2> ft0
+        = xt::zeros<double>({face_rot.size(), face_rot.size()});
+    xt::xtensor<double, 2> ft1
+        = xt::zeros<double>({face_ref.size(), face_ref.size()});
+    for (std::size_t i = 0; i < face_rot.size(); ++i)
     {
-      auto bt0
-          = xt::view(base_transformations, 12 + 2 * face, xt::all(), xt::all());
-      auto bt1 = xt::view(base_transformations, 12 + 2 * face + 1, xt::all(),
-                          xt::all());
-      const int start = 8 + edge_ref.size() * 12 + face_ref.size() * face;
-      for (std::size_t i = 0; i < face_rot.size(); ++i)
-      {
-        bt0(start + i, start + i) = 0;
-        bt0(start + i, start + face_rot[i]) = 1;
-        bt1(start + i, start + i) = 0;
-        bt1(start + i, start + face_ref[i]) = 1;
-      }
+      ft0(i, face_rot[i]) = 1;
+      ft1(i, face_ref[i]) = 1;
     }
-    break;
+    entity_transformations.push_back(ft0);
+    entity_transformations.push_back(ft1);
   }
-  default:
+  else if (celltype == cell::type::hexahedron)
+  {
+    const std::vector<int> face_rot
+        = doftransforms::quadrilateral_rotation(degree - 2);
+    const std::vector<int> face_ref
+        = doftransforms::quadrilateral_reflection(degree - 2);
+    xt::xtensor<double, 2> ft0
+        = xt::zeros<double>({face_rot.size(), face_rot.size()});
+    xt::xtensor<double, 2> ft1
+        = xt::zeros<double>({face_ref.size(), face_ref.size()});
+    for (std::size_t i = 0; i < face_rot.size(); ++i)
+    {
+      ft0(i, face_rot[i]) = 1;
+      ft1(i, face_ref[i]) = 1;
+    }
+    entity_transformations.push_back(ft0);
+    entity_transformations.push_back(ft1);
+  }
+  if (celltype == cell::type::prism or celltype == cell::type::pyramid)
     LOG(WARNING) << "Base transformations not implemented for this cell type.";
-  }
 
   xt::xtensor<double, 3> coeffs = compute_expansion_coefficients(
       celltype, xt::eye<double>(ndofs), {M[0], M[1], M[2], M[3]},
       {x[0], x[1], x[2], x[3]}, degree);
   return FiniteElement(element::family::P, celltype, degree, {1}, coeffs,
-                       base_transformations, x, M, maps::type::identity);
+                       entity_transformations, x, M, maps::type::identity);
 }
 //-----------------------------------------------------------------------------
 FiniteElement basix::create_dlagrange(cell::type celltype, int degree)
@@ -238,9 +171,6 @@ FiniteElement basix::create_dlagrange(cell::type celltype, int degree)
       = cell::topology(celltype);
 
   const std::size_t tdim = topology.size() - 1;
-  std::size_t transform_count = 0;
-  for (std::size_t i = 1; i < tdim; ++i)
-    transform_count += topology[i].size() * i;
 
   std::array<std::vector<xt::xtensor<double, 3>>, 4> M;
   M[tdim].push_back(xt::xtensor<double, 3>({ndofs, 1, ndofs}));
@@ -251,13 +181,14 @@ FiniteElement basix::create_dlagrange(cell::type celltype, int degree)
   std::array<std::vector<xt::xtensor<double, 2>>, 4> x;
   x[tdim].push_back(pt);
 
-  auto base_transformations
-      = xt::tile(xt::expand_dims(xt::eye<double>(ndofs), 0), transform_count);
+  std::vector<xt::xtensor<double, 2>> entity_transformations(
+      tdim == 2 ? 1 : (tdim == 3 ? 3 : 0), xt::xtensor<double, 2>({0, 0}));
+
   xt::xtensor<double, 3> coeffs = compute_expansion_coefficients(
       celltype, xt::eye<double>(ndofs), {M[tdim]}, {x[tdim]}, degree);
 
   return FiniteElement(element::family::DP, celltype, degree, {1}, coeffs,
-                       base_transformations, x, M, maps::type::identity);
+                       entity_transformations, x, M, maps::type::identity);
 }
 //-----------------------------------------------------------------------------
 FiniteElement basix::create_dpc(cell::type celltype, int degree)
@@ -305,9 +236,6 @@ FiniteElement basix::create_dpc(cell::type celltype, int degree)
   const std::vector<std::vector<std::vector<int>>> topology
       = cell::topology(celltype);
   const std::size_t tdim = topology.size() - 1;
-  std::size_t transform_count = 0;
-  for (std::size_t i = 1; i < tdim; ++i)
-    transform_count += topology[i].size() * i;
 
   std::array<std::vector<xt::xtensor<double, 3>>, 4> M;
   M[tdim].push_back(xt::xtensor<double, 3>({ndofs, 1, ndofs}));
@@ -318,11 +246,12 @@ FiniteElement basix::create_dpc(cell::type celltype, int degree)
   std::array<std::vector<xt::xtensor<double, 2>>, 4> x;
   x[tdim].push_back(pt);
 
-  auto base_transformations
-      = xt::tile(xt::expand_dims(xt::eye<double>(ndofs), 0), transform_count);
+  std::vector<xt::xtensor<double, 2>> entity_transformations(
+      tdim == 2 ? 1 : (tdim == 3 ? 3 : 0), xt::xtensor<double, 2>({0, 0}));
+
   xt::xtensor<double, 3> coeffs = compute_expansion_coefficients(
       celltype, wcoeffs, {M[tdim]}, {x[tdim]}, degree);
   return FiniteElement(element::family::DPC, celltype, degree, {1}, coeffs,
-                       base_transformations, x, M, maps::type::identity);
+                       entity_transformations, x, M, maps::type::identity);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/basix/lagrange.cpp
+++ b/cpp/basix/lagrange.cpp
@@ -181,8 +181,9 @@ FiniteElement basix::create_dlagrange(cell::type celltype, int degree)
   std::array<std::vector<xt::xtensor<double, 2>>, 4> x;
   x[tdim].push_back(pt);
 
+  const int num_transformations = tdim * (tdim - 1) / 2;
   std::vector<xt::xtensor<double, 2>> entity_transformations(
-      tdim == 2 ? 1 : (tdim == 3 ? 3 : 0), xt::xtensor<double, 2>({0, 0}));
+      num_transformations, xt::xtensor<double, 2>({0, 0}));
 
   xt::xtensor<double, 3> coeffs = compute_expansion_coefficients(
       celltype, xt::eye<double>(ndofs), {M[tdim]}, {x[tdim]}, degree);
@@ -246,8 +247,9 @@ FiniteElement basix::create_dpc(cell::type celltype, int degree)
   std::array<std::vector<xt::xtensor<double, 2>>, 4> x;
   x[tdim].push_back(pt);
 
+  const int num_transformations = tdim * (tdim - 1) / 2;
   std::vector<xt::xtensor<double, 2>> entity_transformations(
-      tdim == 2 ? 1 : (tdim == 3 ? 3 : 0), xt::xtensor<double, 2>({0, 0}));
+      num_transformations);
 
   xt::xtensor<double, 3> coeffs = compute_expansion_coefficients(
       celltype, wcoeffs, {M[tdim]}, {x[tdim]}, degree);

--- a/cpp/basix/lagrange.cpp
+++ b/cpp/basix/lagrange.cpp
@@ -135,9 +135,9 @@ FiniteElement basix::create_lagrange(cell::type celltype, int degree)
   else if (celltype == cell::type::hexahedron)
   {
     const std::vector<int> face_rot
-        = doftransforms::quadrilateral_rotation(degree - 2);
+        = doftransforms::quadrilateral_rotation(degree - 1);
     const std::vector<int> face_ref
-        = doftransforms::quadrilateral_reflection(degree - 2);
+        = doftransforms::quadrilateral_reflection(degree - 1);
     xt::xtensor<double, 2> ft0
         = xt::zeros<double>({face_rot.size(), face_rot.size()});
     xt::xtensor<double, 2> ft1

--- a/cpp/basix/regge.cpp
+++ b/cpp/basix/regge.cpp
@@ -152,7 +152,7 @@ FiniteElement basix::create_regge(cell::type celltype, int degree)
 
   const std::vector<int> edge_ref
       = doftransforms::interval_reflection(degree + 1);
-  xt::xtensor<double, 2> et({edge_ref.size(), edge_ref.size()});
+  xt::xtensor<double, 2> et = xt::zeros<double>({edge_ref.size(), edge_ref.size()});
   for (std::size_t i = 0; i < edge_ref.size(); ++i)
     et(i, edge_ref[i]) = 1;
   entity_transformations.push_back(et);

--- a/python/wrapper.cpp
+++ b/python/wrapper.cpp
@@ -279,12 +279,11 @@ Each element has a `tabulate` function which returns the basis functions and a n
             return py::array_t<double>(U.shape(), U.data());
           },
           invmapdoc.c_str())
-      .def_property_readonly(
-          "base_transformations",
-          [](const FiniteElement& self) {
-            const xt::xtensor<double, 3>& t = self.base_transformations();
-            return py::array_t<double>(t.shape(), t.data(), py::cast(self));
-          })
+      .def("base_transformations",
+           [](const FiniteElement& self) {
+             xt::xtensor<double, 3> t = self.base_transformations();
+             return py::array_t<double>(t.shape(), t.data());
+           })
       .def_property_readonly("degree", &FiniteElement::degree)
       .def_property_readonly("cell_type", &FiniteElement::cell_type)
       .def_property_readonly("dim", &FiniteElement::dim)

--- a/test/test_dof_transformations.py
+++ b/test/test_dof_transformations.py
@@ -11,7 +11,7 @@ from .utils import parametrize_over_elements
 @parametrize_over_elements(5)
 def test_non_zero(cell_name, element_name, order):
     e = basix.create_element(element_name, cell_name, order)
-    for t in e.base_transformations:
+    for t in e.base_transformations():
         for row in t:
             assert max(abs(i) for i in row) > 1e-6
 
@@ -19,64 +19,62 @@ def test_non_zero(cell_name, element_name, order):
 @parametrize_over_elements(5, "interval")
 def test_interval_transformation_size(element_name, order):
     e = basix.create_element(element_name, "interval", order)
-    assert len(e.base_transformations) == 0
+    assert len(e.base_transformations()) == 0
 
 
 @parametrize_over_elements(5, "triangle")
 def test_triangle_transformation_orders(element_name, order):
-    if element_name == "Crouzeix-Raviart" and order != 1:
-        pytest.xfail()
     e = basix.create_element(element_name, "triangle", order)
-    assert len(e.base_transformations) == 3
+    bt = e.base_transformations()
+    assert len(bt) == 3
     identity = np.identity(e.dim)
     for i, order in enumerate([2, 2, 2]):
         assert np.allclose(
-            np.linalg.matrix_power(e.base_transformations[i], order),
+            np.linalg.matrix_power(bt[i], order),
             identity)
 
 
 @parametrize_over_elements(5, "tetrahedron")
 def test_tetrahedron_transformation_orders(element_name, order):
-    if element_name == "Crouzeix-Raviart" and order != 1:
-        pytest.xfail()
     e = basix.create_element(element_name, "tetrahedron", order)
-    assert len(e.base_transformations) == 14
+    bt = e.base_transformations()
+    assert len(bt) == 14
     identity = np.identity(e.dim)
     for i, order in enumerate([2, 2, 2, 2, 2, 2, 3, 2, 3, 2, 3, 2, 3, 2]):
         assert np.allclose(
-            np.linalg.matrix_power(e.base_transformations[i], order),
+            np.linalg.matrix_power(bt[i], order),
             identity)
 
 
 @parametrize_over_elements(5, "quadrilateral")
 def test_quadrilateral_transformation_orders(element_name, order):
     e = basix.create_element(element_name, "quadrilateral", order)
-    assert len(e.base_transformations) == 4
+    bt = e.base_transformations()
+    assert len(bt) == 4
     identity = np.identity(e.dim)
     for i, order in enumerate([2, 2, 2, 2]):
         assert np.allclose(
-            np.linalg.matrix_power(e.base_transformations[i], order),
+            np.linalg.matrix_power(bt[i], order),
             identity)
 
 
 @parametrize_over_elements(5, "hexahedron")
 def test_hexahedron_transformation_orders(element_name, order):
     e = basix.create_element(element_name, "hexahedron", order)
-    assert len(e.base_transformations) == 24
+    bt = e.base_transformations()
+    assert len(bt) == 24
     identity = np.identity(e.dim)
     for i, order in enumerate([2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
                                4, 2, 4, 2, 4, 2, 4, 2, 4, 2, 4, 2]):
         assert np.allclose(
-            np.linalg.matrix_power(e.base_transformations[i], order),
+            np.linalg.matrix_power(bt[i], order),
             identity)
 
 
 @parametrize_over_elements(5, "triangle")
 def test_transformation_of_tabulated_data_triangle(element_name, order):
-    if element_name == "Crouzeix-Raviart" and order != 1:
-        pytest.xfail()
-
     e = basix.create_element(element_name, "triangle", order)
+    bt = e.base_transformations()
 
     N = 4
     points = np.array([[i / N, j / N] for i in range(N + 1) for j in range(N + 1 - i)])
@@ -99,13 +97,14 @@ def test_transformation_of_tabulated_data_triangle(element_name, order):
             for d in range(e.value_size):
                 i_slice = i[:, d]
                 j_slice = j[:, d]
-                assert np.allclose((e.base_transformations[0].dot(i_slice))[start: start + ndofs],
+                assert np.allclose((bt[0].dot(i_slice))[start: start + ndofs],
                                    j_slice[start: start + ndofs])
 
 
 @parametrize_over_elements(5, "quadrilateral")
 def test_transformation_of_tabulated_data_quadrilateral(element_name, order):
     e = basix.create_element(element_name, "quadrilateral", order)
+    bt = e.base_transformations()
 
     N = 4
     points = np.array([[i / N, j / N] for i in range(N + 1) for j in range(N + 1)])
@@ -127,13 +126,14 @@ def test_transformation_of_tabulated_data_quadrilateral(element_name, order):
             for d in range(e.value_size):
                 i_slice = i[:, d]
                 j_slice = j[:, d]
-                assert np.allclose((e.base_transformations[0].dot(i_slice))[start: start + ndofs],
+                assert np.allclose((bt[0].dot(i_slice))[start: start + ndofs],
                                    j_slice[start: start + ndofs])
 
 
 @parametrize_over_elements(5, "tetrahedron")
 def test_transformation_of_tabulated_data_tetrahedron(element_name, order):
     e = basix.create_element(element_name, "tetrahedron", order)
+    bt = e.base_transformations()
 
     N = 4
     points = np.array([[i / N, j / N, k / N]
@@ -156,7 +156,7 @@ def test_transformation_of_tabulated_data_tetrahedron(element_name, order):
             for d in range(e.value_size):
                 i_slice = i[:, d]
                 j_slice = j[:, d]
-                assert np.allclose((e.base_transformations[0].dot(i_slice))[start: start + ndofs],
+                assert np.allclose((bt[0].dot(i_slice))[start: start + ndofs],
                                    j_slice[start: start + ndofs])
 
     start = sum(e.entity_dofs[0]) + sum(e.entity_dofs[1])
@@ -175,7 +175,7 @@ def test_transformation_of_tabulated_data_tetrahedron(element_name, order):
             for d in range(e.value_size):
                 i_slice = i[:, d]
                 j_slice = j[:, d]
-                assert np.allclose(e.base_transformations[6].dot(i_slice)[start: start + ndofs],
+                assert np.allclose(bt[6].dot(i_slice)[start: start + ndofs],
                                    j_slice[start: start + ndofs])
 
     if ndofs != 0:
@@ -192,7 +192,7 @@ def test_transformation_of_tabulated_data_tetrahedron(element_name, order):
             for d in range(e.value_size):
                 i_slice = i[:, d]
                 j_slice = j[:, d]
-                assert np.allclose((e.base_transformations[7].dot(i_slice))[start: start + ndofs],
+                assert np.allclose((bt[7].dot(i_slice))[start: start + ndofs],
                                    j_slice[start: start + ndofs])
 
 
@@ -204,6 +204,7 @@ def test_transformation_of_tabulated_data_hexahedron(element_name, order):
                      "Lagrange spaces equally spaced points are unstable.")
 
     e = basix.create_element(element_name, "hexahedron", order)
+    bt = e.base_transformations()
 
     N = 4
     points = np.array([[i / N, j / N, k / N]
@@ -226,7 +227,7 @@ def test_transformation_of_tabulated_data_hexahedron(element_name, order):
             for d in range(e.value_size):
                 i_slice = i[:, d]
                 j_slice = j[:, d]
-                assert np.allclose((e.base_transformations[0].dot(i_slice))[start: start + ndofs],
+                assert np.allclose((bt[0].dot(i_slice))[start: start + ndofs],
                                    j_slice[start: start + ndofs])
 
     start = sum(e.entity_dofs[0]) + sum(e.entity_dofs[1])
@@ -245,7 +246,7 @@ def test_transformation_of_tabulated_data_hexahedron(element_name, order):
             for d in range(e.value_size):
                 i_slice = i[:, d]
                 j_slice = j[:, d]
-                assert np.allclose(e.base_transformations[12].dot(i_slice)[start: start + ndofs],
+                assert np.allclose(bt[12].dot(i_slice)[start: start + ndofs],
                                    j_slice[start: start + ndofs])
 
     if ndofs != 0:
@@ -262,5 +263,5 @@ def test_transformation_of_tabulated_data_hexahedron(element_name, order):
             for d in range(e.value_size):
                 i_slice = i[:, d]
                 j_slice = j[:, d]
-                assert np.allclose((e.base_transformations[13].dot(i_slice))[start: start + ndofs],
+                assert np.allclose((bt[13].dot(i_slice))[start: start + ndofs],
                                    j_slice[start: start + ndofs])

--- a/test/test_lagrange.py
+++ b/test/test_lagrange.py
@@ -222,7 +222,7 @@ def test_lagrange(celltype, order):
 @pytest.mark.parametrize("order", [1, 2, 3, 4])
 def test_dof_transformations_interval(order):
     lagrange = basix.create_element("Lagrange", "interval", order)
-    assert len(lagrange.base_transformations) == 0
+    assert len(lagrange.base_transformations()) == 0
 
 
 @pytest.mark.parametrize("order", [1, 2, 3, 4])
@@ -241,7 +241,7 @@ def test_dof_transformations_triangle(order):
         permuted[1] = {6: 8, 8: 6}
         permuted[2] = {9: 11, 11: 9}
 
-    base_transformations = lagrange.base_transformations
+    base_transformations = lagrange.base_transformations()
     assert len(base_transformations) == 3
 
     for i, t in enumerate(base_transformations):
@@ -285,7 +285,7 @@ def test_dof_transformations_tetrahedron(order):
         permuted[12] = {31: 33, 32: 31, 33: 32}
         permuted[13] = {32: 33, 33: 32}
 
-    base_transformations = lagrange.base_transformations
+    base_transformations = lagrange.base_transformations()
     assert len(base_transformations) == 14
 
     for i, t in enumerate(base_transformations):


### PR DESCRIPTION
Instead of storing 1 or 2 `ndofs` by `ndofs` matrices for each edge and face, we now store 1 or 2 `num_entity_dofs` by `num_entity_dofs` matrices for each subentity type.

eg for an order 4 Lagrange space on a hexahedron, we used to store 24 125x125 matrices, but we now store one 3x3 matrix and two 9x9 matrices.

This has simplified the generation of base transformations for each element.

This is progress towards #100.

This PR is coupled with FEniCS/ffcx#322 