### PR TITLE
Add permute_dofs and unpermute_dofs functions to Basix

### DIFF
--- a/.github/workflows/dolfin-tests.yml
+++ b/.github/workflows/dolfin-tests.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           path: ./dolfinx
           repository: FEniCS/dolfinx
-          ref: main
+          ref: mscroggs/dof-permutations
       - name: Install DOLFINX
         run: |
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build -S dolfinx/cpp/

--- a/cpp/basix.h
+++ b/cpp/basix.h
@@ -191,6 +191,10 @@ const char* family_name(int handle);
 /// @param [in] handle Identifier
 const char* mapping_name(int handle);
 
+/// Indicates whether all the DOF transformations are identity matrices
+/// @param [in] handle Identifier
+bool dof_transformations_are_identity(int handle);
+
 /// Number of dofs per entity of given dimension
 /// @param handle Identifier
 /// @param dim Entity dimension

--- a/cpp/basix.h
+++ b/cpp/basix.h
@@ -152,14 +152,14 @@ void map_pull_back_complex(int handle, std::complex<double>* reference_data,
 /// @param[in] handle The handle of the basix element
 /// @param[in,out] dofs The dof numbers
 /// @param[in] cell_info The permutation data of the cell
-void permute_dofs(int handle, int* dofs, std::uint32_t cell_info);
+void permute_dofs(int handle, std::int32_t* dofs, std::uint32_t cell_info);
 
 /// Unpermute the DOF numbering of a cell
 ///
 /// @param[in] handle The handle of the basix element
 /// @param[in,out] dofs The dof numbers
 /// @param[in] cell_info The permutation data of the cell
-void unpermute_dofs(int handle, int* dofs, std::uint32_t cell_info);
+void unpermute_dofs(int handle, std::int32_t* dofs, std::uint32_t cell_info);
 
 /// String representation of the cell type of the finite element
 /// @param handle

--- a/cpp/basix.h
+++ b/cpp/basix.h
@@ -147,6 +147,20 @@ void map_pull_back_complex(int handle, std::complex<double>* reference_data,
                            int physical_dim, int physical_value_size,
                            int nresults, int npoints);
 
+/// Permute the DOF numbering of a cell
+///
+/// @param[in] handle The handle of the basix element
+/// @param[in/out] dofs The dofs numbers
+/// @param[in] cell_info The permutation data of the cell
+void permute_dofs(int handle, int* dofs, std::uint32_t cell_info);
+
+/// Unpermute the DOF numbering of a cell
+///
+/// @param[in] handle The handle of the basix element
+/// @param[in/out] dofs The dofs numbers
+/// @param[in] cell_info The permutation data of the cell
+void unpermute_dofs(int handle, int* dofs, std::uint32_t cell_info);
+
 /// String representation of the cell type of the finite element
 /// @param handle
 /// @return cell type string

--- a/cpp/basix.h
+++ b/cpp/basix.h
@@ -150,14 +150,14 @@ void map_pull_back_complex(int handle, std::complex<double>* reference_data,
 /// Permute the DOF numbering of a cell
 ///
 /// @param[in] handle The handle of the basix element
-/// @param[in/out] dofs The dofs numbers
+/// @param[in,out] dofs The dof numbers
 /// @param[in] cell_info The permutation data of the cell
 void permute_dofs(int handle, int* dofs, std::uint32_t cell_info);
 
 /// Unpermute the DOF numbering of a cell
 ///
 /// @param[in] handle The handle of the basix element
-/// @param[in/out] dofs The dofs numbers
+/// @param[in,out] dofs The dof numbers
 /// @param[in] cell_info The permutation data of the cell
 void unpermute_dofs(int handle, int* dofs, std::uint32_t cell_info);
 

--- a/cpp/basix/basix.cpp
+++ b/cpp/basix/basix.cpp
@@ -170,14 +170,16 @@ void basix::map_pull_back_complex(int handle,
                                        physical_value_size, nresults, npoints);
 }
 
-void basix::permute_dofs(int handle, int* dofs, std::uint32_t cell_info)
+void basix::permute_dofs(int handle, std::int32_t* dofs,
+                         std::uint32_t cell_info)
 {
   check_handle(handle);
   auto dof_array = tcb::span(dofs, _registry[handle]->dim());
   _registry[handle]->permute_dofs(dof_array, cell_info);
 }
 
-void basix::unpermute_dofs(int handle, int* dofs, std::uint32_t cell_info)
+void basix::unpermute_dofs(int handle, std::int32_t* dofs,
+                           std::uint32_t cell_info)
 {
   check_handle(handle);
   auto dof_array = tcb::span(dofs, _registry[handle]->dim());

--- a/cpp/basix/basix.cpp
+++ b/cpp/basix/basix.cpp
@@ -170,6 +170,20 @@ void basix::map_pull_back_complex(int handle,
                                        physical_value_size, nresults, npoints);
 }
 
+void basix::permute_dofs(int handle, int* dofs, std::uint32_t cell_info)
+{
+  check_handle(handle);
+  auto dof_array = tcb::span(dofs, _registry[handle]->dim());
+  _registry[handle]->permute_dofs(dof_array, cell_info);
+}
+
+void basix::unpermute_dofs(int handle, int* dofs, std::uint32_t cell_info)
+{
+  check_handle(handle);
+  auto dof_array = tcb::span(dofs, _registry[handle]->dim());
+  _registry[handle]->unpermute_dofs(dof_array, cell_info);
+}
+
 const char* basix::cell_type(int handle)
 {
   check_handle(handle);

--- a/cpp/basix/basix.cpp
+++ b/cpp/basix/basix.cpp
@@ -261,6 +261,12 @@ const char* basix::mapping_name(int handle)
   return maps::type_to_str(_registry[handle]->mapping_type()).c_str();
 }
 
+bool basix::dof_transformations_are_identity(int handle)
+{
+  check_handle(handle);
+  return _registry[handle]->dof_transformations_are_identity();
+}
+
 int basix::cell_geometry_num_points(const char* cell_type)
 {
   cell::type ct = cell::str_to_type(cell_type);

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -351,50 +351,50 @@ FiniteElement::FiniteElement(
           or _entity_transformations[i](row, row) > 1.001)
         _dof_transformations_are_identity = false;
     }
-  }
-  // If transformations are permutations, then create the permutations
-  if (_dof_transformations_are_permutations)
-  {
-    for (std::size_t i = 0; i < _entity_transformations.size(); ++i)
-    {
-      std::vector<int> perm(_entity_transformations[i].shape(0));
-      std::vector<int> rev_perm(_entity_transformations[i].shape(0));
-      for (std::size_t row = 0; row < _entity_transformations[i].shape(0);
-           ++row)
-      {
-        for (std::size_t col = 0; col < _entity_transformations[i].shape(0);
-             ++col)
-        {
-          if (_entity_transformations[i](row, col) > 0.5)
-          {
-            perm[row] = col;
-            rev_perm[col] = row;
-            break;
           }
-        }
-      }
-      // Factorise the permutations
-      std::vector<int> f_perm(perm.size());
-      for (std::size_t row = 0; row < perm.size(); ++row)
-      {
-        std::size_t row2 = perm[row];
-        while (row2 < row)
-          row2 = perm[row2];
-        f_perm[row] = row2;
-      }
-      _entity_permutations.push_back(f_perm);
+          // If transformations are permutations, then create the permutations
+          if (_dof_transformations_are_permutations)
+          {
+            for (std::size_t i = 0; i < _entity_transformations.size(); ++i)
+            {
+              std::vector<int> perm(_entity_transformations[i].shape(0));
+              std::vector<int> rev_perm(_entity_transformations[i].shape(0));
+              for (std::size_t row = 0;
+                   row < _entity_transformations[i].shape(0); ++row)
+              {
+                for (std::size_t col = 0;
+                     col < _entity_transformations[i].shape(0); ++col)
+                {
+                  if (_entity_transformations[i](row, col) > 0.5)
+                  {
+                    perm[row] = col;
+                    rev_perm[col] = row;
+                    break;
+                  }
+                }
+              }
+              // Factorise the permutations
+              std::vector<int> f_perm(perm.size());
+              for (std::size_t row = 0; row < perm.size(); ++row)
+              {
+                std::size_t row2 = perm[row];
+                while (row2 < row)
+                  row2 = perm[row2];
+                f_perm[row] = row2;
+              }
+              _entity_permutations.push_back(f_perm);
 
-      std::vector<int> f_rev_perm(rev_perm.size());
-      for (std::size_t row = 0; row < rev_perm.size(); ++row)
-      {
-        std::size_t row2 = rev_perm[row];
-        while (row2 < row)
-          row2 = rev_perm[row2];
-        f_rev_perm[row] = row2;
-      }
-      _reverse_entity_permutations.push_back(f_rev_perm);
-    }
-  }
+              std::vector<int> f_rev_perm(rev_perm.size());
+              for (std::size_t row = 0; row < rev_perm.size(); ++row)
+              {
+                std::size_t row2 = rev_perm[row];
+                while (row2 < row)
+                  row2 = rev_perm[row2];
+                f_rev_perm[row] = row2;
+              }
+              _reverse_entity_permutations.push_back(f_rev_perm);
+            }
+          }
 }
 //-----------------------------------------------------------------------------
 cell::type FiniteElement::cell_type() const { return _cell_type; }

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -46,6 +46,8 @@ constexpr int compute_value_size(maps::type map_type, int dim)
   }
 }
 //-----------------------------------------------------------------------------
+bool isClose(double a, double b) { return fabs(a - b) < 0.0001 }
+//-----------------------------------------------------------------------------
 int num_transformations(cell::type cell_type)
 {
   switch (cell_type)
@@ -356,9 +358,8 @@ FiniteElement::FiniteElement(
           = xt::amax(xt::view(_entity_transformations[i], row, xt::all()))(0);
       double rtot
           = xt::sum(xt::view(_entity_transformations[i], row, xt::all()))(0);
-      if ((_entity_transformations[i].shape(1) != 1
-           and (rmin > 0.001 or rmin < -0.001))
-          or (rmax > 1.001 or rmax < 0.999) or (rtot > 1.001 or rtot < 0.999))
+      if ((_entity_transformations[i].shape(1) != 1 and !isClose(rmin, 0))
+          or !isClose(rmax, 1) or !isClose(rtot, 1))
       {
         _dof_transformations_are_permutations = false;
         _dof_transformations_are_identity = false;

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -351,50 +351,50 @@ FiniteElement::FiniteElement(
           or _entity_transformations[i](row, row) > 1.001)
         _dof_transformations_are_identity = false;
     }
-          }
-          // If transformations are permutations, then create the permutations
-          if (_dof_transformations_are_permutations)
+  }
+  // If transformations are permutations, then create the permutations
+  if (_dof_transformations_are_permutations)
+  {
+    for (std::size_t i = 0; i < _entity_transformations.size(); ++i)
+    {
+      std::vector<int> perm(_entity_transformations[i].shape(0));
+      std::vector<int> rev_perm(_entity_transformations[i].shape(0));
+      for (std::size_t row = 0; row < _entity_transformations[i].shape(0);
+           ++row)
+      {
+        for (std::size_t col = 0; col < _entity_transformations[i].shape(0);
+             ++col)
+        {
+          if (_entity_transformations[i](row, col) > 0.5)
           {
-            for (std::size_t i = 0; i < _entity_transformations.size(); ++i)
-            {
-              std::vector<int> perm(_entity_transformations[i].shape(0));
-              std::vector<int> rev_perm(_entity_transformations[i].shape(0));
-              for (std::size_t row = 0;
-                   row < _entity_transformations[i].shape(0); ++row)
-              {
-                for (std::size_t col = 0;
-                     col < _entity_transformations[i].shape(0); ++col)
-                {
-                  if (_entity_transformations[i](row, col) > 0.5)
-                  {
-                    perm[row] = col;
-                    rev_perm[col] = row;
-                    break;
-                  }
-                }
-              }
-              // Factorise the permutations
-              std::vector<int> f_perm(perm.size());
-              for (std::size_t row = 0; row < perm.size(); ++row)
-              {
-                std::size_t row2 = perm[row];
-                while (row2 < row)
-                  row2 = perm[row2];
-                f_perm[row] = row2;
-              }
-              _entity_permutations.push_back(f_perm);
-
-              std::vector<int> f_rev_perm(rev_perm.size());
-              for (std::size_t row = 0; row < rev_perm.size(); ++row)
-              {
-                std::size_t row2 = rev_perm[row];
-                while (row2 < row)
-                  row2 = rev_perm[row2];
-                f_rev_perm[row] = row2;
-              }
-              _reverse_entity_permutations.push_back(f_rev_perm);
-            }
+            perm[row] = col;
+            rev_perm[col] = row;
+            break;
           }
+        }
+      }
+      // Factorise the permutations
+      std::vector<int> f_perm(perm.size());
+      for (std::size_t row = 0; row < perm.size(); ++row)
+      {
+        std::size_t row2 = perm[row];
+        while (row2 < row)
+          row2 = perm[row2];
+        f_perm[row] = row2;
+      }
+      _entity_permutations.push_back(f_perm);
+
+      std::vector<int> f_rev_perm(rev_perm.size());
+      for (std::size_t row = 0; row < rev_perm.size(); ++row)
+      {
+        std::size_t row2 = rev_perm[row];
+        while (row2 < row)
+          row2 = rev_perm[row2];
+        f_rev_perm[row] = row2;
+      }
+      _reverse_entity_permutations.push_back(f_rev_perm);
+    }
+  }
 }
 //-----------------------------------------------------------------------------
 cell::type FiniteElement::cell_type() const { return _cell_type; }

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -46,7 +46,7 @@ constexpr int compute_value_size(maps::type map_type, int dim)
   }
 }
 //-----------------------------------------------------------------------------
-bool isClose(double a, double b) { return fabs(a - b) < 0.0001 }
+bool isClose(double a, double b) { return fabs(a - b) < 0.0001; }
 //-----------------------------------------------------------------------------
 int num_transformations(cell::type cell_type)
 {

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -46,8 +46,6 @@ constexpr int compute_value_size(maps::type map_type, int dim)
   }
 }
 //-----------------------------------------------------------------------------
-bool isClose(double a, double b) { return fabs(a - b) < 0.0001; }
-//-----------------------------------------------------------------------------
 int num_transformations(cell::type cell_type)
 {
   switch (cell_type)
@@ -358,15 +356,14 @@ FiniteElement::FiniteElement(
           = xt::amax(xt::view(_entity_transformations[i], row, xt::all()))(0);
       double rtot
           = xt::sum(xt::view(_entity_transformations[i], row, xt::all()))(0);
-      if ((_entity_transformations[i].shape(1) != 1 and !isClose(rmin, 0))
-          or !isClose(rmax, 1) or !isClose(rtot, 1))
+      if ((_entity_transformations[i].shape(1) != 1 and !xt::allclose(rmin, 0))
+          or !xt::allclose(rmax, 1) or !xt::allclose(rtot, 1))
       {
         _dof_transformations_are_permutations = false;
         _dof_transformations_are_identity = false;
         break;
       }
-      if (_entity_transformations[i](row, row) < 0.999
-          or _entity_transformations[i](row, row) > 1.001)
+      if (!xt::allclose(_entity_transformations[i](row, row), 1))
         _dof_transformations_are_identity = false;
     }
   }
@@ -618,7 +615,7 @@ xt::xtensor<double, 3> FiniteElement::map_pull_back(
   return U;
 }
 //-----------------------------------------------------------------------------
-void FiniteElement::permute_dofs(tcb::span<int>& dofs,
+void FiniteElement::permute_dofs(tcb::span<std::int32_t>& dofs,
                                  std::uint32_t cell_info) const
 {
   if (!_dof_transformations_are_permutations)
@@ -684,7 +681,7 @@ void FiniteElement::permute_dofs(tcb::span<int>& dofs,
   }
 }
 //-----------------------------------------------------------------------------
-void FiniteElement::unpermute_dofs(tcb::span<int>& dofs,
+void FiniteElement::unpermute_dofs(tcb::span<std::int32_t>& dofs,
                                    std::uint32_t cell_info) const
 {
   if (!_dof_transformations_are_permutations)

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -582,7 +582,7 @@ xt::xtensor<double, 3> FiniteElement::map_pull_back(
   return U;
 }
 //-----------------------------------------------------------------------------
-void FiniteElement::permute_dofs(tcb::span<int>& U,
+void FiniteElement::permute_dofs(tcb::span<int>& dofs,
                                  std::uint32_t cell_info) const
 {
   if (!_dof_transformations_are_permutations)
@@ -612,9 +612,9 @@ void FiniteElement::permute_dofs(tcb::span<int>& U,
         if (cell_info >> (face_start + e) & 1)
         {
           for (int i = 0; i < _entity_dofs[1][e]; ++i)
-            temp[i] = U[i];
+            temp[i] = dofs[i];
           for (int i = 0; i < _entity_dofs[1][e]; ++i)
-            U[i] = temp[_entity_permutations[0][i]];
+            dofs[i] = temp[_entity_permutations[0][i]];
         }
 
         dofstart += _entity_dofs[1][e];
@@ -634,18 +634,18 @@ void FiniteElement::permute_dofs(tcb::span<int>& U,
         for (std::uint32_t r = 0; r < (cell_info >> (3 * f + 1) & 3); ++r)
         {
           for (int i = 0; i < _entity_dofs[2][f]; ++i)
-            temp[i] = U[i];
+            temp[i] = dofs[i];
           for (int i = 0; i < _entity_dofs[2][f]; ++i)
-            U[i] = temp[_entity_permutations[1][i]];
+            dofs[i] = temp[_entity_permutations[1][i]];
         }
 
         // Reflect a face
         if (cell_info >> (3 * f) & 1)
         {
           for (int i = 0; i < _entity_dofs[2][f]; ++i)
-            temp[i] = U[i];
+            temp[i] = dofs[i];
           for (int i = 0; i < _entity_dofs[2][f]; ++i)
-            U[i] = temp[_entity_permutations[2][i]];
+            dofs[i] = temp[_entity_permutations[2][i]];
         }
 
         dofstart += _entity_dofs[2][f];
@@ -654,7 +654,7 @@ void FiniteElement::permute_dofs(tcb::span<int>& U,
   }
 }
 //-----------------------------------------------------------------------------
-void FiniteElement::unpermute_dofs(tcb::span<int>& U,
+void FiniteElement::unpermute_dofs(tcb::span<int>& dofs,
                                    std::uint32_t cell_info) const
 {
   if (!_dof_transformations_are_permutations)
@@ -684,9 +684,9 @@ void FiniteElement::unpermute_dofs(tcb::span<int>& U,
         if (cell_info >> (face_start + e) & 1)
         {
           for (int i = 0; i < _entity_dofs[1][e]; ++i)
-            temp[i] = U[i];
+            temp[i] = dofs[i];
           for (int i = 0; i < _entity_dofs[1][e]; ++i)
-            U[i] = temp[_entity_permutations[0][i]];
+            dofs[i] = temp[_entity_permutations[0][i]];
         }
         dofstart += _entity_dofs[1][e];
       }
@@ -705,18 +705,18 @@ void FiniteElement::unpermute_dofs(tcb::span<int>& U,
         if (cell_info >> (3 * f) & 1)
         {
           for (int i = 0; i < _entity_dofs[2][f]; ++i)
-            temp[i] = U[i];
+            temp[i] = dofs[i];
           for (int i = 0; i < _entity_dofs[2][f]; ++i)
-            U[i] = temp[_entity_permutations[2][i]];
+            dofs[i] = temp[_entity_permutations[2][i]];
         }
 
         // Rotate a face
         for (std::uint32_t r = 0; r < (cell_info >> (3 * f + 1) & 3); ++r)
         {
           for (int i = 0; i < _entity_dofs[2][f]; ++i)
-            temp[_entity_permutations[1][i]] = U[i];
+            temp[_entity_permutations[1][i]] = dofs[i];
           for (int i = 0; i < _entity_dofs[2][f]; ++i)
-            U[i] = temp[i];
+            dofs[i] = temp[i];
         }
 
         dofstart += _entity_dofs[2][f];

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -612,9 +612,9 @@ void FiniteElement::permute_dofs(tcb::span<int>& dofs,
         if (cell_info >> (face_start + e) & 1)
         {
           for (int i = 0; i < _entity_dofs[1][e]; ++i)
-            temp[i] = dofs[i];
+            temp[i] = dofs[dofstart + i];
           for (int i = 0; i < _entity_dofs[1][e]; ++i)
-            dofs[i] = temp[_entity_permutations[0][i]];
+            dofs[dofstart + i] = temp[_entity_permutations[0][i]];
         }
 
         dofstart += _entity_dofs[1][e];
@@ -630,22 +630,22 @@ void FiniteElement::permute_dofs(tcb::span<int>& dofs,
       // Permute DOFs on faces
       for (int f = 0; f < cell::sub_entity_count(_cell_type, 2); ++f)
       {
-        // Rotate a face
-        for (std::uint32_t r = 0; r < (cell_info >> (3 * f + 1) & 3); ++r)
-        {
-          for (int i = 0; i < _entity_dofs[2][f]; ++i)
-            temp[i] = dofs[i];
-          for (int i = 0; i < _entity_dofs[2][f]; ++i)
-            dofs[i] = temp[_entity_permutations[1][i]];
-        }
-
         // Reflect a face
         if (cell_info >> (3 * f) & 1)
         {
           for (int i = 0; i < _entity_dofs[2][f]; ++i)
-            temp[i] = dofs[i];
+            temp[i] = dofs[dofstart + i];
           for (int i = 0; i < _entity_dofs[2][f]; ++i)
-            dofs[i] = temp[_entity_permutations[2][i]];
+            dofs[dofstart + i] = temp[_entity_permutations[2][i]];
+        }
+
+        // Rotate a face
+        for (std::uint32_t r = 0; r < (cell_info >> (3 * f + 1) & 3); ++r)
+        {
+          for (int i = 0; i < _entity_dofs[2][f]; ++i)
+            temp[i] = dofs[dofstart + i];
+          for (int i = 0; i < _entity_dofs[2][f]; ++i)
+            dofs[dofstart + i] = temp[_entity_permutations[1][i]];
         }
 
         dofstart += _entity_dofs[2][f];
@@ -684,9 +684,9 @@ void FiniteElement::unpermute_dofs(tcb::span<int>& dofs,
         if (cell_info >> (face_start + e) & 1)
         {
           for (int i = 0; i < _entity_dofs[1][e]; ++i)
-            temp[i] = dofs[i];
+            temp[i] = dofs[dofstart + i];
           for (int i = 0; i < _entity_dofs[1][e]; ++i)
-            dofs[i] = temp[_entity_permutations[0][i]];
+            dofs[dofstart + i] = temp[_entity_permutations[0][i]];
         }
         dofstart += _entity_dofs[1][e];
       }
@@ -701,22 +701,22 @@ void FiniteElement::unpermute_dofs(tcb::span<int>& dofs,
       // Permute DOFs on faces
       for (int f = 0; f < cell::sub_entity_count(_cell_type, 2); ++f)
       {
-        // Reflect a face
-        if (cell_info >> (3 * f) & 1)
-        {
-          for (int i = 0; i < _entity_dofs[2][f]; ++i)
-            temp[i] = dofs[i];
-          for (int i = 0; i < _entity_dofs[2][f]; ++i)
-            dofs[i] = temp[_entity_permutations[2][i]];
-        }
-
         // Rotate a face
         for (std::uint32_t r = 0; r < (cell_info >> (3 * f + 1) & 3); ++r)
         {
           for (int i = 0; i < _entity_dofs[2][f]; ++i)
-            temp[_entity_permutations[1][i]] = dofs[i];
+            temp[_entity_permutations[1][i]] = dofs[dofstart + i];
           for (int i = 0; i < _entity_dofs[2][f]; ++i)
-            dofs[i] = temp[i];
+            dofs[dofstart + i] = temp[i];
+        }
+
+        // Reflect a face
+        if (cell_info >> (3 * f) & 1)
+        {
+          for (int i = 0; i < _entity_dofs[2][f]; ++i)
+            temp[i] = dofs[dofstart + i];
+          for (int i = 0; i < _entity_dofs[2][f]; ++i)
+            dofs[dofstart + i] = temp[_entity_permutations[2][i]];
         }
 
         dofstart += _entity_dofs[2][f];

--- a/cpp/basix/finite-element.h
+++ b/cpp/basix/finite-element.h
@@ -516,9 +516,13 @@ private:
   /// Indicates whether or not the DOF transformations are all identity
   bool _dof_transformations_are_identity;
 
-  /// The base permutations. This will only be set if
+  /// The entity permutations (factorised). This will only be set if
   /// _dof_transformations_are_permutations is True
   std::vector<std::vector<int>> _entity_permutations;
+
+  /// The reverse entity permutations (factorised). This will only be set if
+  /// _dof_transformations_are_permutations is True
+  std::vector<std::vector<int>> _reverse_entity_permutations;
 };
 
 /// Create an element by name

--- a/cpp/basix/finite-element.h
+++ b/cpp/basix/finite-element.h
@@ -284,6 +284,14 @@ public:
   /// @return The mapping
   maps::type mapping_type() const;
 
+  /// Indicates whether the dof transformations are all permutations
+  /// @return True or False
+  bool dof_transformations_are_permutations() const;
+
+  /// Indicates whether the dof transformations are all the identity
+  /// @return True or False
+  bool dof_transformations_are_identity() const;
+
   /// Map function values from the reference to a physical cell
   /// @param U The function values on the reference
   /// @param J The Jacobian of the mapping
@@ -421,6 +429,16 @@ public:
   /// ~~~~~~~~~~~~~~~~
   xt::xtensor<double, 3> base_transformations() const;
 
+  /// Permute the dof numbering on a cell
+  /// @param[in/out] dofs The dof numbering for the cell
+  /// @param cell_perm The permutation info for the cell
+  void permute_dofs(std::vector<int>& U, std::uint32_t cell_perm) const;
+
+  /// Unpermute the dof numbering on a cell
+  /// @param[in/out] dofs The dof numbering for the cell
+  /// @param cell_perm The permutation info for the cell
+  void unpermute_dofs(std::vector<int>& U, std::uint32_t cell_perm) const;
+
   /// Return the interpolation points, i.e. the coordinates on the
   /// reference element where a function need to be evaluated in order
   /// to interpolate it in the finite element space.
@@ -491,6 +509,16 @@ private:
 
   /// Interpolation matrices
   std::array<std::vector<xt::xtensor<double, 3>>, 4> _matM_new;
+
+  /// Indicates whether or not the DOF transformations are all permutations
+  bool _dof_transformations_are_permutations;
+
+  /// Indicates whether or not the DOF transformations are all identity
+  bool _dof_transformations_are_identity;
+
+  /// The base permutations. This will only be set if
+  /// _dof_transformations_are_permutations is True
+  std::vector<std::vector<int>> _entity_permutations;
 };
 
 /// Create an element by name

--- a/cpp/basix/finite-element.h
+++ b/cpp/basix/finite-element.h
@@ -432,12 +432,12 @@ public:
   /// Permute the dof numbering on a cell
   /// @param[in,out] dofs The dof numbering for the cell
   /// @param cell_info The permutation info for the cell
-  void permute_dofs(tcb::span<int>& U, std::uint32_t cell_info) const;
+  void permute_dofs(tcb::span<int>& dofs, std::uint32_t cell_info) const;
 
   /// Unpermute the dof numbering on a cell
   /// @param[in,out] dofs The dof numbering for the cell
   /// @param cell_info The permutation info for the cell
-  void unpermute_dofs(tcb::span<int>& U, std::uint32_t cell_info) const;
+  void unpermute_dofs(tcb::span<int>& dofs, std::uint32_t cell_info) const;
 
   /// Return the interpolation points, i.e. the coordinates on the
   /// reference element where a function need to be evaluated in order

--- a/cpp/basix/finite-element.h
+++ b/cpp/basix/finite-element.h
@@ -432,12 +432,14 @@ public:
   /// Permute the dof numbering on a cell
   /// @param[in,out] dofs The dof numbering for the cell
   /// @param cell_info The permutation info for the cell
-  void permute_dofs(tcb::span<int>& dofs, std::uint32_t cell_info) const;
+  void permute_dofs(tcb::span<std::int32_t>& dofs,
+                    std::uint32_t cell_info) const;
 
   /// Unpermute the dof numbering on a cell
   /// @param[in,out] dofs The dof numbering for the cell
   /// @param cell_info The permutation info for the cell
-  void unpermute_dofs(tcb::span<int>& dofs, std::uint32_t cell_info) const;
+  void unpermute_dofs(tcb::span<std::int32_t>& dofs,
+                      std::uint32_t cell_info) const;
 
   /// Return the interpolation points, i.e. the coordinates on the
   /// reference element where a function need to be evaluated in order

--- a/cpp/basix/finite-element.h
+++ b/cpp/basix/finite-element.h
@@ -430,12 +430,12 @@ public:
   xt::xtensor<double, 3> base_transformations() const;
 
   /// Permute the dof numbering on a cell
-  /// @param[in/out] dofs The dof numbering for the cell
+  /// @param[in,out] dofs The dof numbering for the cell
   /// @param cell_info The permutation info for the cell
   void permute_dofs(tcb::span<int>& U, std::uint32_t cell_info) const;
 
   /// Unpermute the dof numbering on a cell
-  /// @param[in/out] dofs The dof numbering for the cell
+  /// @param[in,out] dofs The dof numbering for the cell
   /// @param cell_info The permutation info for the cell
   void unpermute_dofs(tcb::span<int>& U, std::uint32_t cell_info) const;
 

--- a/cpp/basix/finite-element.h
+++ b/cpp/basix/finite-element.h
@@ -431,13 +431,13 @@ public:
 
   /// Permute the dof numbering on a cell
   /// @param[in/out] dofs The dof numbering for the cell
-  /// @param cell_perm The permutation info for the cell
-  void permute_dofs(std::vector<int>& U, std::uint32_t cell_perm) const;
+  /// @param cell_info The permutation info for the cell
+  void permute_dofs(tcb::span<int>& U, std::uint32_t cell_info) const;
 
   /// Unpermute the dof numbering on a cell
   /// @param[in/out] dofs The dof numbering for the cell
-  /// @param cell_perm The permutation info for the cell
-  void unpermute_dofs(std::vector<int>& U, std::uint32_t cell_perm) const;
+  /// @param cell_info The permutation info for the cell
+  void unpermute_dofs(tcb::span<int>& U, std::uint32_t cell_info) const;
 
   /// Return the interpolation points, i.e. the coordinates on the
   /// reference element where a function need to be evaluated in order

--- a/cpp/basix/finite-element.h
+++ b/cpp/basix/finite-element.h
@@ -463,6 +463,9 @@ private:
   // Cell type
   cell::type _cell_type;
 
+  // Topological dimension of the cell
+  std::size_t _cell_tdim;
+
   // Finite element family
   element::family _family;
 
@@ -481,6 +484,9 @@ private:
   // _coeffs.row(i) are the expansion coefficients for shape function i
   // (@f$\psi_{i}@f$).
   xt::xtensor<double, 2> _coeffs;
+
+  // Number of cell subentities of each dimension
+  std::vector<int> _cell_sub_entity_count;
 
   // Number of dofs associated each subentity
   //

--- a/python/wrapper.cpp
+++ b/python/wrapper.cpp
@@ -291,6 +291,11 @@ Each element has a `tabulate` function which returns the basis functions and a n
       .def_property_readonly("value_size", &FiniteElement::value_size)
       .def_property_readonly("value_shape", &FiniteElement::value_shape)
       .def_property_readonly("family", &FiniteElement::family)
+      .def_property_readonly(
+          "dof_transformations_are_permutations",
+          &FiniteElement::dof_transformations_are_permutations)
+      .def_property_readonly("dof_transformations_are_identity",
+                             &FiniteElement::dof_transformations_are_identity)
       .def_property_readonly("mapping_type", &FiniteElement::mapping_type)
       .def_property_readonly("points",
                              [](const FiniteElement& self) {

--- a/test/test_dof_transformations.py
+++ b/test/test_dof_transformations.py
@@ -8,6 +8,30 @@ import numpy as np
 from .utils import parametrize_over_elements
 
 
+@parametrize_over_elements(3)
+def test_if_permutations(cell_name, element_name, order):
+    e = basix.create_element(element_name, cell_name, order)
+
+    for t in e.base_transformations():
+        for row in t:
+            a = np.argmax(row)
+            if not np.isclose(row[a], 1) or not np.allclose(row[:a], 0) or not np.allclose(row[a + 1:], 0):
+                assert not e.dof_transformations_are_permutations
+                return
+    assert e.dof_transformations_are_permutations
+
+
+@parametrize_over_elements(3)
+def test_if_identity(cell_name, element_name, order):
+    e = basix.create_element(element_name, cell_name, order)
+
+    for t in e.base_transformations():
+        if not np.allclose(t, np.eye(t.shape[0])):
+            assert not e.dof_transformations_are_identity
+            return
+    assert e.dof_transformations_are_identity
+
+
 @parametrize_over_elements(5)
 def test_non_zero(cell_name, element_name, order):
     e = basix.create_element(element_name, cell_name, order)


### PR DESCRIPTION
Added permute_dofs and unpermute_dofs functions to Basix, so these can be removed from the generated code.

Progress towards #100.

This PR is coupled with FEniCS/ffcx#325 and FEniCS/dolfinx#1471.