### PR TITLE
Disable GLL points on pyramid

### DIFF
--- a/cpp/basix/lattice.cpp
+++ b/cpp/basix/lattice.cpp
@@ -443,6 +443,8 @@ xt::xtensor<double, 2> create_pyramid_equispaced(int n, bool exterior)
 //-----------------------------------------------------------------------------
 xt::xtensor<double, 2> create_pyramid_gll_warped(int n, bool exterior)
 {
+  throw std::runtime_error("GLL on Pyramid is not currently working.");
+
   const double h = 1.0 / static_cast<double>(n);
 
   // Interpolate warp factor along interval

--- a/test/test_lagrange.py
+++ b/test/test_lagrange.py
@@ -255,7 +255,7 @@ def test_dof_transformations_tetrahedron(degree):
 ])
 def test_celltypes(degree, celltype):
     tp = basix.create_element(basix.ElementFamily.P, celltype, degree,
-                              basix.LatticeType.gll_warped)
+                              basix.LatticeType.equispaced)
     pts = basix.create_lattice(celltype, 5,
                                basix.LatticeType.equispaced, True)
     w = tp.tabulate(0, pts)[0]

--- a/test/test_lattice.py
+++ b/test/test_lattice.py
@@ -8,12 +8,10 @@ import numpy as np
 
 
 @pytest.mark.parametrize("lattice_type", [
-    basix.LatticeType.equispaced, basix.LatticeType.gll_isaac, basix.LatticeType.gll_warped
+    basix.LatticeType.equispaced # basix.LatticeType.gll_isaac, basix.LatticeType.gll_warped
 ])
 @pytest.mark.parametrize("n", [1, 2, 4, 8])
 def test_pyramid(n, lattice_type):
-    if lattice_type == basix.LatticeType.gll_isaac:
-        pytest.xfail("This lattice is not implemented on a pyramid yet.")
     # Check that all the surface points of the pyramid match up with the
     # same points on quad and triangle
     tri_pts = basix.create_lattice(basix.CellType.triangle, n, lattice_type, True)

--- a/test/test_lattice.py
+++ b/test/test_lattice.py
@@ -8,7 +8,7 @@ import numpy as np
 
 
 @pytest.mark.parametrize("lattice_type", [
-    basix.LatticeType.equispaced # basix.LatticeType.gll_isaac, basix.LatticeType.gll_warped
+    basix.LatticeType.equispaced  # basix.LatticeType.gll_isaac, basix.LatticeType.gll_warped
 ])
 @pytest.mark.parametrize("n", [1, 2, 4, 8])
 def test_pyramid(n, lattice_type):

--- a/test/utils.py
+++ b/test/utils.py
@@ -19,7 +19,7 @@ def parametrize_over_elements(degree, reference=None):
                     for c in [basix.CellType.interval, basix.CellType.triangle,
                               basix.CellType.tetrahedron,
                               basix.CellType.quadrilateral, basix.CellType.hexahedron,
-                              basix.CellType.prism, basix.CellType.pyramid]
+                              basix.CellType.prism]
                     for o in range(1, degree + 1)]
     elementlist += [(c, basix.ElementFamily.P, o, [basix.LatticeType.gll_isaac, True])
                     for c in [basix.CellType.interval, basix.CellType.triangle,


### PR DESCRIPTION
Disable some of the new tests on pyramids I recently added. These are causing intermittent failing tests.

Fixes #269.