### PR TITLE
Make numba requirement optional

### DIFF
--- a/test/test_numba.py
+++ b/test/test_numba.py
@@ -15,7 +15,7 @@ import pytest
 @pytest.mark.parametrize("block_size", [1, 2, 4])
 def test_dof_transformations(cell, element, degree, element_args, block_size):
     try:
-        import numba
+        import numba  # noqa: F401
     except ImportError:
         pytest.skip("Numba must be installed to run this test.")
 
@@ -68,7 +68,7 @@ def test_dof_transformations(cell, element, degree, element_args, block_size):
 @pytest.mark.parametrize("block_size", [1, 2, 4])
 def test_dof_transformations_to_transpose(cell, element, degree, block_size, element_args):
     try:
-        import numba
+        import numba  # noqa: F401
     except ImportError:
         pytest.skip("Numba must be installed to run this test.")
 

--- a/test/test_numba.py
+++ b/test/test_numba.py
@@ -3,9 +3,6 @@ import random
 import basix
 import numpy as np
 import pytest
-from basix import numba_helpers
-from numba.core import types
-from numba.typed import Dict
 
 
 @pytest.mark.parametrize("cell", [basix.CellType.triangle, basix.CellType.tetrahedron,
@@ -17,6 +14,14 @@ from numba.typed import Dict
 ])
 @pytest.mark.parametrize("block_size", [1, 2, 4])
 def test_dof_transformations(cell, element, degree, element_args, block_size):
+    try:
+        import numba
+    except ImportError:
+        pytest.skip("Numba must be installed to run this test.")
+
+    from basix import numba_helpers
+    from numba.core import types
+    from numba.typed import Dict
 
     transform_functions = {
         basix.CellType.triangle: numba_helpers.apply_dof_transformation_triangle,
@@ -62,6 +67,14 @@ def test_dof_transformations(cell, element, degree, element_args, block_size):
 ])
 @pytest.mark.parametrize("block_size", [1, 2, 4])
 def test_dof_transformations_to_transpose(cell, element, degree, block_size, element_args):
+    try:
+        import numba
+    except ImportError:
+        pytest.skip("Numba must be installed to run this test.")
+
+    from basix import numba_helpers
+    from numba.core import types
+    from numba.typed import Dict
 
     transform_functions = {
         basix.CellType.triangle: numba_helpers.apply_dof_transformation_to_transpose_triangle,


### PR DESCRIPTION
Numba does not need to be installed to run Basix, so this test should be skipped if its not installed