### PR TITLE
Add Issac's GLL points on triangle and tetrahedron

### DIFF
--- a/cpp/basix/lattice.cpp
+++ b/cpp/basix/lattice.cpp
@@ -71,7 +71,9 @@ xt::xtensor<double, 1> create_interval(int n, lattice::type lattice_type,
     x = xt::linspace<double>(h, 1.0 - h, n - 1);
   }
 
-  if (x.shape(0) > 0 and lattice_type == lattice::type::gll)
+  if (x.shape(0) > 0
+      and (lattice_type == lattice::type::gll
+           or lattice_type == lattice::type::gll_isaac))
     x += warp_function(n, x);
 
   return x;
@@ -148,16 +150,37 @@ xt::xtensor<double, 2> create_hex(int n, lattice::type lattice_type,
   return x;
 }
 //-----------------------------------------------------------------------------
-xt::xtensor<double, 2> create_tri(int n, lattice::type lattice_type,
-                                  bool exterior)
+xt::xtensor<double, 2> create_tri_equispaced(int n, bool exterior)
 {
-  if (n == 0)
-    return {{1.0 / 3.0, 1.0 / 3.0}};
+  const std::size_t b = exterior ? 0 : 1;
 
+  // Points
+  xt::xtensor<double, 2> p({(n - 3 * b + 1) * (n - 3 * b + 2) / 2, 2});
+
+  // Displacement from GLL points in 1D, scaled by 1 /(r * (1 - r))
+  xt::xtensor<double, 1> r = xt::linspace<double>(0.0, 1.0, 2 * n + 1);
+
+  int c = 0;
+  for (std::size_t j = b; j < (n - b + 1); ++j)
+  {
+    for (std::size_t i = b; i < (n - b + 1 - j); ++i)
+    {
+      p(c, 0) = r[2 * i];
+      p(c, 1) = r[2 * j];
+      ++c;
+    }
+  }
+  return p;
+}
+//-----------------------------------------------------------------------------
+xt::xtensor<double, 2> create_tri_gll_warped(int n, bool exterior)
+{
   // Warp points: see Hesthaven and Warburton, Nodal Discontinuous
   // Galerkin Methods, pp. 175-180
-
   const std::size_t b = exterior ? 0 : 1;
+
+  // Points
+  xt::xtensor<double, 2> p({(n - 3 * b + 1) * (n - 3 * b + 2) / 2, 2});
 
   // Displacement from GLL points in 1D, scaled by 1 /(r * (1 - r))
   xt::xtensor<double, 1> r = xt::linspace<double>(0.0, 1.0, 2 * n + 1);
@@ -165,8 +188,6 @@ xt::xtensor<double, 2> create_tri(int n, lattice::type lattice_type,
   auto s = xt::view(r, xt::range(1, 2 * n - 1));
   xt::view(wbar, xt::range(1, 2 * n - 1)) /= (s * (1 - s));
 
-  // Points
-  xt::xtensor<double, 2> p({(n - 3 * b + 1) * (n - 3 * b + 2) / 2, 2});
   int c = 0;
   for (std::size_t j = b; j < (n - b + 1); ++j)
   {
@@ -176,26 +197,133 @@ xt::xtensor<double, 2> create_tri(int n, lattice::type lattice_type,
       const double y = r[2 * j];
       p(c, 0) = x;
       p(c, 1) = y;
-      if (lattice_type == lattice::type::gll)
-      {
-        const std::size_t l = n - j - i;
-        const double a = r[2 * l];
-        p(c, 0) += x * (a * wbar(n + i - l) + y * wbar(n + i - j));
-        p(c, 1) += y * (a * wbar(n + j - l) + x * wbar(n + j - i));
-      }
+      const std::size_t l = n - j - i;
+      const double a = r[2 * l];
+      p(c, 0) += x * (a * wbar(n + i - l) + y * wbar(n + i - j));
+      p(c, 1) += y * (a * wbar(n + j - l) + x * wbar(n + j - i));
       ++c;
+    }
+    }
+    return p;
+}
+//-----------------------------------------------------------------------------
+xt::xtensor<double, 1> isaac_point(xt::xtensor<std::size_t, 1> a)
+{
+  if (a.shape(0) == 1)
+    return {1};
+  xt::xtensor<double, 1> res = xt::zeros<double>(a.shape());
+  double denominator = 0;
+  xt::xtensor<std::size_t, 1> sub_a
+      = xt::view(a, xt::range(1, xt::placeholders::_));
+  const std::size_t size = xt::sum(a)();
+  xt::xtensor<double, 1> x = create_interval(size, lattice::type::gll, true);
+  for (std::size_t i = 0; i < a.shape(0); ++i)
+  {
+    if (i > 0)
+      sub_a(i - 1) = a(i - 1);
+    const std::size_t sub_size = size - a(i);
+    const xt::xtensor<double, 1> sub_res = isaac_point(sub_a);
+    for (std::size_t j = 0; j < sub_res.shape(0); ++j)
+      res[j < i ? j : j + 1] += x[sub_size] * sub_res[j];
+    denominator += x[sub_size];
+  }
+  for (std::size_t i = 0; i < res.shape(0); ++i)
+    res[i] /= denominator;
+  return res;
+}
+//-----------------------------------------------------------------------------
+xt::xtensor<double, 2> create_tri_isaac(int n, bool exterior)
+{
+  // See http://dx.doi.org/10.1137/20M1321802
+  const std::size_t b = exterior ? 0 : 1;
+
+  // Points
+  xt::xtensor<double, 2> p({(n - 3 * b + 1) * (n - 3 * b + 2) / 2, 2});
+
+  int c = 0;
+  for (std::size_t j = b; j < (n - b + 1); ++j)
+  {
+    for (std::size_t i = b; i < (n - b + 1 - j); ++i)
+    {
+      xt::view(p, c, xt::all())
+          = xt::view(isaac_point({i, j, n - i - j}), xt::range(0, 2));
+      ++c;
+    }
+  }
+  return p;
+}
+//-----------------------------------------------------------------------------
+xt::xtensor<double, 2> create_tri(int n, lattice::type lattice_type,
+                                  bool exterior)
+{
+  if (n == 0)
+    return {{1.0 / 3.0, 1.0 / 3.0}};
+
+  switch (lattice_type)
+  {
+  case lattice::type::equispaced:
+    return create_tri_equispaced(n, exterior);
+  case lattice::type::gll:
+    return create_tri_gll_warped(n, exterior);
+  case lattice::type::gll_isaac:
+    return create_tri_isaac(n, exterior);
+  default:
+    throw std::runtime_error("Unrecognised lattice type.");
+  }
+}
+//-----------------------------------------------------------------------------
+xt::xtensor<double, 2> create_tet_equispaced(int n, bool exterior)
+{
+  const std::size_t b = exterior ? 0 : 1;
+  xt::xtensor<double, 2> p(
+      {(n - 4 * b + 1) * (n - 4 * b + 2) * (n - 4 * b + 3) / 6, 3});
+  auto r = xt::linspace<double>(0.0, 1.0, 2 * n + 1);
+
+  std::size_t c = 0;
+  for (std::size_t k = b; k < (n - b + 1); ++k)
+  {
+    for (std::size_t j = b; j < (n - b + 1 - k); ++j)
+    {
+      for (std::size_t i = b; i < (n - b + 1 - j - k); ++i)
+      {
+        p(c, 0) = r[2 * i];
+        p(c, 1) = r[2 * j];
+        p(c, 2) = r[2 * k];
+        ++c;
+      }
     }
   }
 
   return p;
 }
 //-----------------------------------------------------------------------------
-xt::xtensor<double, 2> create_tet(int n, lattice::type lattice_type,
-                                  bool exterior)
+xt::xtensor<double, 2> create_tet_isaac(int n, bool exterior)
 {
-  if (n == 0)
-    return {{0.25, 0.25, 0.25}};
+  // See http://dx.doi.org/10.1137/20M1321802
+  const std::size_t b = exterior ? 0 : 1;
 
+  // Points
+  xt::xtensor<double, 2> p(
+      {(n - 4 * b + 1) * (n - 4 * b + 2) * (n - 4 * b + 3) / 6, 3});
+
+  int c = 0;
+  for (std::size_t k = b; k < (n - b + 1); ++k)
+  {
+    for (std::size_t j = b; j < (n - b + 1 - k); ++j)
+    {
+      for (std::size_t i = b; i < (n - b + 1 - j - k); ++i)
+      {
+        xt::view(p, c, xt::all())
+            = xt::view(isaac_point({i, j, k, n - i - j - k}), xt::range(0, 3));
+        ++c;
+      }
+    }
+  }
+  return p;
+}
+//-----------------------------------------------------------------------------
+xt::xtensor<double, 2> create_tet_gll_warped(int n, bool exterior)
+{
   const std::size_t b = exterior ? 0 : 1;
   xt::xtensor<double, 2> p(
       {(n - 4 * b + 1) * (n - 4 * b + 2) * (n - 4 * b + 3) / 6, 3});
@@ -219,21 +347,18 @@ xt::xtensor<double, 2> create_tet(int n, lattice::type lattice_type,
         p(c, 0) = x;
         p(c, 1) = y;
         p(c, 2) = z;
-        if (lattice_type == lattice::type::gll)
-        {
-          const double dx = x
-                            * (a * wbar(n + i - l) + y * wbar(n + i - j)
-                               + z * wbar(n + i - k));
-          const double dy = y
-                            * (a * wbar(n + j - l) + z * wbar(n + j - k)
-                               + x * wbar(n + j - i));
-          const double dz = z
-                            * (a * wbar(n + k - l) + x * wbar(n + k - i)
-                               + y * wbar(n + k - j));
-          p(c, 0) += dx;
-          p(c, 1) += dy;
-          p(c, 2) += dz;
-        }
+        const double dx = x
+                          * (a * wbar(n + i - l) + y * wbar(n + i - j)
+                             + z * wbar(n + i - k));
+        const double dy = y
+                          * (a * wbar(n + j - l) + z * wbar(n + j - k)
+                             + x * wbar(n + j - i));
+        const double dz = z
+                          * (a * wbar(n + k - l) + x * wbar(n + k - i)
+                             + y * wbar(n + k - j));
+        p(c, 0) += dx;
+        p(c, 1) += dy;
+        p(c, 2) += dz;
 
         ++c;
       }
@@ -241,6 +366,25 @@ xt::xtensor<double, 2> create_tet(int n, lattice::type lattice_type,
   }
 
   return p;
+}
+//-----------------------------------------------------------------------------
+xt::xtensor<double, 2> create_tet(int n, lattice::type lattice_type,
+                                  bool exterior)
+{
+  if (n == 0)
+    return {{0.25, 0.25, 0.25}};
+
+  switch (lattice_type)
+  {
+  case lattice::type::equispaced:
+    return create_tet_equispaced(n, exterior);
+  case lattice::type::gll:
+    return create_tet_gll_warped(n, exterior);
+  case lattice::type::gll_isaac:
+    return create_tet_isaac(n, exterior);
+  default:
+    throw std::runtime_error("Unrecognised lattice type.");
+  }
 }
 //-----------------------------------------------------------------------------
 xt::xtensor<double, 2> create_prism(int n, lattice::type lattice_type,
@@ -440,7 +584,8 @@ lattice::type lattice::str_to_type(std::string name)
 {
   static const std::map<std::string, lattice::type> name_to_type
       = {{"equispaced", lattice::type::equispaced},
-         {"gll", lattice::type::gll}};
+         {"gll", lattice::type::gll},
+         {"gll_isaac", lattice::type::gll_isaac}};
 
   auto it = name_to_type.find(name);
   if (it == name_to_type.end())
@@ -453,7 +598,8 @@ std::string lattice::type_to_str(lattice::type type)
 {
   static const std::map<lattice::type, std::string> name_to_type
       = {{lattice::type::equispaced, "equispaced"},
-         {lattice::type::gll, "gll"}};
+         {lattice::type::gll, "gll"},
+         {lattice::type::gll_isaac, "gll_isaac"}};
 
   auto it = name_to_type.find(type);
   if (it == name_to_type.end())

--- a/cpp/basix/lattice.cpp
+++ b/cpp/basix/lattice.cpp
@@ -96,7 +96,7 @@ xt::xtensor<double, 1> create_interval(int n, lattice::type lattice_type,
     return create_interval_equispaced(n, exterior);
   case lattice::type::gll_warped:
     return create_interval_gll(n, exterior);
-  case lattice::type::gll:
+  case lattice::type::gll_isaac:
     return create_interval_gll(n, exterior);
   default:
     throw std::runtime_error("Unrecognised lattice type.");
@@ -221,7 +221,8 @@ xt::xtensor<double, 1> isaac_point(xt::xtensor<std::size_t, 1> a)
   xt::xtensor<std::size_t, 1> sub_a
       = xt::view(a, xt::range(1, xt::placeholders::_));
   const std::size_t size = xt::sum(a)();
-  xt::xtensor<double, 1> x = create_interval(size, lattice::type::gll, true);
+  xt::xtensor<double, 1> x
+      = create_interval(size, lattice::type::gll_warped, true);
   for (std::size_t i = 0; i < a.shape(0); ++i)
   {
     if (i > 0)
@@ -270,7 +271,7 @@ xt::xtensor<double, 2> create_tri(int n, lattice::type lattice_type,
     return create_tri_equispaced(n, exterior);
   case lattice::type::gll_warped:
     return create_tri_gll_warped(n, exterior);
-  case lattice::type::gll:
+  case lattice::type::gll_isaac:
     return create_tri_gll_isaac(n, exterior);
   default:
     throw std::runtime_error("Unrecognised lattice type.");
@@ -385,7 +386,7 @@ xt::xtensor<double, 2> create_tet(int n, lattice::type lattice_type,
     return create_tet_equispaced(n, exterior);
   case lattice::type::gll_warped:
     return create_tet_gll_warped(n, exterior);
-  case lattice::type::gll:
+  case lattice::type::gll_isaac:
     return create_tet_gll_isaac(n, exterior);
   default:
     throw std::runtime_error("Unrecognised lattice type.");
@@ -585,7 +586,7 @@ xt::xtensor<double, 2> create_pyramid(int n, lattice::type lattice_type,
     return create_pyramid_equispaced(n, exterior);
   case lattice::type::gll_warped:
     return create_pyramid_gll_warped(n, exterior);
-  case lattice::type::gll:
+  case lattice::type::gll_isaac:
     throw std::runtime_error("GLL points compatible with Isaac's GLL points on "
                              "a triangle not implemented yet.");
   default:
@@ -628,7 +629,7 @@ lattice::type lattice::str_to_type(std::string name)
 {
   static const std::map<std::string, lattice::type> name_to_type
       = {{"equispaced", lattice::type::equispaced},
-         {"gll", lattice::type::gll},
+         {"gll_isaac", lattice::type::gll_isaac},
          {"gll_warped", lattice::type::gll_warped}};
 
   auto it = name_to_type.find(name);
@@ -642,7 +643,7 @@ std::string lattice::type_to_str(lattice::type type)
 {
   static const std::map<lattice::type, std::string> name_to_type
       = {{lattice::type::equispaced, "equispaced"},
-         {lattice::type::gll, "gll"},
+         {lattice::type::gll_isaac, "gll_isaac"},
          {lattice::type::gll_warped, "gll_warped"}};
 
   auto it = name_to_type.find(type);

--- a/cpp/basix/lattice.h
+++ b/cpp/basix/lattice.h
@@ -21,7 +21,8 @@ namespace basix::lattice
 enum class type
 {
   equispaced = 0,
-  gll = 1
+  gll = 1,
+  gll_isaac = 2,
 };
 
 /// Convert string to a lattice type

--- a/cpp/basix/lattice.h
+++ b/cpp/basix/lattice.h
@@ -11,18 +11,27 @@
 namespace basix::lattice
 {
 /// The type of point spacing to be used in a lattice.
+///
 /// lattice::type::equispaced represents equally spaced points
 /// on an interval and a regularly spaced set of points on other
-/// shapes. lattice::type:gll represents the GLL (Gauss-Lobatto-Legendre)
+/// shapes.
+///
+/// lattice::type:gll_warped represents the GLL (Gauss-Lobatto-Legendre)
 /// points on an interval. Fot other shapes, the points used are obtained
 /// by warping an equispaced grid of points, as described in Hesthaven and
 /// Warburton, Nodal Discontinuous Galerkin Methods, 2008, pp 175-180
 /// (https://doi.org/10.1007/978-0-387-72067-8).
+///
+/// lattice::type:gll_isaac represents the GLL (Gauss-Lobatto-Legendre)
+/// points on an interval. Fot other shapes, the points used are obtained
+/// following the methd described in Isaac, Recursive, Parameter-Free,
+/// Explicitly Defined Interpolation Nodes for Simplices, 2020
+/// (https://doi.org/10.1137/20M1321802).
 enum class type
 {
   equispaced = 0,
-  gll = 1,
-  gll_warped = 2,
+  gll_warped = 1,
+  gll_isaac = 2,
 };
 
 /// Convert string to a lattice type
@@ -47,7 +56,7 @@ std::string type_to_str(lattice::type type);
 /// @param celltype The cell::type
 /// @param n Size in each direction. There are n+1 points along each edge of the
 /// cell.
-/// @param type Either lattice::type::equispaced or lattice::type::gll
+/// @param type A lattice type
 /// @param exterior If set, includes outer boundaries
 /// @return Set of points
 xt::xtensor<double, 2> create(cell::type celltype, int n, lattice::type type,

--- a/cpp/basix/lattice.h
+++ b/cpp/basix/lattice.h
@@ -22,7 +22,7 @@ enum class type
 {
   equispaced = 0,
   gll = 1,
-  gll_isaac = 2,
+  gll_warped = 2,
 };
 
 /// Convert string to a lattice type

--- a/python/basix/lattice.py
+++ b/python/basix/lattice.py
@@ -5,6 +5,9 @@ from ._basixcpp import LatticeType as _LT
 
 def string_to_type(lattice: str):
     """Convert a string to a Basix LatticeType enum."""
+    if lattice == "gll":
+        return _LT.gll_warped
+
     if not hasattr(_LT, lattice):
         raise ValueError(f"Unknown lattice: {lattice}")
     return getattr(_LT, lattice)

--- a/python/wrapper.cpp
+++ b/python/wrapper.cpp
@@ -130,8 +130,8 @@ Interface to the Basix C++ library.
 
   py::enum_<lattice::type>(m, "LatticeType")
       .value("equispaced", lattice::type::equispaced)
-      .value("gll", lattice::type::gll)
-      .value("gll_warped", lattice::type::gll_warped);
+      .value("gll_warped", lattice::type::gll_warped)
+      .value("gll_isaac", lattice::type::gll_isaac);
 
   m.def(
       "create_lattice",

--- a/python/wrapper.cpp
+++ b/python/wrapper.cpp
@@ -130,7 +130,8 @@ Interface to the Basix C++ library.
 
   py::enum_<lattice::type>(m, "LatticeType")
       .value("equispaced", lattice::type::equispaced)
-      .value("gll", lattice::type::gll);
+      .value("gll", lattice::type::gll)
+      .value("gll_isaac", lattice::type::gll_isaac);
 
   m.def(
       "create_lattice",

--- a/python/wrapper.cpp
+++ b/python/wrapper.cpp
@@ -131,7 +131,7 @@ Interface to the Basix C++ library.
   py::enum_<lattice::type>(m, "LatticeType")
       .value("equispaced", lattice::type::equispaced)
       .value("gll", lattice::type::gll)
-      .value("gll_isaac", lattice::type::gll_isaac);
+      .value("gll_warped", lattice::type::gll_warped);
 
   m.def(
       "create_lattice",

--- a/test/test_interpolation.py
+++ b/test/test_interpolation.py
@@ -12,7 +12,7 @@ from .utils import parametrize_over_elements
 @pytest.mark.parametrize("cell_type", [basix.CellType.interval, basix.CellType.triangle, basix.CellType.tetrahedron])
 @pytest.mark.parametrize("element_type", [basix.ElementFamily.P])
 def test_interpolation(cell_type, n, element_type):
-    element = basix.create_element(element_type, cell_type, n, basix.LatticeType.gll)
+    element = basix.create_element(element_type, cell_type, n, basix.LatticeType.gll_warped)
     assert element.interpolation_matrix.shape[0] == element.dim
     assert element.interpolation_matrix.shape[1] == element.points.shape[0]
     assert element.points.shape[1] == len(basix.topology(element.cell_type)) - 1

--- a/test/test_lagrange.py
+++ b/test/test_lagrange.py
@@ -254,7 +254,8 @@ def test_dof_transformations_tetrahedron(degree):
     basix.CellType.prism
 ])
 def test_celltypes(degree, celltype):
-    tp = basix.create_element(basix.ElementFamily.P, celltype, degree, basix.LatticeType.gll)
+    tp = basix.create_element(basix.ElementFamily.P, celltype, degree,
+                              basix.LatticeType.gll_warped)
     pts = basix.create_lattice(celltype, 5,
                                basix.LatticeType.equispaced, True)
     w = tp.tabulate(0, pts)[0]

--- a/test/test_lattice.py
+++ b/test/test_lattice.py
@@ -8,11 +8,11 @@ import numpy as np
 
 
 @pytest.mark.parametrize("lattice_type", [
-    basix.LatticeType.equispaced, basix.LatticeType.gll, basix.LatticeType.gll_warped
+    basix.LatticeType.equispaced, basix.LatticeType.gll_isaac, basix.LatticeType.gll_warped
 ])
 @pytest.mark.parametrize("n", [1, 2, 4, 8])
 def test_pyramid(n, lattice_type):
-    if lattice_type == basix.LatticeType.gll:
+    if lattice_type == basix.LatticeType.gll_isaac:
         pytest.xfail("This lattice is not implemented on a pyramid yet.")
     # Check that all the surface points of the pyramid match up with the
     # same points on quad and triangle
@@ -47,7 +47,7 @@ def test_pyramid(n, lattice_type):
 
 
 @pytest.mark.parametrize("lattice_type", [
-    basix.LatticeType.equispaced, basix.LatticeType.gll, basix.LatticeType.gll_warped
+    basix.LatticeType.equispaced, basix.LatticeType.gll_isaac, basix.LatticeType.gll_warped
 ])
 @pytest.mark.parametrize("n", [1, 2, 4, 8])
 def test_tetrahedron(n, lattice_type):
@@ -78,7 +78,7 @@ def test_tetrahedron(n, lattice_type):
 
 
 @pytest.mark.parametrize("lattice_type", [
-    basix.LatticeType.equispaced, basix.LatticeType.gll, basix.LatticeType.gll_warped
+    basix.LatticeType.equispaced, basix.LatticeType.gll_isaac, basix.LatticeType.gll_warped
 ])
 @pytest.mark.parametrize("n", [1, 2, 4, 8])
 def test_triangle(n, lattice_type):

--- a/test/test_lattice.py
+++ b/test/test_lattice.py
@@ -1,19 +1,24 @@
-# Copyright (c) 2020 Chris Richardson
+# Copyright (c) 2020 Chris Richardson & Matthew Scroggs
 # FEniCS Project
 # SPDX-License-Identifier: MIT
 
+import pytest
 import basix
 import numpy as np
 
 
-def test_gll_pyramid():
-    n = 8
-
+@pytest.mark.parametrize("lattice_type", [
+    basix.LatticeType.equispaced, basix.LatticeType.gll, basix.LatticeType.gll_warped
+])
+@pytest.mark.parametrize("n", [1, 2, 4, 8])
+def test_pyramid(n, lattice_type):
+    if lattice_type == basix.LatticeType.gll:
+        pytest.xfail("This lattice is not implemented on a pyramid yet.")
     # Check that all the surface points of the pyramid match up with the
     # same points on quad and triangle
-    tri_pts = basix.create_lattice(basix.CellType.triangle, n, basix.LatticeType.gll, True)
-    quad_pts = basix.create_lattice(basix.CellType.quadrilateral, n, basix.LatticeType.gll, True)
-    pyr_pts = basix.create_lattice(basix.CellType.pyramid, n, basix.LatticeType.gll, True)
+    tri_pts = basix.create_lattice(basix.CellType.triangle, n, lattice_type, True)
+    quad_pts = basix.create_lattice(basix.CellType.quadrilateral, n, lattice_type, True)
+    pyr_pts = basix.create_lattice(basix.CellType.pyramid, n, lattice_type, True)
 
     # Remove any near-zero values to make sorting robust
     pyr_pts[np.where(abs(pyr_pts) < 1e-12)] = 0.0
@@ -41,13 +46,15 @@ def test_gll_pyramid():
     assert np.allclose(np.sort(quad_pts), np.sort(pyr_z0))
 
 
-def test_gll_tetrahedron():
-    n = 8
-
+@pytest.mark.parametrize("lattice_type", [
+    basix.LatticeType.equispaced, basix.LatticeType.gll, basix.LatticeType.gll_warped
+])
+@pytest.mark.parametrize("n", [1, 2, 4, 8])
+def test_tetrahedron(n, lattice_type):
     # Check that all the surface points of the tet match up with the same points on
     # triangle
-    tri_pts = basix.create_lattice(basix.CellType.triangle, n, basix.LatticeType.gll, True)
-    tet_pts = basix.create_lattice(basix.CellType.tetrahedron, n, basix.LatticeType.gll, True)
+    tri_pts = basix.create_lattice(basix.CellType.triangle, n, lattice_type, True)
+    tet_pts = basix.create_lattice(basix.CellType.tetrahedron, n, lattice_type, True)
 
     tet_pts[np.where(abs(tet_pts) < 1e-12)] = 0.0
     tri_pts[np.where(abs(tri_pts) < 1e-12)] = 0.0

--- a/test/test_lattice.py
+++ b/test/test_lattice.py
@@ -75,3 +75,30 @@ def test_tetrahedron(n, lattice_type):
     idx = np.where(np.isclose(tet_pts[:, 0] + tet_pts[:, 1] + tet_pts[:, 2], 1.0))
     tet_xyz = tet_pts[idx][:, 1:]
     assert np.allclose(np.sort(tri_pts), np.sort(tet_xyz))
+
+
+@pytest.mark.parametrize("lattice_type", [
+    basix.LatticeType.equispaced, basix.LatticeType.gll, basix.LatticeType.gll_warped
+])
+@pytest.mark.parametrize("n", [1, 2, 4, 8])
+def test_triangle(n, lattice_type):
+    # Check that all the surface points of the triangle match up with the same points on
+    # an interval
+    tri_pts = basix.create_lattice(basix.CellType.triangle, n, lattice_type, True)
+    interval_pts = basix.create_lattice(basix.CellType.interval, n, lattice_type, True)
+
+    tri_pts[np.where(abs(tri_pts) < 1e-12)] = 0.0
+    interval_pts[np.where(abs(interval_pts) < 1e-12)] = 0.0
+
+    idx = np.where(np.isclose(tri_pts[:, 0], 0.0))
+    tri_x0 = tri_pts[idx][:, 1:]
+    assert np.allclose(np.sort(interval_pts), np.sort(tri_x0))
+
+    idx = np.where(np.isclose(tri_pts[:, 1], 0.0))
+    tri_y0 = tri_pts[idx][:, :1]
+    assert np.allclose(np.sort(interval_pts), np.sort(tri_y0))
+
+    # Project x+y=1 onto x=0
+    idx = np.where(np.isclose(tri_pts[:, 0] + tri_pts[:, 1], 1.0))
+    tri_xyz = tri_pts[idx][:, 1:]
+    assert np.allclose(np.sort(interval_pts), np.sort(tri_xyz))

--- a/test/test_mappings.py
+++ b/test/test_mappings.py
@@ -8,7 +8,7 @@ import pytest
 import numpy as np
 
 elements = [
-    (basix.ElementFamily.P, [basix.LatticeType.gll]),  # identity
+    (basix.ElementFamily.P, [basix.LatticeType.gll_warped]),  # identity
     (basix.ElementFamily.N1E, []),  # covariant Piola
     (basix.ElementFamily.RT, []),  # contravariant Piola
     (basix.ElementFamily.Regge, []),  # double covariant Piola

--- a/test/test_numba.py
+++ b/test/test_numba.py
@@ -11,8 +11,8 @@ from numba.typed import Dict
 @pytest.mark.parametrize("cell", [basix.CellType.triangle, basix.CellType.tetrahedron,
                                   basix.CellType.quadrilateral, basix.CellType.hexahedron])
 @pytest.mark.parametrize("element, degree, element_args", [
-    (basix.ElementFamily.P, 1, [basix.LatticeType.gll]),
-    (basix.ElementFamily.P, 3, [basix.LatticeType.gll]),
+    (basix.ElementFamily.P, 1, [basix.LatticeType.gll_warped]),
+    (basix.ElementFamily.P, 3, [basix.LatticeType.gll_warped]),
     (basix.ElementFamily.N1E, 3, [])
 ])
 @pytest.mark.parametrize("block_size", [1, 2, 4])
@@ -56,8 +56,8 @@ def test_dof_transformations(cell, element, degree, element_args, block_size):
 @pytest.mark.parametrize("cell", [basix.CellType.triangle, basix.CellType.tetrahedron,
                                   basix.CellType.quadrilateral, basix.CellType.hexahedron])
 @pytest.mark.parametrize("element, degree, element_args", [
-    (basix.ElementFamily.P, 1, [basix.LatticeType.gll]),
-    (basix.ElementFamily.P, 3, [basix.LatticeType.gll]),
+    (basix.ElementFamily.P, 1, [basix.LatticeType.gll_warped]),
+    (basix.ElementFamily.P, 3, [basix.LatticeType.gll_warped]),
     (basix.ElementFamily.N1E, 3, [])
 ])
 @pytest.mark.parametrize("block_size", [1, 2, 4])

--- a/test/utils.py
+++ b/test/utils.py
@@ -13,6 +13,12 @@ def parametrize_over_elements(degree, reference=None):
                     for c in [basix.CellType.interval, basix.CellType.triangle,
                               basix.CellType.tetrahedron,
                               basix.CellType.quadrilateral, basix.CellType.hexahedron,
+                              basix.CellType.prism]
+                    for o in range(1, degree + 1)]
+    elementlist += [(c, basix.ElementFamily.P, o, [basix.LatticeType.gll_warped])
+                    for c in [basix.CellType.interval, basix.CellType.triangle,
+                              basix.CellType.tetrahedron,
+                              basix.CellType.quadrilateral, basix.CellType.hexahedron,
                               basix.CellType.prism, basix.CellType.pyramid]
                     for o in range(1, degree + 1)]
     elementlist += [(c, basix.ElementFamily.P, o, [basix.LatticeType.gll, True])

--- a/test/utils.py
+++ b/test/utils.py
@@ -9,7 +9,7 @@ import basix
 def parametrize_over_elements(degree, reference=None):
     elementlist = []
 
-    elementlist += [(c, basix.ElementFamily.P, o, [basix.LatticeType.gll])
+    elementlist += [(c, basix.ElementFamily.P, o, [basix.LatticeType.gll_isaac])
                     for c in [basix.CellType.interval, basix.CellType.triangle,
                               basix.CellType.tetrahedron,
                               basix.CellType.quadrilateral, basix.CellType.hexahedron,
@@ -21,7 +21,7 @@ def parametrize_over_elements(degree, reference=None):
                               basix.CellType.quadrilateral, basix.CellType.hexahedron,
                               basix.CellType.prism, basix.CellType.pyramid]
                     for o in range(1, degree + 1)]
-    elementlist += [(c, basix.ElementFamily.P, o, [basix.LatticeType.gll, True])
+    elementlist += [(c, basix.ElementFamily.P, o, [basix.LatticeType.gll_isaac, True])
                     for c in [basix.CellType.interval, basix.CellType.triangle,
                               basix.CellType.tetrahedron,
                               basix.CellType.quadrilateral, basix.CellType.hexahedron]


### PR DESCRIPTION
Added points defined in https://doi.org/10.1137/20M1321802.

Below order ~20, these give a lower Lesbesgue constant on a triangle than warped GLL points:
![tri-isaac](https://user-images.githubusercontent.com/9850599/132817076-fb1b1be5-3cfd-4ee1-b10f-cf856494f18c.png)

On a tetrahedron, they also give a lower Lebesgue constant:
![Figure_2](https://user-images.githubusercontent.com/9850599/132817402-d8312fac-0b81-4e65-a64e-4c361171b303.png)

Closes #251.