### PR TITLE
Fix for 'maybe unused' variable in release mode

### DIFF
--- a/cpp/basix/moments.cpp
+++ b/cpp/basix/moments.cpp
@@ -395,9 +395,7 @@ moments::make_dot_integral_moments(const FiniteElement& V, cell::type celltype,
   auto wts = xt::adapt(_wts);
 
   // If this is always true, value_size input can be removed
-  [[maybe_unused]] const std::size_t tdim
-      = cell::topological_dimension(celltype);
-  assert(tdim == value_size);
+  assert(cell::topological_dimension(celltype) == value_size);
 
   // Evaluate moment space at quadrature points
   xt::xtensor<double, 3> phi

--- a/cpp/basix/moments.cpp
+++ b/cpp/basix/moments.cpp
@@ -389,13 +389,14 @@ moments::make_dot_integral_moments(const FiniteElement& V, cell::type celltype,
   const cell::type sub_celltype = V.cell_type();
   const std::size_t entity_dim = cell::topological_dimension(sub_celltype);
   const std::size_t num_entities = cell::num_sub_entities(celltype, entity_dim);
-  const std::size_t tdim = cell::topological_dimension(celltype);
 
   auto [pts, _wts] = quadrature::make_quadrature(quadrature::type::Default,
                                                  sub_celltype, q_deg);
   auto wts = xt::adapt(_wts);
 
   // If this is always true, value_size input can be removed
+  [[maybe_unused]] const std::size_t tdim
+      = cell::topological_dimension(celltype);
   assert(tdim == value_size);
 
   // Evaluate moment space at quadrature points

--- a/cpp/basix/moments.cpp
+++ b/cpp/basix/moments.cpp
@@ -395,7 +395,7 @@ moments::make_dot_integral_moments(const FiniteElement& V, cell::type celltype,
   auto wts = xt::adapt(_wts);
 
   // If this is always true, value_size input can be removed
-  assert(cell::topological_dimension(celltype) == value_size);
+  assert(std::size_t(cell::topological_dimension(celltype)) == value_size);
 
   // Evaluate moment space at quadrature points
   xt::xtensor<double, 3> phi


### PR DESCRIPTION
`tdim` is only used in an assertion, and will there be unused if running in `Release` mode.