### PR TITLE
Remove Intel 'Classic' compiler from CI

### DIFF
--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -18,9 +18,6 @@ jobs:
     strategy:
       matrix:
         include:
-          # - compiler: "Classic"
-          #   c_compiler: icc
-          #   cxx_compiler: icpc
           - compiler: "LLVM-based"
             c_compiler: icx
             cxx_compiler: icpx

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build and test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     defaults:
       run:
@@ -18,12 +18,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: "Classic"
-            c_compiler: icc
-            cxx_compiler: icpc
+          # - compiler: "Classic"
+          #   c_compiler: icc
+          #   cxx_compiler: icpc
           - compiler: "LLVM-based"
             c_compiler: icx
-            cxx_compiler: icpx    
+            cxx_compiler: icpx
 
     env:
       CC: ${{ matrix.c_compiler }}
@@ -33,19 +33,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      
+
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
-      
-      - name: Install pybind11
-        run: |
-          pip install pybind11
-      
-      - name: Install dependencies (non-Python, Linux)
-        run: |
-          sudo apt-get install -y ninja-build
 
       - name: Install Intel compilers
         run: |
@@ -53,21 +45,13 @@ jobs:
           sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
           echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
           sudo apt update
-          sudo apt install -y intel-oneapi-common-vars intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
-      
-      - name: Install Basix C++
+          sudo apt install -y intel-oneapi-common-vars intel-oneapi-compiler-dpcpp-cpp
+
+      - name: Install Basix
         run: |
           . /opt/intel/oneapi/setvars.sh
-          cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build-dir -S .
-          cmake --build build-dir
-          sudo cmake --install build-dir
-      
-      - name: Build Basix Python
-        run: |
-          . /opt/intel/oneapi/setvars.sh
-          cd python
           pip install .
-      
+
       - name: Run units tests
         run: |
           . /opt/intel/oneapi/setvars.sh


### PR DESCRIPTION
No longer actively supported for FEniCS.