### PR TITLE
Performance speedup of numba transformations

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -44,6 +44,7 @@ jobs:
         run: |
           pip install flake8
           flake8 --statistics test/
+          flake8 --statistics python/
 
       - name: Install Basix C++
         run: |

--- a/python/basix/__init__.py
+++ b/python/basix/__init__.py
@@ -9,4 +9,3 @@ from ._basixcpp import (create_element, CellType, mapping_to_str, family_to_str,
 from ._basixcpp import (topology, geometry, tabulate_polynomial_set,
                         create_lattice, LatticeType, index,
                         make_quadrature, compute_jacobi_deriv)
-

--- a/python/basix/numba_helpers.py
+++ b/python/basix/numba_helpers.py
@@ -1,5 +1,6 @@
 try:
     import numba
+    import numpy
 except ImportError:
     raise RuntimeError("You must have numba installed to use the numba helper functions.")
 
@@ -41,10 +42,10 @@ def apply_dof_transformation(tdim, edge_count, face_count, entity_transformation
         edge_reflection = entity_transformations[0].copy()
         for e in range(edge_count):
             edofs = entity_dofs[1][e]
+            if edofs == 0:
+                continue
             if cell_info >> (face_start + e) & 1:
-                for b in range(block_size):
-                    s = (dofstart * block_size + b, (dofstart + edofs) * block_size, block_size)
-                    data[slice(*s)] = edge_reflection.dot(data[slice(*s)].copy())
+                data[ dofstart:dofstart+edofs] = numpy.dot(edge_reflection, data[dofstart:dofstart+edofs])
             dofstart += edofs
 
         if tdim == 3:
@@ -52,14 +53,12 @@ def apply_dof_transformation(tdim, edge_count, face_count, entity_transformation
             face_reflection = entity_transformations[2].copy()
             for f in range(face_count):
                 fdofs = entity_dofs[2][f]
+                if fdofs == 0:
+                    continue
                 if cell_info >> (3 * f) & 1:
-                    for b in range(block_size):
-                        s = (dofstart * block_size + b, (dofstart + fdofs) * block_size, block_size)
-                        data[slice(*s)] = face_reflection.dot(data[slice(*s)].copy())
+                    data[dofstart:dofstart+fdofs] = numpy.dot(face_reflection, data[dofstart:dofstart+fdofs])
                 for _ in range(cell_info >> (3 * f + 1) & 3):
-                    for b in range(block_size):
-                        s = (dofstart * block_size + b, (dofstart + fdofs) * block_size, block_size)
-                        data[slice(*s)] = face_rotation.dot(data[slice(*s)].copy())
+                    data[dofstart:dofstart+fdofs] = numpy.dot(face_rotation, data[dofstart:dofstart+fdofs])
                 dofstart += fdofs
 
 

--- a/python/basix/numba_helpers.py
+++ b/python/basix/numba_helpers.py
@@ -45,7 +45,7 @@ def apply_dof_transformation(tdim, edge_count, face_count, entity_transformation
             if edofs == 0:
                 continue
             if cell_info >> (face_start + e) & 1:
-                data[ dofstart:dofstart+edofs] = numpy.dot(edge_reflection, data[dofstart:dofstart+edofs])
+                data[dofstart:dofstart+edofs] = numpy.dot(edge_reflection, data[dofstart:dofstart+edofs])
             dofstart += edofs
 
         if tdim == 3:

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,9 +1,6 @@
 import os
-import platform
-import re
 import subprocess
 import sys
-from distutils.version import LooseVersion
 
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
@@ -39,7 +36,7 @@ class CMakeExtension(Extension):
 class CMakeBuild(build_ext):
     def run(self):
         try:
-            out = subprocess.check_output(['cmake', '--version'])
+            subprocess.check_output(['cmake', '--version'])
         except OSError:
             raise RuntimeError("CMake must be installed to build the following extensions: "
                                + ", ".join(e.name for e in self.extensions))

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,5 @@
 [flake8]
 max-line-length = 120
 ignore = W503, E226, E241
+per-file-ignores =
+    */__init__.py: F401

--- a/test/test_numba.py
+++ b/test/test_numba.py
@@ -32,9 +32,8 @@ def test_dof_transformations(cell, element, degree, block_size):
 
         data1 = data.copy()
         data1 = e.apply_dof_transformation(data1, block_size, cell_info)
-
-        data2 = data.copy()
-
+        # Numba function does not use blocked data
+        data2 = data.copy().reshape(e.dim, block_size)
         # Mapping lists to numba dictionaries
         entity_transformations = Dict.empty(key_type=types.int64, value_type=types.float64[:, :])
         for i, transformation in enumerate(e.entity_transformations()):
@@ -44,5 +43,6 @@ def test_dof_transformations(cell, element, degree, block_size):
         for i, e_dofs in enumerate(e.entity_dofs):
             entity_dofs[i] = np.asarray(e_dofs, dtype=np.int32)
         transform_functions[cell](entity_transformations, entity_dofs, data2, block_size, cell_info)
-
+        # Reshape numba output for comparison
+        data2 = data2.reshape(-1)
         assert np.allclose(data1, data2)


### PR DESCRIPTION
The data yielded from basix.tabulate is a 4 dimensional matrix and  is commonly reduced to a 2D structure.

Using slicing is a very expensive operation, and numba can use the numpy dot products to improve performance of these operations. 

In our custom assembler code, this reduced the total assembly runtime of about 50 %.