### PR TITLE
Add Chebyshev point lattice

### DIFF
--- a/cpp/basix/e-brezzi-douglas-marini.cpp
+++ b/cpp/basix/e-brezzi-douglas-marini.cpp
@@ -39,8 +39,8 @@ FiniteElement basix::create_bdm(cell::type celltype, int degree,
   std::array<std::vector<xt::xtensor<double, 2>>, 4> x;
 
   // Add integral moments on facets
-  const FiniteElement facet_moment_space
-      = create_lagrange(facettype, degree, lattice::type::equispaced, true);
+  const FiniteElement facet_moment_space = create_lagrange(
+      facettype, degree, element::lagrange_variant::equispaced, true);
   std::tie(x[tdim - 1], M[tdim - 1]) = moments::make_normal_integral_moments(
       facet_moment_space, celltype, tdim, quad_deg);
 

--- a/cpp/basix/e-lagrange.cpp
+++ b/cpp/basix/e-lagrange.cpp
@@ -16,10 +16,32 @@
 
 using namespace basix;
 
+namespace
+{
+//----------------------------------------------------------------------------
+std::pair<lattice::type, lattice::simplex_method>
+variant_to_lattice(lagrange_variant variant)
+{
+  switch (variant)
+  {
+  case lagrange_variant::equispaced:
+    return {lattice::type::equispaced, lattice::simplex_method::none};
+  case lagrange_variant::gll_warped:
+    return {lattice::type::gll, lattice::simplex_method::warp};
+  case lagrange_variant::gll_isaac:
+    return {lattice::type::gll, lattice::simplex_method::isaac};
+  case lagrange_variant::chebyshev_warped:
+    return {lattice::type::chebyshev, lattice::simplex_method::warp};
+  case lagrange_variant::chebyshev_isaac:
+    return {lattice::type::chebyshev, lattice::simplex_method::isaac};
+  default:
+    throw std::runtime_error("Unsupported variant");
+  }
+} // namespace
+
 //----------------------------------------------------------------------------
 FiniteElement basix::create_lagrange(cell::type celltype, int degree,
-                                     lattice::type lattice_type,
-                                     lattice::simplex_method simplex_method,
+                                     lagrange_variant variant,
                                      bool discontinuous)
 {
   if (celltype == cell::type::point)
@@ -32,6 +54,8 @@ FiniteElement basix::create_lagrange(cell::type celltype, int degree,
 
   std::array<std::vector<xt::xtensor<double, 3>>, 4> M;
   std::array<std::vector<xt::xtensor<double, 2>>, 4> x;
+
+  auto [lattice_type, simplex_method] = variant_to_lattice(variant);
 
   // Create points at nodes, ordered by topology (vertices first)
   if (degree == 0)

--- a/cpp/basix/e-lagrange.cpp
+++ b/cpp/basix/e-lagrange.cpp
@@ -37,8 +37,8 @@ variant_to_lattice(cell::type celltype, element::lagrange_variant variant)
         or celltype == cell::type::hexahedron)
       return {lattice::type::chebyshev, lattice::simplex_method::none, false};
     // TODO: is this the best thing to do for simplices?
-    return {lattice::type::chebyshev_stretched, lattice::simplex_method::warp,
-            false};
+    return {lattice::type::chebyshev_plus_endpoints,
+            lattice::simplex_method::warp, false};
   }
   case element::lagrange_variant::chebyshev_isaac:
   {
@@ -47,8 +47,8 @@ variant_to_lattice(cell::type celltype, element::lagrange_variant variant)
         or celltype == cell::type::hexahedron)
       return {lattice::type::chebyshev, lattice::simplex_method::none, false};
     // TODO: is this the best thing to do for simplices?
-    return {lattice::type::chebyshev_stretched, lattice::simplex_method::isaac,
-            false};
+    return {lattice::type::chebyshev_plus_endpoints,
+            lattice::simplex_method::isaac, false};
   }
   default:
     throw std::runtime_error("Unsupported variant");

--- a/cpp/basix/e-lagrange.cpp
+++ b/cpp/basix/e-lagrange.cpp
@@ -19,6 +19,7 @@ using namespace basix;
 //----------------------------------------------------------------------------
 FiniteElement basix::create_lagrange(cell::type celltype, int degree,
                                      lattice::type lattice_type,
+                                     lattice::simplex_method simplex_method,
                                      bool discontinuous)
 {
   if (celltype == cell::type::point)
@@ -40,7 +41,7 @@ FiniteElement basix::create_lagrange(cell::type celltype, int degree,
       throw std::runtime_error(
           "Cannot create a continuous order 0 Lagrange basis function");
     }
-    auto pt = lattice::create(celltype, 0, lattice_type, true);
+    auto pt = lattice::create(celltype, 0, lattice_type, true, simplex_method);
     x[tdim].push_back(pt);
     const std::size_t num_dofs = pt.shape(0);
     std::array<std::size_t, 3> s = {num_dofs, 1, num_dofs};
@@ -70,7 +71,8 @@ FiniteElement basix::create_lagrange(cell::type celltype, int degree,
         }
         else if (dim == tdim)
         {
-          x[dim][e] = lattice::create(celltype, degree, lattice_type, false);
+          x[dim][e] = lattice::create(celltype, degree, lattice_type, false,
+                                      simplex_method);
           const std::size_t num_dofs = x[dim][e].shape(0);
           std::array<std::size_t, 3> s = {num_dofs, 1, num_dofs};
           M[dim][e] = xt::xtensor<double, 3>(s);
@@ -80,7 +82,8 @@ FiniteElement basix::create_lagrange(cell::type celltype, int degree,
         else
         {
           cell::type ct = cell::sub_entity_type(celltype, dim, e);
-          const auto lattice = lattice::create(ct, degree, lattice_type, false);
+          const auto lattice = lattice::create(ct, degree, lattice_type, false,
+                                               simplex_method);
           const std::size_t num_dofs = lattice.shape(0);
           std::array<std::size_t, 3> s = {num_dofs, 1, num_dofs};
           M[dim][e] = xt::xtensor<double, 3>(s);

--- a/cpp/basix/e-lagrange.h
+++ b/cpp/basix/e-lagrange.h
@@ -15,8 +15,6 @@ namespace basix
 /// @param[in] celltype The reference cell type that the element is defined on
 /// @param[in] degree The degree of the element
 /// @param[in] variant The variant of the element to be created
-/// @param[in] simplex_method The simplex method that should be used to create
-/// lattice on simplices
 /// @param discontinuous
 /// points of the element
 /// @return A FiniteElement

--- a/cpp/basix/e-lagrange.h
+++ b/cpp/basix/e-lagrange.h
@@ -5,21 +5,12 @@
 #pragma once
 
 #include "cell.h"
+#include "element-families.h"
 #include "finite-element.h"
 #include "lattice.h"
 
 namespace basix
 {
-/// An enum defining the variants of a Lagrange space that can be created
-enum class lagrange_variant
-{
-  equispaced = 0,
-  gll_warped = 1,
-  gll_isaac = 2,
-  chebyshev_warped = 3,
-  chebyshev_isaac = 4,
-};
-
 /// Create a Lagrange element on cell with given degree
 /// @param[in] celltype The reference cell type that the element is defined on
 /// @param[in] degree The degree of the element
@@ -30,7 +21,8 @@ enum class lagrange_variant
 /// points of the element
 /// @return A FiniteElement
 FiniteElement create_lagrange(cell::type celltype, int degree,
-                              lagrange_variant variant, bool discontinuous);
+                              element::lagrange_variant variant,
+                              bool discontinuous);
 
 /// Create a DPC element on cell with given degree
 /// @param[in] celltype The reference cell type that the element is defined on

--- a/cpp/basix/e-lagrange.h
+++ b/cpp/basix/e-lagrange.h
@@ -10,6 +10,16 @@
 
 namespace basix
 {
+/// An enum defining the variants of a Lagrange space that can be created
+enum class lagrange_variant
+{
+  equispaced = 0,
+  gll_warped = 1,
+  gll_isaac = 2,
+  chebyshev_warped = 3,
+  chebyshev_isaac = 4,
+};
+
 /// Create a Lagrange element on cell with given degree
 /// @param[in] celltype The reference cell type that the element is defined on
 /// @param[in] degree The degree of the element
@@ -20,9 +30,7 @@ namespace basix
 /// points of the element
 /// @return A FiniteElement
 FiniteElement create_lagrange(cell::type celltype, int degree,
-                              lattice::type lattice_type,
-                              lattice::simplex_method simplex_method,
-                              bool discontinuous);
+                              lagrange_variant variant, bool discontinuous);
 
 /// Create a DPC element on cell with given degree
 /// @param[in] celltype The reference cell type that the element is defined on

--- a/cpp/basix/e-lagrange.h
+++ b/cpp/basix/e-lagrange.h
@@ -13,12 +13,16 @@ namespace basix
 /// Create a Lagrange element on cell with given degree
 /// @param[in] celltype The reference cell type that the element is defined on
 /// @param[in] degree The degree of the element
-/// @param[in] lattice_type The lattice type that should be used to arrange DOF
+/// @param[in] lattice_type The lattice type that should be used to arrange DOFs
+/// @param[in] simplex_method The simplex method that should be used to create
+/// lattice on simplices
 /// @param discontinuous
 /// points of the element
 /// @return A FiniteElement
 FiniteElement create_lagrange(cell::type celltype, int degree,
-                              lattice::type lattice_type, bool discontinuous);
+                              lattice::type lattice_type,
+                              lattice::simplex_method simplex_method,
+                              bool discontinuous);
 
 /// Create a DPC element on cell with given degree
 /// @param[in] celltype The reference cell type that the element is defined on

--- a/cpp/basix/e-lagrange.h
+++ b/cpp/basix/e-lagrange.h
@@ -14,7 +14,7 @@ namespace basix
 /// Create a Lagrange element on cell with given degree
 /// @param[in] celltype The reference cell type that the element is defined on
 /// @param[in] degree The degree of the element
-/// @param[in] lattice_type The lattice type that should be used to arrange DOFs
+/// @param[in] variant The variant of the element to be created
 /// @param[in] simplex_method The simplex method that should be used to create
 /// lattice on simplices
 /// @param discontinuous

--- a/cpp/basix/e-nce-rtc.cpp
+++ b/cpp/basix/e-nce-rtc.cpp
@@ -120,8 +120,8 @@ FiniteElement basix::create_rtc(cell::type celltype, int degree,
   std::array<std::vector<xt::xtensor<double, 3>>, 4> M;
   std::array<std::vector<xt::xtensor<double, 2>>, 4> x;
 
-  FiniteElement moment_space
-      = create_lagrange(facettype, degree - 1, lattice::type::equispaced, true);
+  FiniteElement moment_space = create_lagrange(
+      facettype, degree - 1, element::lagrange_variant::equispaced, true);
   std::tie(x[tdim - 1], M[tdim - 1]) = moments::make_normal_integral_moments(
       moment_space, celltype, tdim, quad_deg);
   xt::xtensor<double, 3> facet_transforms
@@ -292,8 +292,9 @@ FiniteElement basix::create_nce(cell::type celltype, int degree,
   std::array<std::vector<xt::xtensor<double, 3>>, 4> M;
   std::array<std::vector<xt::xtensor<double, 2>>, 4> x;
 
-  FiniteElement edge_moment_space = create_lagrange(
-      cell::type::interval, degree - 1, lattice::type::equispaced, true);
+  FiniteElement edge_moment_space
+      = create_lagrange(cell::type::interval, degree - 1,
+                        element::lagrange_variant::equispaced, true);
   std::tie(x[1], M[1]) = moments::make_tangent_integral_moments(
       edge_moment_space, celltype, tdim, quad_deg);
   xt::xtensor<double, 3> edge_transforms

--- a/cpp/basix/e-nedelec.cpp
+++ b/cpp/basix/e-nedelec.cpp
@@ -77,13 +77,13 @@ create_nedelec_2d_interpolation(int degree)
   // Integral representation for the boundary (edge) dofs
   std::tie(x[1], M[1]) = moments::make_tangent_integral_moments(
       create_lagrange(cell::type::interval, degree - 1,
-                      lattice::type::equispaced, true),
+                      element::lagrange_variant::equispaced, true),
       cell::type::triangle, 2, quad_deg);
   if (degree > 1)
   {
     std::tie(x[2], M[2]) = moments::make_integral_moments(
         create_lagrange(cell::type::triangle, degree - 2,
-                        lattice::type::equispaced, true),
+                        element::lagrange_variant::equispaced, true),
         cell::type::triangle, 2, quad_deg);
   }
 
@@ -96,8 +96,9 @@ create_nedelec_2d_entity_transforms(int degree)
   std::map<cell::type, xt::xtensor<double, 3>> entity_transformations;
 
   xt::xtensor<double, 3> edge_transforms
-      = moments::create_tangent_moment_dof_transformations(create_lagrange(
-          cell::type::interval, degree - 1, lattice::type::equispaced, true));
+      = moments::create_tangent_moment_dof_transformations(
+          create_lagrange(cell::type::interval, degree - 1,
+                          element::lagrange_variant::equispaced, true));
   entity_transformations[cell::type::interval] = edge_transforms;
 
   return entity_transformations;
@@ -201,14 +202,14 @@ create_nedelec_3d_interpolation(int degree)
 
   std::tie(x[1], M[1]) = moments::make_tangent_integral_moments(
       create_lagrange(cell::type::interval, degree - 1,
-                      lattice::type::equispaced, true),
+                      element::lagrange_variant::equispaced, true),
       cell::type::tetrahedron, 3, quad_deg);
 
   if (degree > 1)
   {
     std::tie(x[2], M[2]) = moments::make_integral_moments(
         create_lagrange(cell::type::triangle, degree - 2,
-                        lattice::type::equispaced, true),
+                        element::lagrange_variant::equispaced, true),
         cell::type::tetrahedron, 3, quad_deg);
   }
 
@@ -216,7 +217,7 @@ create_nedelec_3d_interpolation(int degree)
   {
     std::tie(x[3], M[3]) = moments::make_integral_moments(
         create_lagrange(cell::type::tetrahedron, degree - 3,
-                        lattice::type::equispaced, true),
+                        element::lagrange_variant::equispaced, true),
         cell::type::tetrahedron, 3, quad_deg);
   }
 
@@ -229,16 +230,18 @@ create_nedelec_3d_entity_transforms(int degree)
   std::map<cell::type, xt::xtensor<double, 3>> entity_transformations;
 
   const xt::xtensor<double, 3> edge_transforms
-      = moments::create_tangent_moment_dof_transformations(create_lagrange(
-          cell::type::interval, degree - 1, lattice::type::equispaced, true));
+      = moments::create_tangent_moment_dof_transformations(
+          create_lagrange(cell::type::interval, degree - 1,
+                          element::lagrange_variant::equispaced, true));
   entity_transformations[cell::type::interval] = edge_transforms;
 
   // Faces
   if (degree > 1)
   {
     xt::xtensor<double, 3> face_transforms
-        = moments::create_moment_dof_transformations(create_lagrange(
-            cell::type::triangle, degree - 2, lattice::type::equispaced, true));
+        = moments::create_moment_dof_transformations(
+            create_lagrange(cell::type::triangle, degree - 2,
+                            element::lagrange_variant::equispaced, true));
 
     entity_transformations[cell::type::triangle] = face_transforms;
   }
@@ -260,8 +263,8 @@ create_nedelec2_2d_interpolation(int degree)
   std::array<std::vector<xt::xtensor<double, 3>>, 4> M;
 
   std::tie(x[1], M[1]) = moments::make_tangent_integral_moments(
-      create_lagrange(cell::type::interval, degree, lattice::type::equispaced,
-                      true),
+      create_lagrange(cell::type::interval, degree,
+                      element::lagrange_variant::equispaced, true),
       cell::type::triangle, 2, quad_deg);
   if (degree > 1)
   {
@@ -279,8 +282,9 @@ create_nedelec2_2d_entity_transformations(int degree)
   std::map<cell::type, xt::xtensor<double, 3>> entity_transformations;
 
   xt::xtensor<double, 3> edge_transforms
-      = moments::create_tangent_moment_dof_transformations(create_lagrange(
-          cell::type::interval, degree, lattice::type::equispaced, true));
+      = moments::create_tangent_moment_dof_transformations(
+          create_lagrange(cell::type::interval, degree,
+                          element::lagrange_variant::equispaced, true));
   entity_transformations[cell::type::interval] = edge_transforms;
 
   return entity_transformations;
@@ -298,8 +302,8 @@ create_nedelec2_3d_interpolation(int degree)
 
   // Integral representation for the boundary (edge) dofs
   std::tie(x[1], M[1]) = moments::make_tangent_integral_moments(
-      create_lagrange(cell::type::interval, degree, lattice::type::equispaced,
-                      true),
+      create_lagrange(cell::type::interval, degree,
+                      element::lagrange_variant::equispaced, true),
       cell::type::tetrahedron, 3, quad_deg);
 
   if (degree > 1)
@@ -327,8 +331,9 @@ create_nedelec2_3d_entity_transformations(int degree)
   std::map<cell::type, xt::xtensor<double, 3>> entity_transformations;
 
   const xt::xtensor<double, 3> edge_transforms
-      = moments::create_tangent_moment_dof_transformations(create_lagrange(
-          cell::type::interval, degree, lattice::type::equispaced, true));
+      = moments::create_tangent_moment_dof_transformations(
+          create_lagrange(cell::type::interval, degree,
+                          element::lagrange_variant::equispaced, true));
   entity_transformations[cell::type::interval] = edge_transforms;
 
   // Faces

--- a/cpp/basix/e-raviart-thomas.cpp
+++ b/cpp/basix/e-raviart-thomas.cpp
@@ -82,8 +82,8 @@ FiniteElement basix::create_rt(cell::type celltype, int degree,
   std::array<std::vector<xt::xtensor<double, 2>>, 4> x;
 
   // Add integral moments on facets
-  const FiniteElement facet_moment_space
-      = create_lagrange(facettype, degree - 1, lattice::type::equispaced, true);
+  const FiniteElement facet_moment_space = create_lagrange(
+      facettype, degree - 1, element::lagrange_variant::equispaced, true);
   std::tie(x[tdim - 1], M[tdim - 1]) = moments::make_normal_integral_moments(
       facet_moment_space, celltype, tdim, quad_deg);
   xt::xtensor<double, 3> facet_transforms
@@ -94,7 +94,8 @@ FiniteElement basix::create_rt(cell::type celltype, int degree,
   {
     // Interior integral moment
     std::tie(x[tdim], M[tdim]) = moments::make_integral_moments(
-        create_lagrange(celltype, degree - 2, lattice::type::equispaced, true),
+        create_lagrange(celltype, degree - 2,
+                        element::lagrange_variant::equispaced, true),
         celltype, tdim, quad_deg);
   }
 

--- a/cpp/basix/element-families.h
+++ b/cpp/basix/element-families.h
@@ -10,6 +10,16 @@ namespace basix
 
 namespace element
 {
+/// An enum defining the variants of a Lagrange space that can be created
+enum class lagrange_variant
+{
+  equispaced = 0,
+  gll_warped = 1,
+  gll_isaac = 2,
+  chebyshev_warped = 3,
+  chebyshev_isaac = 4,
+};
+
 /// Enum of available element families
 enum class family
 {

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -142,15 +142,17 @@ basix::FiniteElement basix::create_element(element::family family,
   }
 }
 //-----------------------------------------------------------------------------
-basix::FiniteElement basix::create_element(element::family family,
-                                           cell::type cell, int degree,
-                                           lattice::type lattice_type,
-                                           bool discontinuous)
+basix::FiniteElement
+basix::create_element(element::family family, cell::type cell, int degree,
+                      lattice::type lattice_type,
+                      lattice::simplex_method simplex_method,
+                      bool discontinuous)
 {
   switch (family)
   {
   case element::family::P:
-    return create_lagrange(cell, degree, lattice_type, discontinuous);
+    return create_lagrange(cell, degree, lattice_type, simplex_method,
+                           discontinuous);
   default:
     throw std::runtime_error("Cannot pass a lattice type to this element.");
   }
@@ -158,9 +160,28 @@ basix::FiniteElement basix::create_element(element::family family,
 //-----------------------------------------------------------------------------
 basix::FiniteElement basix::create_element(element::family family,
                                            cell::type cell, int degree,
+                                           lattice::type lattice_type,
+                                           bool discontinuous)
+{
+  return create_element(family, cell, degree, lattice_type,
+                        lattice::simplex_method::none, discontinuous);
+}
+//-----------------------------------------------------------------------------
+basix::FiniteElement basix::create_element(element::family family,
+                                           cell::type cell, int degree,
                                            lattice::type lattice_type)
 {
-  return basix::create_element(family, cell, degree, lattice_type, false);
+  return basix::create_element(family, cell, degree, lattice_type,
+                               lattice::simplex_method::none, false);
+}
+//-----------------------------------------------------------------------------
+basix::FiniteElement
+basix::create_element(element::family family, cell::type cell, int degree,
+                      lattice::type lattice_type,
+                      lattice::simplex_method simplex_method)
+{
+  return basix::create_element(family, cell, degree, lattice_type,
+                               simplex_method, false);
 }
 //-----------------------------------------------------------------------------
 basix::FiniteElement basix::create_element(element::family family,

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -81,8 +81,7 @@ basix::FiniteElement basix::create_element(element::family family,
   switch (family)
   {
   case element::family::P:
-    throw std::runtime_error(
-        "Lagrange elements need to be given a lattice type.");
+    throw std::runtime_error("Lagrange elements need to be given a variant.");
   case element::family::BDM:
     switch (cell)
     {

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -141,46 +141,25 @@ basix::FiniteElement basix::create_element(element::family family,
   }
 }
 //-----------------------------------------------------------------------------
-basix::FiniteElement
-basix::create_element(element::family family, cell::type cell, int degree,
-                      lattice::type lattice_type,
-                      lattice::simplex_method simplex_method,
-                      bool discontinuous)
+basix::FiniteElement basix::create_element(element::family family,
+                                           cell::type cell, int degree,
+                                           element::lagrange_variant variant,
+                                           bool discontinuous)
 {
   switch (family)
   {
   case element::family::P:
-    return create_lagrange(cell, degree, lattice_type, simplex_method,
-                           discontinuous);
+    return create_lagrange(cell, degree, variant, discontinuous);
   default:
-    throw std::runtime_error("Cannot pass a lattice type to this element.");
+    throw std::runtime_error("Cannot pass a Lagrange variant.");
   }
 }
 //-----------------------------------------------------------------------------
 basix::FiniteElement basix::create_element(element::family family,
                                            cell::type cell, int degree,
-                                           lattice::type lattice_type,
-                                           bool discontinuous)
+                                           element::lagrange_variant variant)
 {
-  return create_element(family, cell, degree, lattice_type,
-                        lattice::simplex_method::none, discontinuous);
-}
-//-----------------------------------------------------------------------------
-basix::FiniteElement basix::create_element(element::family family,
-                                           cell::type cell, int degree,
-                                           lattice::type lattice_type)
-{
-  return basix::create_element(family, cell, degree, lattice_type,
-                               lattice::simplex_method::none, false);
-}
-//-----------------------------------------------------------------------------
-basix::FiniteElement
-basix::create_element(element::family family, cell::type cell, int degree,
-                      lattice::type lattice_type,
-                      lattice::simplex_method simplex_method)
-{
-  return basix::create_element(family, cell, degree, lattice_type,
-                               simplex_method, false);
+  return basix::create_element(family, cell, degree, variant, false);
 }
 //-----------------------------------------------------------------------------
 basix::FiniteElement basix::create_element(element::family family,

--- a/cpp/basix/finite-element.h
+++ b/cpp/basix/finite-element.h
@@ -9,7 +9,6 @@
 
 #include "cell.h"
 #include "element-families.h"
-#include "lattice.h"
 #include "maps.h"
 #include "precompute.h"
 #include <array>
@@ -759,31 +758,16 @@ private:
   bool _discontinuous;
 };
 
-/// Create an element using a given lattice type
+/// Create an element using a given Lagrange variant
 /// @param[in] family The element family
 /// @param[in] cell The reference cell type that the element is defined on
 /// @param[in] degree The degree of the element
-/// @param[in] lattice_type The lattice type that should be used to arrange DOF
+/// @param[in] variant The variant of Lagrange to use
 /// @param[in] discontinuous Indicates whether the element is discontinuous
 /// between cells points of the element. The discontinuous element will have the
 /// same DOFs, but they will all be associated with the interior of the cell.
 FiniteElement create_element(element::family family, cell::type cell,
-                             int degree, lattice::type lattice_type,
-                             bool discontinuous);
-
-/// Create an element using a given lattice type and simplex method
-/// @param[in] family The element family
-/// @param[in] cell The reference cell type that the element is defined on
-/// @param[in] degree The degree of the element
-/// @param[in] lattice_type The lattice type that should be used to arrange DOFs
-/// @param[in] simmplex_method The method that should be used to create a
-/// lattice on simplices
-/// @param[in] discontinuous Indicates whether the element is discontinuous
-/// between cells points of the element. The discontinuous element will have the
-/// same DOFs, but they will all be associated with the interior of the cell.
-FiniteElement create_element(element::family family, cell::type cell,
-                             int degree, lattice::type lattice_type,
-                             lattice::simplex_method simplex_method,
+                             int degree, element::lagrange_variant variant,
                              bool discontinuous);
 
 /// Create an element
@@ -796,24 +780,13 @@ FiniteElement create_element(element::family family, cell::type cell,
 FiniteElement create_element(element::family family, cell::type cell,
                              int degree, bool discontinuous);
 
-/// Create a continuous element using a given lattice type
+/// Create a continuous element using a given Lagrange variant
 /// @param[in] family The element family
 /// @param[in] cell The reference cell type that the element is defined on
 /// @param[in] degree The degree of the element
-/// @param[in] lattice_type The lattice type that should be used to arrange DOF
+/// @param[in] variant The variant of Lagrange to use
 FiniteElement create_element(element::family family, cell::type cell,
-                             int degree, lattice::type lattice_type);
-
-/// Create an element using a given lattice type and simplex method
-/// @param[in] family The element family
-/// @param[in] cell The reference cell type that the element is defined on
-/// @param[in] degree The degree of the element
-/// @param[in] lattice_type The lattice type that should be used to arrange DOFs
-/// @param[in] simmplex_method The method that should be used to create a
-/// lattice on simplices
-FiniteElement create_element(element::family family, cell::type cell,
-                             int degree, lattice::type lattice_type,
-                             lattice::simplex_method simplex_method);
+                             int degree, element::lagrange_variant variant);
 
 /// Create a continuous element
 /// @param[in] family The element family

--- a/cpp/basix/finite-element.h
+++ b/cpp/basix/finite-element.h
@@ -771,6 +771,21 @@ FiniteElement create_element(element::family family, cell::type cell,
                              int degree, lattice::type lattice_type,
                              bool discontinuous);
 
+/// Create an element using a given lattice type and simplex method
+/// @param[in] family The element family
+/// @param[in] cell The reference cell type that the element is defined on
+/// @param[in] degree The degree of the element
+/// @param[in] lattice_type The lattice type that should be used to arrange DOFs
+/// @param[in] simmplex_method The method that should be used to create a
+/// lattice on simplices
+/// @param[in] discontinuous Indicates whether the element is discontinuous
+/// between cells points of the element. The discontinuous element will have the
+/// same DOFs, but they will all be associated with the interior of the cell.
+FiniteElement create_element(element::family family, cell::type cell,
+                             int degree, lattice::type lattice_type,
+                             lattice::simplex_method simplex_method,
+                             bool discontinuous);
+
 /// Create an element
 /// @param[in] family The element family
 /// @param[in] cell The reference cell type that the element is defined on
@@ -788,6 +803,17 @@ FiniteElement create_element(element::family family, cell::type cell,
 /// @param[in] lattice_type The lattice type that should be used to arrange DOF
 FiniteElement create_element(element::family family, cell::type cell,
                              int degree, lattice::type lattice_type);
+
+/// Create an element using a given lattice type and simplex method
+/// @param[in] family The element family
+/// @param[in] cell The reference cell type that the element is defined on
+/// @param[in] degree The degree of the element
+/// @param[in] lattice_type The lattice type that should be used to arrange DOFs
+/// @param[in] simmplex_method The method that should be used to create a
+/// lattice on simplices
+FiniteElement create_element(element::family family, cell::type cell,
+                             int degree, lattice::type lattice_type,
+                             lattice::simplex_method simplex_method);
 
 /// Create a continuous element
 /// @param[in] family The element family

--- a/cpp/basix/lattice.cpp
+++ b/cpp/basix/lattice.cpp
@@ -54,7 +54,31 @@ xt::xtensor<double, 1> create_interval_chebyshev(int n, bool exterior)
   xt::xtensor<double, 1> x(s);
 
   for (int i = 1; i < n; ++i)
-    x[i - 1] = 0.5 - cos((2 * i - 1) * M_PI / (2 * n)) / 2.0;
+    x[i - 1] = 0.5 - cos((2 * i - 1) * M_PI / (2 * n - 2)) / 2.0;
+
+  return x;
+}
+//-----------------------------------------------------------------------------
+xt::xtensor<double, 1> create_interval_chebyshev_stretched(int n, bool exterior)
+{
+  xt::xtensor<double, 1> x_cheb = create_interval_chebyshev(n + 2, false);
+
+  const double a = x_cheb[0];
+  const double b = x_cheb[n] - x_cheb[0];
+  for (std::size_t i = 0; i < x_cheb.shape(0); ++i)
+  {
+    x_cheb[i] -= a;
+    x_cheb[i] /= b;
+  }
+
+  if (exterior)
+    return x_cheb;
+
+  std::array<std::size_t, 1> s = {static_cast<std::size_t>(n - 1)};
+  xt::xtensor<double, 1> x(s);
+
+  for (int i = 1; i < n; ++i)
+    x[i - 1] = x_cheb[i];
 
   return x;
 }
@@ -73,6 +97,8 @@ xt::xtensor<double, 1> create_interval(int n, lattice::type lattice_type,
     return create_interval_gll(n, exterior);
   case lattice::type::chebyshev:
     return create_interval_chebyshev(n, exterior);
+  case lattice::type::chebyshev_stretched:
+    return create_interval_chebyshev_stretched(n, exterior);
   default:
     throw std::runtime_error("Unrecognised lattice type.");
   }

--- a/cpp/basix/lattice.cpp
+++ b/cpp/basix/lattice.cpp
@@ -59,26 +59,21 @@ xt::xtensor<double, 1> create_interval_chebyshev(int n, bool exterior)
   return x;
 }
 //-----------------------------------------------------------------------------
-xt::xtensor<double, 1> create_interval_chebyshev_stretched(int n, bool exterior)
+xt::xtensor<double, 1> create_interval_chebyshev_plus_endpoints(int n,
+                                                                bool exterior)
 {
-  xt::xtensor<double, 1> x_cheb = create_interval_chebyshev(n + 2, false);
+  xt::xtensor<double, 1> x_cheb = create_interval_chebyshev(n, false);
 
-  const double a = x_cheb[0];
-  const double b = x_cheb[n] - x_cheb[0];
-  for (std::size_t i = 0; i < x_cheb.shape(0); ++i)
-  {
-    x_cheb[i] -= a;
-    x_cheb[i] /= b;
-  }
-
-  if (exterior)
+  if (!exterior)
     return x_cheb;
 
-  std::array<std::size_t, 1> s = {static_cast<std::size_t>(n - 1)};
+  std::array<std::size_t, 1> s = {static_cast<std::size_t>(n + 1)};
   xt::xtensor<double, 1> x(s);
 
-  for (int i = 1; i < n; ++i)
-    x[i - 1] = x_cheb[i];
+  x[0] = 0.;
+  x[n] = 1.;
+  for (int i = 0; i < n - 1; ++i)
+    x[i + 1] = x_cheb[i];
 
   return x;
 }
@@ -97,8 +92,8 @@ xt::xtensor<double, 1> create_interval(int n, lattice::type lattice_type,
     return create_interval_gll(n, exterior);
   case lattice::type::chebyshev:
     return create_interval_chebyshev(n, exterior);
-  case lattice::type::chebyshev_stretched:
-    return create_interval_chebyshev_stretched(n, exterior);
+  case lattice::type::chebyshev_plus_endpoints:
+    return create_interval_chebyshev_plus_endpoints(n, exterior);
   default:
     throw std::runtime_error("Unrecognised lattice type.");
   }

--- a/cpp/basix/lattice.h
+++ b/cpp/basix/lattice.h
@@ -28,6 +28,7 @@ enum class type
   equispaced = 0,
   gll = 1,
   chebyshev = 2,
+  chebyshev_stretched = 3,
 };
 
 /// The method used to generate points inside simplices.

--- a/cpp/basix/lattice.h
+++ b/cpp/basix/lattice.h
@@ -16,38 +16,38 @@ namespace basix::lattice
 /// on an interval and a regularly spaced set of points on other
 /// shapes.
 ///
-/// lattice::type::gll_warped represents the GLL (Gauss-Lobatto-Legendre)
-/// points on an interval. For other shapes, the points used are obtained
-/// by warping an equispaced grid of points, as described in Hesthaven and
-/// Warburton, Nodal Discontinuous Galerkin Methods, 2008, pp 175-180
-/// (https://doi.org/10.1007/978-0-387-72067-8).
+/// lattice::type::gll represents the GLL (Gauss-Lobatto-Legendre)
+/// points.
 ///
-/// lattice::type::gll_isaac represents the GLL (Gauss-Lobatto-Legendre)
-/// points on an interval. For other shapes, the points used are obtained
-/// following the method described in Isaac, Recursive, Parameter-Free,
-/// Explicitly Defined Interpolation Nodes for Simplices, 2020
-/// (https://doi.org/10.1137/20M1321802).
+/// lattice::type::chebyshev represents the Chebyshev points.
 ///
-/// lattice::type::chebyshev_warped represents the Chebyshev points on an
-/// interval. For other shapes, the points used are obtained using warping.
-///
-/// lattice::type::chebyshev_isaac represents the Chebyshev points on an
-/// interval. For other shapes, the points used are obtained using Isaac's
-/// method.
+/// lattice::type::chebyshev_stretched represents the Chebyshev points scaled so
+/// that the first and last points are at 0 and 1.
 enum class type
 {
   equispaced = 0,
-  gll_warped = 1,
-  gll_isaac = 2,
-  chebyshev_warped = 3,
-  chebyshev_isaac = 4,
+  gll = 1,
+  chebyshev = 2,
 };
 
-/// Convert string to a lattice type
-lattice::type str_to_type(std::string name);
-
-// Convert family to string
-std::string type_to_str(lattice::type type);
+/// The method used to generate points inside simplices.
+///
+/// lattice::simplex_method::none can be used when no method is needed (eg when
+/// making points on a quadrilateral, or when making equispaced points).
+///
+/// lattice::simplex_method::warp will use the warping defined in Hesthaven and
+/// Warburton, Nodal Discontinuous Galerkin Methods, 2008, pp 175-180
+/// (https://doi.org/10.1007/978-0-387-72067-8).
+///
+/// lattice::simplex_method::isaac will use the method described in Isaac,
+/// Recursive, Parameter-Free, Explicitly Defined Interpolation Nodes for
+/// Simplices, 2020 (https://doi.org/10.1137/20M1321802).
+enum class simplex_method
+{
+  none = 0,
+  warp = 1,
+  isaac = 2
+};
 
 /// Create a lattice of points on a reference cell
 /// optionally including the outer surface points
@@ -65,10 +65,12 @@ std::string type_to_str(lattice::type type);
 /// @param celltype The cell::type
 /// @param n Size in each direction. There are n+1 points along each edge of the
 /// cell.
-/// @param type A lattice type
 /// @param exterior If set, includes outer boundaries
+/// @param type A lattice type
+/// @param simplex_method The method used to generate points on simplices
 /// @return Set of points
-xt::xtensor<double, 2> create(cell::type celltype, int n, lattice::type type,
-                              bool exterior);
+xt::xtensor<double, 2>
+create(cell::type celltype, int n, lattice::type type, bool exterior,
+       lattice::simplex_method simplex_method = lattice::simplex_method::none);
 
 } // namespace basix::lattice

--- a/cpp/basix/lattice.h
+++ b/cpp/basix/lattice.h
@@ -16,22 +16,31 @@ namespace basix::lattice
 /// on an interval and a regularly spaced set of points on other
 /// shapes.
 ///
-/// lattice::type:gll_warped represents the GLL (Gauss-Lobatto-Legendre)
-/// points on an interval. Fot other shapes, the points used are obtained
+/// lattice::type::gll_warped represents the GLL (Gauss-Lobatto-Legendre)
+/// points on an interval. For other shapes, the points used are obtained
 /// by warping an equispaced grid of points, as described in Hesthaven and
 /// Warburton, Nodal Discontinuous Galerkin Methods, 2008, pp 175-180
 /// (https://doi.org/10.1007/978-0-387-72067-8).
 ///
-/// lattice::type:gll_isaac represents the GLL (Gauss-Lobatto-Legendre)
-/// points on an interval. Fot other shapes, the points used are obtained
-/// following the methd described in Isaac, Recursive, Parameter-Free,
+/// lattice::type::gll_isaac represents the GLL (Gauss-Lobatto-Legendre)
+/// points on an interval. For other shapes, the points used are obtained
+/// following the method described in Isaac, Recursive, Parameter-Free,
 /// Explicitly Defined Interpolation Nodes for Simplices, 2020
 /// (https://doi.org/10.1137/20M1321802).
+///
+/// lattice::type::chebyshev_warped represents the Chebyshev points on an
+/// interval. For other shapes, the points used are obtained using warping.
+///
+/// lattice::type::chebyshev_isaac represents the Chebyshev points on an
+/// interval. For other shapes, the points used are obtained using Isaac's
+/// method.
 enum class type
 {
   equispaced = 0,
   gll_warped = 1,
   gll_isaac = 2,
+  chebyshev_warped = 3,
+  chebyshev_isaac = 4,
 };
 
 /// Convert string to a lattice type

--- a/cpp/basix/lattice.h
+++ b/cpp/basix/lattice.h
@@ -21,14 +21,14 @@ namespace basix::lattice
 ///
 /// lattice::type::chebyshev represents the Chebyshev points.
 ///
-/// lattice::type::chebyshev_stretched represents the Chebyshev points scaled so
-/// that the first and last points are at 0 and 1.
+/// lattice::type::chebyshev_plus_endpoints represents the Chebyshev points plus
+/// the endpoints of the interval.
 enum class type
 {
   equispaced = 0,
   gll = 1,
   chebyshev = 2,
-  chebyshev_stretched = 3,
+  chebyshev_plus_endpoints = 3,
 };
 
 /// The method used to generate points inside simplices.

--- a/python/basix/__init__.py
+++ b/python/basix/__init__.py
@@ -7,7 +7,7 @@ functionality can be used via this Python interface.
 
 # Public interface
 from ._basixcpp import __version__
-from . import cell, finite_element, lattice
+from . import cell, finite_element, lattice, variants
 from ._basixcpp import (CellType, LatticeType, LatticeSimplexMethod, create_lattice, ElementFamily,
                         create_element, LagrangeVariant)
 

--- a/python/basix/__init__.py
+++ b/python/basix/__init__.py
@@ -8,7 +8,8 @@ functionality can be used via this Python interface.
 # Public interface
 from ._basixcpp import __version__
 from . import cell, finite_element, lattice
-from ._basixcpp import CellType, LatticeType, LatticeSimplexMethod, create_lattice, ElementFamily, create_element
+from ._basixcpp import (CellType, LatticeType, LatticeSimplexMethod, create_lattice, ElementFamily,
+                        create_element, LagrangeVariant)
 
 # To possibly be removed
 from ._basixcpp import (topology, geometry, tabulate_polynomial_set,

--- a/python/basix/__init__.py
+++ b/python/basix/__init__.py
@@ -8,7 +8,7 @@ functionality can be used via this Python interface.
 # Public interface
 from ._basixcpp import __version__
 from . import cell, finite_element, lattice
-from ._basixcpp import CellType, LatticeType, create_lattice, ElementFamily, create_element
+from ._basixcpp import CellType, LatticeType, LatticeSimplexMethod, create_lattice, ElementFamily, create_element
 
 # To possibly be removed
 from ._basixcpp import (topology, geometry, tabulate_polynomial_set,

--- a/python/basix/lattice.py
+++ b/python/basix/lattice.py
@@ -1,13 +1,11 @@
 """Functions to create lattices and manipulate lattice types."""
 
 from ._basixcpp import LatticeType as _LT
+from ._basixcpp import LatticeSimplexMethod as _LSM
 
 
 def string_to_type(lattice: str):
     """Convert a string to a Basix LatticeType enum."""
-    if lattice == "gll":
-        return _LT.gll_warped
-
     if not hasattr(_LT, lattice):
         raise ValueError(f"Unknown lattice: {lattice}")
     return getattr(_LT, lattice)
@@ -16,3 +14,15 @@ def string_to_type(lattice: str):
 def type_to_string(latticetype: _LT):
     """Convert a Basix LatticeType enum to a string."""
     return latticetype.name
+
+
+def string_to_simplex_method(method: str):
+    """Convert a string to a Basix LatticeSimplexMethod enum."""
+    if not hasattr(_LSM, method):
+        raise ValueError(f"Unknown simplex method: {method}")
+    return getattr(_LSM, method)
+
+
+def simplex_method_to_string(simplex_method: _LSM):
+    """Convert a Basix LatticeSimplexMethod enum to a string."""
+    return simplex_method.name

--- a/python/basix/lattice.py
+++ b/python/basix/lattice.py
@@ -1,4 +1,4 @@
-"""Functions to create lattices and manipulate lattice types."""
+"""Functions to manipulate lattice types."""
 
 from ._basixcpp import LatticeType as _LT
 from ._basixcpp import LatticeSimplexMethod as _LSM

--- a/python/basix/variants.py
+++ b/python/basix/variants.py
@@ -5,6 +5,11 @@ from ._basixcpp import LagrangeVariant as _LV
 
 def string_to_lagrange_variant(variant: str):
     """Convert a string to a Basix LagrangeVariant enum."""
+    if variant == "gll":
+        return _LV.gll_warped
+    if variant == "chebyshev":
+        return _LV.chebyshev_warped
+
     if not hasattr(_LV, variant):
         raise ValueError(f"Unknown variant: {variant}")
     return getattr(_LV, variant)

--- a/python/basix/variants.py
+++ b/python/basix/variants.py
@@ -10,6 +10,6 @@ def string_to_lagrange_variant(variant: str):
     return getattr(_LV, variant)
 
 
-def lagrange_variant_to_string(variant: _LT):
+def lagrange_variant_to_string(variant: _LV):
     """Convert a Basix LagrangeVariant enum to a string."""
     return variant.name

--- a/python/basix/variants.py
+++ b/python/basix/variants.py
@@ -1,0 +1,15 @@
+"""Functions to manipulate variant types."""
+
+from ._basixcpp import LagrangeVariant as _LV
+
+
+def string_to_lagrange_variant(variant: str):
+    """Convert a string to a Basix LagrangeVariant enum."""
+    if not hasattr(_LV, variant):
+        raise ValueError(f"Unknown variant: {variant}")
+    return getattr(_LV, variant)
+
+
+def lagrange_variant_to_string(variant: _LT):
+    """Convert a Basix LagrangeVariant enum to a string."""
+    return variant.name

--- a/python/wrapper.cpp
+++ b/python/wrapper.cpp
@@ -439,18 +439,6 @@ Interface to the Basix C++ library.
 
   m.def(
       "create_element",
-      [](element::family family_name, cell::type cell_name, int degree,
-         lattice::type lattice_type, lattice::simplex_method simplex_method,
-         bool discontinuous) -> FiniteElement {
-        return basix::create_element(family_name, cell_name, degree,
-                                     lattice_type, simplex_method,
-                                     discontinuous);
-      },
-      "Create a FiniteElement of a given family, celltype, degree, lattice "
-      "type and lattice simplex method");
-
-  m.def(
-      "create_element",
       [](element::family family_name, cell::type cell_name,
          int degree) -> FiniteElement {
         return basix::create_element(family_name, cell_name, degree);
@@ -467,17 +455,6 @@ Interface to the Basix C++ library.
       },
       "Create a continuous FiniteElement of a given family, celltype, degree "
       "and lattice type");
-
-  m.def(
-      "create_element",
-      [](element::family family_name, cell::type cell_name, int degree,
-         lattice::type lattice_type,
-         lattice::simplex_method simplex_method) -> FiniteElement {
-        return basix::create_element(family_name, cell_name, degree,
-                                     lattice_type, simplex_method);
-      },
-      "Create a continuous FiniteElement of a given family, celltype, degree, "
-      "lattice type and lattice simplex method");
 
   m.def(
       "tabulate_polynomial_set",

--- a/python/wrapper.cpp
+++ b/python/wrapper.cpp
@@ -417,6 +417,13 @@ Interface to the Basix C++ library.
             return py::array_t<double>(P.shape(), P.data(), py::cast(self));
           });
 
+  py::enum_<element::lagrange_variant>(m, "LagrangeVariant")
+      .value("equispaced", element::lagrange_variant::equispaced)
+      .value("gll_warped", element::lagrange_variant::gll_warped)
+      .value("gll_isaac", element::lagrange_variant::gll_isaac)
+      .value("chebyshev_warped", element::lagrange_variant::chebyshev_warped)
+      .value("chebyshev_isaac", element::lagrange_variant::chebyshev_isaac);
+
   // Create FiniteElement
   m.def(
       "create_element",
@@ -430,12 +437,13 @@ Interface to the Basix C++ library.
   m.def(
       "create_element",
       [](element::family family_name, cell::type cell_name, int degree,
-         lattice::type lattice_type, bool discontinuous) -> FiniteElement {
-        return basix::create_element(family_name, cell_name, degree,
-                                     lattice_type, discontinuous);
+         element::lagrange_variant variant,
+         bool discontinuous) -> FiniteElement {
+        return basix::create_element(family_name, cell_name, degree, variant,
+                                     discontinuous);
       },
-      "Create a FiniteElement of a given family, celltype, degree and lattice "
-      "type");
+      "Create a FiniteElement of a given family, celltype, degree and Lagrange "
+      "variant");
 
   m.def(
       "create_element",
@@ -449,12 +457,11 @@ Interface to the Basix C++ library.
   m.def(
       "create_element",
       [](element::family family_name, cell::type cell_name, int degree,
-         lattice::type lattice_type) -> FiniteElement {
-        return basix::create_element(family_name, cell_name, degree,
-                                     lattice_type);
+         element::lagrange_variant variant) -> FiniteElement {
+        return basix::create_element(family_name, cell_name, degree, variant);
       },
       "Create a continuous FiniteElement of a given family, celltype, degree "
-      "and lattice type");
+      "and Lagrange variant");
 
   m.def(
       "tabulate_polynomial_set",

--- a/python/wrapper.cpp
+++ b/python/wrapper.cpp
@@ -130,22 +130,37 @@ Interface to the Basix C++ library.
 
   py::enum_<lattice::type>(m, "LatticeType")
       .value("equispaced", lattice::type::equispaced)
-      .value("gll_warped", lattice::type::gll_warped)
-      .value("gll_isaac", lattice::type::gll_isaac)
-      .value("chebyshev_warped", lattice::type::chebyshev_warped)
-      .value("chebyshev_isaac", lattice::type::chebyshev_isaac);
+      .value("gll", lattice::type::gll)
+      .value("chebyshev", lattice::type::chebyshev);
+
+  py::enum_<lattice::simplex_method>(m, "LatticeSimplexMethod")
+      .value("none", lattice::simplex_method::none)
+      .value("warp", lattice::simplex_method::warp)
+      .value("isaac", lattice::simplex_method::isaac);
 
   m.def(
       "create_lattice",
-      [](cell::type celltype, int n, lattice::type type, bool exterior)
-      {
-        auto l = lattice::create(celltype, n, type, exterior);
+      [](cell::type celltype, int n, lattice::type type, bool exterior) {
+        auto l = lattice::create(celltype, n, type, exterior,
+                                 lattice::simplex_method::none);
         auto strides = l.strides();
         for (auto& s : strides)
           s *= sizeof(double);
         return py::array_t<double>(l.shape(), strides, l.data());
       },
-      "Create a uniform lattice of points on a reference cell");
+      "Create a lattice of points on a reference cell");
+
+  m.def(
+      "create_lattice",
+      [](cell::type celltype, int n, lattice::type type, bool exterior,
+         lattice::simplex_method method) {
+        auto l = lattice::create(celltype, n, type, exterior, method);
+        auto strides = l.strides();
+        for (auto& s : strides)
+          s *= sizeof(double);
+        return py::array_t<double>(l.shape(), strides, l.data());
+      },
+      "Create a lattice of points on a reference cell");
 
   py::enum_<maps::type>(m, "MappingType")
       .value("identity", maps::type::identity)
@@ -424,6 +439,18 @@ Interface to the Basix C++ library.
 
   m.def(
       "create_element",
+      [](element::family family_name, cell::type cell_name, int degree,
+         lattice::type lattice_type, lattice::simplex_method simplex_method,
+         bool discontinuous) -> FiniteElement {
+        return basix::create_element(family_name, cell_name, degree,
+                                     lattice_type, simplex_method,
+                                     discontinuous);
+      },
+      "Create a FiniteElement of a given family, celltype, degree, lattice "
+      "type and lattice simplex method");
+
+  m.def(
+      "create_element",
       [](element::family family_name, cell::type cell_name,
          int degree) -> FiniteElement {
         return basix::create_element(family_name, cell_name, degree);
@@ -439,8 +466,18 @@ Interface to the Basix C++ library.
                                      lattice_type);
       },
       "Create a continuous FiniteElement of a given family, celltype, degree "
-      "and lattice "
-      "type");
+      "and lattice type");
+
+  m.def(
+      "create_element",
+      [](element::family family_name, cell::type cell_name, int degree,
+         lattice::type lattice_type,
+         lattice::simplex_method simplex_method) -> FiniteElement {
+        return basix::create_element(family_name, cell_name, degree,
+                                     lattice_type, simplex_method);
+      },
+      "Create a continuous FiniteElement of a given family, celltype, degree, "
+      "lattice type and lattice simplex method");
 
   m.def(
       "tabulate_polynomial_set",

--- a/python/wrapper.cpp
+++ b/python/wrapper.cpp
@@ -131,7 +131,9 @@ Interface to the Basix C++ library.
   py::enum_<lattice::type>(m, "LatticeType")
       .value("equispaced", lattice::type::equispaced)
       .value("gll_warped", lattice::type::gll_warped)
-      .value("gll_isaac", lattice::type::gll_isaac);
+      .value("gll_isaac", lattice::type::gll_isaac)
+      .value("chebyshev_warped", lattice::type::chebyshev_warped)
+      .value("chebyshev_isaac", lattice::type::chebyshev_isaac);
 
   m.def(
       "create_lattice",

--- a/test/test_interpolation.py
+++ b/test/test_interpolation.py
@@ -12,7 +12,7 @@ from .utils import parametrize_over_elements
 @pytest.mark.parametrize("cell_type", [basix.CellType.interval, basix.CellType.triangle, basix.CellType.tetrahedron])
 @pytest.mark.parametrize("element_type", [basix.ElementFamily.P])
 def test_interpolation(cell_type, n, element_type):
-    element = basix.create_element(element_type, cell_type, n, basix.LatticeType.gll_warped)
+    element = basix.create_element(element_type, cell_type, n, basix.LatticeType.gll, basix.LatticeSimplexMethod.warp)
     assert element.interpolation_matrix.shape[0] == element.dim
     assert element.interpolation_matrix.shape[1] == element.points.shape[0]
     assert element.points.shape[1] == len(basix.topology(element.cell_type)) - 1

--- a/test/test_interpolation.py
+++ b/test/test_interpolation.py
@@ -12,7 +12,7 @@ from .utils import parametrize_over_elements
 @pytest.mark.parametrize("cell_type", [basix.CellType.interval, basix.CellType.triangle, basix.CellType.tetrahedron])
 @pytest.mark.parametrize("element_type", [basix.ElementFamily.P])
 def test_interpolation(cell_type, n, element_type):
-    element = basix.create_element(element_type, cell_type, n, basix.LatticeType.gll, basix.LatticeSimplexMethod.warp)
+    element = basix.create_element(element_type, cell_type, n, basix.LagrangeVariant.gll_warped)
     assert element.interpolation_matrix.shape[0] == element.dim
     assert element.interpolation_matrix.shape[1] == element.points.shape[0]
     assert element.points.shape[1] == len(basix.topology(element.cell_type)) - 1

--- a/test/test_lagrange.py
+++ b/test/test_lagrange.py
@@ -86,7 +86,7 @@ def test_line(n):
     g = sympy_lagrange(celltype, n)
     x = sympy.Symbol("x")
     lagrange = basix.create_element(basix.ElementFamily.P, basix.CellType.interval, n,
-                                    basix.LatticeType.equispaced)
+                                    basix.LagrangeVariant.equispaced)
     pts = basix.create_lattice(celltype, 6, basix.LatticeType.equispaced, True)
     nderiv = n
     wtab = lagrange.tabulate(nderiv, pts)
@@ -107,7 +107,7 @@ def test_tri(degree):
     x = sympy.Symbol("x")
     y = sympy.Symbol("y")
     lagrange = basix.create_element(basix.ElementFamily.P, basix.CellType.triangle, degree,
-                                    basix.LatticeType.equispaced)
+                                    basix.LagrangeVariant.equispaced)
     pts = basix.create_lattice(celltype, 6, basix.LatticeType.equispaced, True)
     nderiv = 3
     wtab = lagrange.tabulate(nderiv, pts)
@@ -131,7 +131,7 @@ def test_tet(degree):
     y = sympy.Symbol("y")
     z = sympy.Symbol("z")
     lagrange = basix.create_element(basix.ElementFamily.P, basix.CellType.tetrahedron, degree,
-                                    basix.LatticeType.equispaced)
+                                    basix.LagrangeVariant.equispaced)
     pts = basix.create_lattice(celltype, 6,
                                basix.LatticeType.equispaced, True)
     nderiv = 1
@@ -158,7 +158,7 @@ def test_tet(degree):
 @pytest.mark.parametrize("degree", [1, 2, 3, 4])
 def test_lagrange(celltype, degree):
     lagrange = basix.create_element(basix.ElementFamily.P, celltype[1], degree,
-                                    basix.LatticeType.equispaced)
+                                    basix.LagrangeVariant.equispaced)
     pts = basix.create_lattice(celltype[0], 6, basix.LatticeType.equispaced, True)
     w = lagrange.tabulate(0, pts)[0]
     assert(numpy.isclose(numpy.sum(w, axis=1), 1.0).all())
@@ -167,14 +167,14 @@ def test_lagrange(celltype, degree):
 @pytest.mark.parametrize("degree", [1, 2, 3, 4])
 def test_dof_transformations_interval(degree):
     lagrange = basix.create_element(basix.ElementFamily.P, basix.CellType.interval, degree,
-                                    basix.LatticeType.equispaced)
+                                    basix.LagrangeVariant.equispaced)
     assert len(lagrange.base_transformations()) == 0
 
 
 @pytest.mark.parametrize("degree", [1, 2, 3, 4])
 def test_dof_transformations_triangle(degree):
     lagrange = basix.create_element(basix.ElementFamily.P, basix.CellType.triangle, degree,
-                                    basix.LatticeType.equispaced)
+                                    basix.LagrangeVariant.equispaced)
 
     permuted = {}
     if degree == 3:
@@ -204,7 +204,7 @@ def test_dof_transformations_triangle(degree):
 @pytest.mark.parametrize("degree", [1, 2, 3, 4])
 def test_dof_transformations_tetrahedron(degree):
     lagrange = basix.create_element(basix.ElementFamily.P, basix.CellType.tetrahedron, degree,
-                                    basix.LatticeType.equispaced)
+                                    basix.LagrangeVariant.equispaced)
 
     permuted = {}
     if degree == 3:
@@ -255,8 +255,44 @@ def test_dof_transformations_tetrahedron(degree):
 ])
 def test_celltypes(degree, celltype):
     tp = basix.create_element(basix.ElementFamily.P, celltype, degree,
-                              basix.LatticeType.equispaced)
+                              basix.LagrangeVariant.equispaced)
     pts = basix.create_lattice(celltype, 5,
                                basix.LatticeType.equispaced, True)
     w = tp.tabulate(0, pts)[0]
     assert(numpy.allclose(numpy.sum(w, axis=1), 1.0))
+
+
+def leq(a, b):
+    return a <= b or numpy.isclose(a, b)
+
+
+def in_cell(celltype, p):
+    if celltype == basix.CellType.interval:
+        return leq(0, p[0]) and leq(p[0], 1)
+    if celltype == basix.CellType.triangle:
+        return leq(0, p[0]) and leq(0, p[1]) and leq(p[0] + p[1], 1)
+    if celltype == basix.CellType.tetrahedron:
+        return leq(0, p[0]) and leq(0, p[1]) and leq(0, p[2]) and leq(p[0] + p[1] + p[2], 1)
+    if celltype == basix.CellType.quadrilateral:
+        return leq(0, p[0]) and leq(0, p[1]) and leq(p[0], 1) and leq(p[1], 1)
+    if celltype == basix.CellType.hexahedron:
+        return leq(0, p[0]) and leq(0, p[1]) and leq(0, p[2]) and leq(p[0], 1) and leq(p[1], 1) and leq(p[2], 1)
+    if celltype == basix.CellType.prism:
+        return leq(0, p[0]) and leq(0, p[1]) and leq(0, p[2]) and leq(p[0] + p[1], 1) and leq(p[2], 1)
+
+
+@pytest.mark.parametrize("variant", [
+    basix.LagrangeVariant.equispaced,
+    basix.LagrangeVariant.gll_warped, basix.LagrangeVariant.gll_isaac,
+    basix.LagrangeVariant.chebyshev_warped, basix.LagrangeVariant.chebyshev_isaac,
+])
+@pytest.mark.parametrize("celltype", [
+    basix.CellType.triangle, basix.CellType.tetrahedron,
+    basix.CellType.quadrilateral, basix.CellType.hexahedron,
+])
+@pytest.mark.parametrize("degree", range(1, 5))
+def test_variant_points(celltype, degree, variant):
+    e = basix.create_element(basix.ElementFamily.P, celltype, 4, variant, True)
+
+    for p in e.points:
+        assert in_cell(celltype, p)

--- a/test/test_lattice.py
+++ b/test/test_lattice.py
@@ -45,7 +45,9 @@ def test_pyramid(n, lattice_type):
 
 
 @pytest.mark.parametrize("lattice_type", [
-    basix.LatticeType.equispaced, basix.LatticeType.gll_isaac, basix.LatticeType.gll_warped
+    basix.LatticeType.equispaced,
+    basix.LatticeType.gll_isaac, basix.LatticeType.gll_warped,
+    basix.LatticeType.chebyshev_isaac, basix.LatticeType.chebyshev_warped,
 ])
 @pytest.mark.parametrize("n", [1, 2, 4, 8])
 def test_tetrahedron(n, lattice_type):
@@ -76,7 +78,9 @@ def test_tetrahedron(n, lattice_type):
 
 
 @pytest.mark.parametrize("lattice_type", [
-    basix.LatticeType.equispaced, basix.LatticeType.gll_isaac, basix.LatticeType.gll_warped
+    basix.LatticeType.equispaced,
+    basix.LatticeType.gll_isaac, basix.LatticeType.gll_warped,
+    basix.LatticeType.chebyshev_isaac, basix.LatticeType.chebyshev_warped,
 ])
 @pytest.mark.parametrize("n", [1, 2, 4, 8])
 def test_triangle(n, lattice_type):

--- a/test/test_lattice.py
+++ b/test/test_lattice.py
@@ -7,16 +7,17 @@ import basix
 import numpy as np
 
 
-@pytest.mark.parametrize("lattice_type", [
-    basix.LatticeType.equispaced  # basix.LatticeType.gll_isaac, basix.LatticeType.gll_warped
+@pytest.mark.parametrize("lattice_type, simplex_method", [
+    (basix.LatticeType.equispaced, basix.LatticeSimplexMethod.none),
+    # (basix.LatticeType.gll, basix.LatticeSimplexMethod.warp),
 ])
 @pytest.mark.parametrize("n", [1, 2, 4, 8])
-def test_pyramid(n, lattice_type):
+def test_pyramid(n, lattice_type, simplex_method):
     # Check that all the surface points of the pyramid match up with the
     # same points on quad and triangle
-    tri_pts = basix.create_lattice(basix.CellType.triangle, n, lattice_type, True)
-    quad_pts = basix.create_lattice(basix.CellType.quadrilateral, n, lattice_type, True)
-    pyr_pts = basix.create_lattice(basix.CellType.pyramid, n, lattice_type, True)
+    tri_pts = basix.create_lattice(basix.CellType.triangle, n, lattice_type, True, simplex_method)
+    quad_pts = basix.create_lattice(basix.CellType.quadrilateral, n, lattice_type, True, simplex_method)
+    pyr_pts = basix.create_lattice(basix.CellType.pyramid, n, lattice_type, True, simplex_method)
 
     # Remove any near-zero values to make sorting robust
     pyr_pts[np.where(abs(pyr_pts) < 1e-12)] = 0.0
@@ -44,17 +45,17 @@ def test_pyramid(n, lattice_type):
     assert np.allclose(np.sort(quad_pts), np.sort(pyr_z0))
 
 
-@pytest.mark.parametrize("lattice_type", [
-    basix.LatticeType.equispaced,
-    basix.LatticeType.gll_isaac, basix.LatticeType.gll_warped,
-    basix.LatticeType.chebyshev_isaac, basix.LatticeType.chebyshev_warped,
+@pytest.mark.parametrize("lattice_type, simplex_method", [
+    (basix.LatticeType.equispaced, basix.LatticeSimplexMethod.none),
+    (basix.LatticeType.gll, basix.LatticeSimplexMethod.warp),
+    (basix.LatticeType.gll, basix.LatticeSimplexMethod.isaac),
 ])
 @pytest.mark.parametrize("n", [1, 2, 4, 8])
-def test_tetrahedron(n, lattice_type):
+def test_tetrahedron(n, lattice_type, simplex_method):
     # Check that all the surface points of the tet match up with the same points on
     # triangle
-    tri_pts = basix.create_lattice(basix.CellType.triangle, n, lattice_type, True)
-    tet_pts = basix.create_lattice(basix.CellType.tetrahedron, n, lattice_type, True)
+    tri_pts = basix.create_lattice(basix.CellType.triangle, n, lattice_type, True, simplex_method)
+    tet_pts = basix.create_lattice(basix.CellType.tetrahedron, n, lattice_type, True, simplex_method)
 
     tet_pts[np.where(abs(tet_pts) < 1e-12)] = 0.0
     tri_pts[np.where(abs(tri_pts) < 1e-12)] = 0.0
@@ -77,17 +78,17 @@ def test_tetrahedron(n, lattice_type):
     assert np.allclose(np.sort(tri_pts), np.sort(tet_xyz))
 
 
-@pytest.mark.parametrize("lattice_type", [
-    basix.LatticeType.equispaced,
-    basix.LatticeType.gll_isaac, basix.LatticeType.gll_warped,
-    basix.LatticeType.chebyshev_isaac, basix.LatticeType.chebyshev_warped,
+@pytest.mark.parametrize("lattice_type, simplex_method", [
+    (basix.LatticeType.equispaced, basix.LatticeSimplexMethod.none),
+    (basix.LatticeType.gll, basix.LatticeSimplexMethod.warp),
+    (basix.LatticeType.gll, basix.LatticeSimplexMethod.isaac),
 ])
 @pytest.mark.parametrize("n", [1, 2, 4, 8])
-def test_triangle(n, lattice_type):
+def test_triangle(n, lattice_type, simplex_method):
     # Check that all the surface points of the triangle match up with the same points on
     # an interval
-    tri_pts = basix.create_lattice(basix.CellType.triangle, n, lattice_type, True)
-    interval_pts = basix.create_lattice(basix.CellType.interval, n, lattice_type, True)
+    tri_pts = basix.create_lattice(basix.CellType.triangle, n, lattice_type, True, simplex_method)
+    interval_pts = basix.create_lattice(basix.CellType.interval, n, lattice_type, True, simplex_method)
 
     tri_pts[np.where(abs(tri_pts) < 1e-12)] = 0.0
     interval_pts[np.where(abs(interval_pts) < 1e-12)] = 0.0

--- a/test/test_mappings.py
+++ b/test/test_mappings.py
@@ -8,7 +8,7 @@ import pytest
 import numpy as np
 
 elements = [
-    (basix.ElementFamily.P, [basix.LatticeType.gll_warped]),  # identity
+    (basix.ElementFamily.P, [basix.LatticeType.gll, basix.LatticeSimplexMethod.warp]),  # identity
     (basix.ElementFamily.N1E, []),  # covariant Piola
     (basix.ElementFamily.RT, []),  # contravariant Piola
     (basix.ElementFamily.Regge, []),  # double covariant Piola

--- a/test/test_mappings.py
+++ b/test/test_mappings.py
@@ -8,7 +8,7 @@ import pytest
 import numpy as np
 
 elements = [
-    (basix.ElementFamily.P, [basix.LatticeType.gll, basix.LatticeSimplexMethod.warp]),  # identity
+    (basix.ElementFamily.P, [basix.LagrangeVariant.gll_warped]),  # identity
     (basix.ElementFamily.N1E, []),  # covariant Piola
     (basix.ElementFamily.RT, []),  # contravariant Piola
     (basix.ElementFamily.Regge, []),  # double covariant Piola

--- a/test/test_numba.py
+++ b/test/test_numba.py
@@ -8,8 +8,8 @@ import pytest
 @pytest.mark.parametrize("cell", [basix.CellType.triangle, basix.CellType.tetrahedron,
                                   basix.CellType.quadrilateral, basix.CellType.hexahedron])
 @pytest.mark.parametrize("element, degree, element_args", [
-    (basix.ElementFamily.P, 1, [basix.LatticeType.gll_warped]),
-    (basix.ElementFamily.P, 3, [basix.LatticeType.gll_warped]),
+    (basix.ElementFamily.P, 1, [basix.LatticeType.gll, basix.LatticeSimplexMethod.warp]),
+    (basix.ElementFamily.P, 3, [basix.LatticeType.gll, basix.LatticeSimplexMethod.warp]),
     (basix.ElementFamily.N1E, 3, [])
 ])
 @pytest.mark.parametrize("block_size", [1, 2, 4])
@@ -61,8 +61,8 @@ def test_dof_transformations(cell, element, degree, element_args, block_size):
 @pytest.mark.parametrize("cell", [basix.CellType.triangle, basix.CellType.tetrahedron,
                                   basix.CellType.quadrilateral, basix.CellType.hexahedron])
 @pytest.mark.parametrize("element, degree, element_args", [
-    (basix.ElementFamily.P, 1, [basix.LatticeType.gll_warped]),
-    (basix.ElementFamily.P, 3, [basix.LatticeType.gll_warped]),
+    (basix.ElementFamily.P, 1, [basix.LatticeType.gll, basix.LatticeSimplexMethod.warp]),
+    (basix.ElementFamily.P, 3, [basix.LatticeType.gll, basix.LatticeSimplexMethod.warp]),
     (basix.ElementFamily.N1E, 3, [])
 ])
 @pytest.mark.parametrize("block_size", [1, 2, 4])

--- a/test/test_numba.py
+++ b/test/test_numba.py
@@ -8,8 +8,8 @@ import pytest
 @pytest.mark.parametrize("cell", [basix.CellType.triangle, basix.CellType.tetrahedron,
                                   basix.CellType.quadrilateral, basix.CellType.hexahedron])
 @pytest.mark.parametrize("element, degree, element_args", [
-    (basix.ElementFamily.P, 1, [basix.LatticeType.gll, basix.LatticeSimplexMethod.warp]),
-    (basix.ElementFamily.P, 3, [basix.LatticeType.gll, basix.LatticeSimplexMethod.warp]),
+    (basix.ElementFamily.P, 1, [basix.LagrangeVariant.gll_warped]),
+    (basix.ElementFamily.P, 3, [basix.LagrangeVariant.gll_warped]),
     (basix.ElementFamily.N1E, 3, [])
 ])
 @pytest.mark.parametrize("block_size", [1, 2, 4])
@@ -61,8 +61,8 @@ def test_dof_transformations(cell, element, degree, element_args, block_size):
 @pytest.mark.parametrize("cell", [basix.CellType.triangle, basix.CellType.tetrahedron,
                                   basix.CellType.quadrilateral, basix.CellType.hexahedron])
 @pytest.mark.parametrize("element, degree, element_args", [
-    (basix.ElementFamily.P, 1, [basix.LatticeType.gll, basix.LatticeSimplexMethod.warp]),
-    (basix.ElementFamily.P, 3, [basix.LatticeType.gll, basix.LatticeSimplexMethod.warp]),
+    (basix.ElementFamily.P, 1, [basix.LagrangeVariant.gll_warped]),
+    (basix.ElementFamily.P, 3, [basix.LagrangeVariant.gll_warped]),
     (basix.ElementFamily.N1E, 3, [])
 ])
 @pytest.mark.parametrize("block_size", [1, 2, 4])

--- a/test/utils.py
+++ b/test/utils.py
@@ -9,23 +9,18 @@ import basix
 def parametrize_over_elements(degree, reference=None):
     elementlist = []
 
-    elementlist += [(c, basix.ElementFamily.P, o, [basix.LatticeType.gll_isaac])
+    elementlist += [(c, basix.ElementFamily.P, o, [basix.LatticeType.gll, basix.LatticeSimplexMethod.isaac])
                     for c in [basix.CellType.interval, basix.CellType.triangle,
                               basix.CellType.tetrahedron,
                               basix.CellType.quadrilateral, basix.CellType.hexahedron,
                               basix.CellType.prism]
                     for o in range(1, degree + 1)]
-    elementlist += [(c, basix.ElementFamily.P, o, [basix.LatticeType.gll_warped])
+    elementlist += [(c, basix.ElementFamily.P, o, [basix.LatticeType.gll, basix.LatticeSimplexMethod.warp])
                     for c in [basix.CellType.interval, basix.CellType.triangle,
                               basix.CellType.tetrahedron,
                               basix.CellType.quadrilateral, basix.CellType.hexahedron,
                               basix.CellType.prism]
                     for o in range(1, degree + 1)]
-    elementlist += [(c, basix.ElementFamily.P, o, [basix.LatticeType.gll_isaac, True])
-                    for c in [basix.CellType.interval, basix.CellType.triangle,
-                              basix.CellType.tetrahedron,
-                              basix.CellType.quadrilateral, basix.CellType.hexahedron]
-                    for o in range(0, degree + 1)]
     elementlist += [(c, basix.ElementFamily.P, o, [basix.LatticeType.equispaced])
                     for c in [basix.CellType.interval, basix.CellType.triangle,
                               basix.CellType.tetrahedron,

--- a/test/utils.py
+++ b/test/utils.py
@@ -9,19 +9,19 @@ import basix
 def parametrize_over_elements(degree, reference=None):
     elementlist = []
 
-    elementlist += [(c, basix.ElementFamily.P, o, [basix.LatticeType.gll, basix.LatticeSimplexMethod.isaac])
+    elementlist += [(c, basix.ElementFamily.P, o, [basix.LagrangeVariant.gll_isaac])
                     for c in [basix.CellType.interval, basix.CellType.triangle,
                               basix.CellType.tetrahedron,
                               basix.CellType.quadrilateral, basix.CellType.hexahedron,
                               basix.CellType.prism]
                     for o in range(1, degree + 1)]
-    elementlist += [(c, basix.ElementFamily.P, o, [basix.LatticeType.gll, basix.LatticeSimplexMethod.warp])
+    elementlist += [(c, basix.ElementFamily.P, o, [basix.LagrangeVariant.gll_warped])
                     for c in [basix.CellType.interval, basix.CellType.triangle,
                               basix.CellType.tetrahedron,
                               basix.CellType.quadrilateral, basix.CellType.hexahedron,
                               basix.CellType.prism]
                     for o in range(1, degree + 1)]
-    elementlist += [(c, basix.ElementFamily.P, o, [basix.LatticeType.equispaced])
+    elementlist += [(c, basix.ElementFamily.P, o, [basix.LagrangeVariant.equispaced])
                     for c in [basix.CellType.interval, basix.CellType.triangle,
                               basix.CellType.tetrahedron,
                               basix.CellType.quadrilateral, basix.CellType.hexahedron,


### PR DESCRIPTION
Added Chebyshev points as a lattice to be used for creating Lagrange elements. This new variant can only be used for discontinuous Lagrange elements, as the endpoints are not included in the Chebyshev points.

For simplices, the Chebyshev points are created by defining the Chebyshev points on an interval, adding the end points then using warping or Isaac's method to create points in the cell. (This can probably be improved on)

The Lebesgue constants for these points (compared to equispaced and GLL points) are shown here:

![Figure_4](https://user-images.githubusercontent.com/9850599/133981935-98fb25f3-a576-4d26-9e47-66a6037663cb.png)

Other changed in this PR that may need discussing before merging:

- Replaced `lattice::type` with `lattice::type` and `lattice::simplex_method`, as each lattice type can have a warped or isaac variant and it made sense to me to split the point spacing on an interval from the method used to turn this into points on non-TP cells.
- Added `element::lagrange_variant` and made Lagrange elements take this as in input instead of a lattice type. This is because (eg) Chebyshev points are ordered differently so taking the Chebyshev variant does more than just change the lattice type. It also would allow us to support other variants of Lagrange (eg. variant where basis functions are orthonormal polynomials, variant with integral moments) where the change is not just due to a different Lattice.