### PR TITLE
Generalise lattice creation

### DIFF
--- a/cpp/basix/lattice.cpp
+++ b/cpp/basix/lattice.cpp
@@ -44,25 +44,6 @@ xt::xtensor<double, 1> create_interval_gll(int n, bool exterior)
   return x;
 }
 //-----------------------------------------------------------------------------
-xt::xtensor<double, 1> create_interval_chebyshev(int n, bool exterior)
-{
-  const std::size_t b = exterior ? 0 : 1;
-  std::array<std::size_t, 1> s = {static_cast<std::size_t>(n + 1 - 2 * b)};
-  xt::xtensor<double, 1> x(s);
-
-  if (exterior)
-  {
-    for (int i = 0; i < n + 1; ++i)
-      x[i - b] = 0.5 - cos(i * M_PI / n) / 2.0;
-  }
-  else
-  {
-    for (int i = 1; i < n; ++i)
-      x[i - b] = 0.5 - cos((2 * i - 1) * M_PI / (2 * n)) / 2.0;
-  }
-  return x;
-}
-//-----------------------------------------------------------------------------
 xt::xtensor<double, 1> create_interval(int n, lattice::type lattice_type,
                                        bool exterior)
 {
@@ -77,10 +58,6 @@ xt::xtensor<double, 1> create_interval(int n, lattice::type lattice_type,
     return create_interval_gll(n, exterior);
   case lattice::type::gll_isaac:
     return create_interval_gll(n, exterior);
-  case lattice::type::chebyshev_warped:
-    return create_interval_chebyshev(n, exterior);
-  case lattice::type::chebyshev_isaac:
-    return create_interval_chebyshev(n, exterior);
   default:
     throw std::runtime_error("Unrecognised lattice type.");
   }
@@ -293,12 +270,8 @@ xt::xtensor<double, 2> create_tri(int n, lattice::type lattice_type,
 
   case lattice::type::gll_warped:
     return create_tri_warped(n, lattice_type, exterior);
-  case lattice::type::chebyshev_warped:
-    return create_tri_warped(n, lattice_type, exterior);
 
   case lattice::type::gll_isaac:
-    return create_tri_isaac(n, lattice_type, exterior);
-  case lattice::type::chebyshev_isaac:
     return create_tri_isaac(n, lattice_type, exterior);
 
   default:
@@ -418,12 +391,8 @@ xt::xtensor<double, 2> create_tet(int n, lattice::type lattice_type,
 
   case lattice::type::gll_warped:
     return create_tet_warped(n, lattice_type, exterior);
-  case lattice::type::chebyshev_warped:
-    return create_tet_warped(n, lattice_type, exterior);
 
   case lattice::type::gll_isaac:
-    return create_tet_isaac(n, lattice_type, exterior);
-  case lattice::type::chebyshev_isaac:
     return create_tet_isaac(n, lattice_type, exterior);
   default:
     throw std::runtime_error("Unrecognised lattice type.");
@@ -480,6 +449,7 @@ xt::xtensor<double, 2> create_pyramid_equispaced(int n, bool exterior)
 //-----------------------------------------------------------------------------
 xt::xtensor<double, 2> create_pyramid_gll_warped(int n, bool exterior)
 {
+  // FIXME
   throw std::runtime_error("GLL on Pyramid is not currently working.");
 
   const double h = 1.0 / static_cast<double>(n);

--- a/cpp/basix/lattice.h
+++ b/cpp/basix/lattice.h
@@ -16,22 +16,31 @@ namespace basix::lattice
 /// on an interval and a regularly spaced set of points on other
 /// shapes.
 ///
-/// lattice::type:gll_warped represents the GLL (Gauss-Lobatto-Legendre)
-/// points on an interval. Fot other shapes, the points used are obtained
+/// lattice::type::gll_warped represents the GLL (Gauss-Lobatto-Legendre)
+/// points on an interval. For other shapes, the points used are obtained
 /// by warping an equispaced grid of points, as described in Hesthaven and
 /// Warburton, Nodal Discontinuous Galerkin Methods, 2008, pp 175-180
 /// (https://doi.org/10.1007/978-0-387-72067-8).
 ///
-/// lattice::type:gll_isaac represents the GLL (Gauss-Lobatto-Legendre)
-/// points on an interval. Fot other shapes, the points used are obtained
-/// following the methd described in Isaac, Recursive, Parameter-Free,
+/// lattice::type::gll_isaac represents the GLL (Gauss-Lobatto-Legendre)
+/// points on an interval. For other shapes, the points used are obtained
+/// following the method described in Isaac, Recursive, Parameter-Free,
 /// Explicitly Defined Interpolation Nodes for Simplices, 2020
 /// (https://doi.org/10.1137/20M1321802).
+///
+/// lattice::type::chebyshev_warped represents the Chebyshev points on an
+/// interval. For other shapes, the points used are obtained using warping.
+///
+/// lattice::type::chebyshev_isaac represents the Chebyshev points on an
+/// interval. For other shapes, the points used are obtained using Isaac's
+/// method.
 enum class type
 {
   equispaced = 0,
   gll_warped = 1,
   gll_isaac = 2,
+  chebyshev_warped = 3,
+  chebyshev_isaac = 4,
 };
 
 /// Convert string to a lattice type

--- a/cpp/basix/lattice.h
+++ b/cpp/basix/lattice.h
@@ -27,20 +27,11 @@ namespace basix::lattice
 /// following the method described in Isaac, Recursive, Parameter-Free,
 /// Explicitly Defined Interpolation Nodes for Simplices, 2020
 /// (https://doi.org/10.1137/20M1321802).
-///
-/// lattice::type::chebyshev_warped represents the Chebyshev points on an
-/// interval. For other shapes, the points used are obtained using warping.
-///
-/// lattice::type::chebyshev_isaac represents the Chebyshev points on an
-/// interval. For other shapes, the points used are obtained using Isaac's
-/// method.
 enum class type
 {
   equispaced = 0,
   gll_warped = 1,
   gll_isaac = 2,
-  chebyshev_warped = 3,
-  chebyshev_isaac = 4,
 };
 
 /// Convert string to a lattice type

--- a/python/wrapper.cpp
+++ b/python/wrapper.cpp
@@ -131,9 +131,7 @@ Interface to the Basix C++ library.
   py::enum_<lattice::type>(m, "LatticeType")
       .value("equispaced", lattice::type::equispaced)
       .value("gll_warped", lattice::type::gll_warped)
-      .value("gll_isaac", lattice::type::gll_isaac)
-      .value("chebyshev_warped", lattice::type::chebyshev_warped)
-      .value("chebyshev_isaac", lattice::type::chebyshev_isaac);
+      .value("gll_isaac", lattice::type::gll_isaac);
 
   m.def(
       "create_lattice",

--- a/python/wrapper.cpp
+++ b/python/wrapper.cpp
@@ -131,7 +131,9 @@ Interface to the Basix C++ library.
   py::enum_<lattice::type>(m, "LatticeType")
       .value("equispaced", lattice::type::equispaced)
       .value("gll_warped", lattice::type::gll_warped)
-      .value("gll_isaac", lattice::type::gll_isaac);
+      .value("gll_isaac", lattice::type::gll_isaac)
+      .value("chebyshev_warped", lattice::type::chebyshev_warped)
+      .value("chebyshev_isaac", lattice::type::chebyshev_isaac);
 
   m.def(
       "create_lattice",

--- a/test/test_lattice.py
+++ b/test/test_lattice.py
@@ -47,7 +47,6 @@ def test_pyramid(n, lattice_type):
 @pytest.mark.parametrize("lattice_type", [
     basix.LatticeType.equispaced,
     basix.LatticeType.gll_isaac, basix.LatticeType.gll_warped,
-    basix.LatticeType.chebyshev_isaac, basix.LatticeType.chebyshev_warped,
 ])
 @pytest.mark.parametrize("n", [1, 2, 4, 8])
 def test_tetrahedron(n, lattice_type):
@@ -80,7 +79,6 @@ def test_tetrahedron(n, lattice_type):
 @pytest.mark.parametrize("lattice_type", [
     basix.LatticeType.equispaced,
     basix.LatticeType.gll_isaac, basix.LatticeType.gll_warped,
-    basix.LatticeType.chebyshev_isaac, basix.LatticeType.chebyshev_warped,
 ])
 @pytest.mark.parametrize("n", [1, 2, 4, 8])
 def test_triangle(n, lattice_type):

--- a/test/test_lattice.py
+++ b/test/test_lattice.py
@@ -45,7 +45,9 @@ def test_pyramid(n, lattice_type):
 
 
 @pytest.mark.parametrize("lattice_type", [
-    basix.LatticeType.equispaced, basix.LatticeType.gll_isaac, basix.LatticeType.gll_warped
+    basix.LatticeType.equispaced,
+    basix.LatticeType.gll_isaac, basix.LatticeType.gll_warped,
+    basix.LatticeType.chebyshev_isaac, basix.LatticeType.chebyshev_warped,
 ])
 @pytest.mark.parametrize("n", [1, 2, 4, 8])
 def test_tetrahedron(n, lattice_type):
@@ -76,7 +78,9 @@ def test_tetrahedron(n, lattice_type):
 
 
 @pytest.mark.parametrize("lattice_type", [
-    basix.LatticeType.equispaced, basix.LatticeType.gll_isaac, basix.LatticeType.gll_warped
+    basix.LatticeType.equispaced,
+    basix.LatticeType.gll_isaac, basix.LatticeType.gll_warped,
+    basix.LatticeType.chebyshev_isaac, basix.LatticeType.chebyshev_warped,
 ])
 @pytest.mark.parametrize("n", [1, 2, 4, 8])
 def test_triangle(n, lattice_type):


### PR DESCRIPTION
Warping and Isaac's method can both be used to make versions of various points on triangles and tetrahedra. This removes the hard coding of these methods using GLL points so other points can more easily be added.

Removed warping from creating of GLL points on interval, as GLL points from quadrature can be used directly.