### PR TITLE
Remove redundant function `FiniteElement::num_points`

### DIFF
--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -723,8 +723,6 @@ xt::xtensor<double, 3> FiniteElement::base_transformations() const
   return bt;
 }
 //-----------------------------------------------------------------------------
-int FiniteElement::num_points() const { return _points.shape(0); }
-//-----------------------------------------------------------------------------
 const xt::xtensor<double, 2>& FiniteElement::points() const { return _points; }
 //-----------------------------------------------------------------------------
 xt::xtensor<double, 3> FiniteElement::map_push_forward(

--- a/cpp/basix/finite-element.h
+++ b/cpp/basix/finite-element.h
@@ -707,9 +707,6 @@ public:
   /// @return Array of coordinate with shape `(num_points, tdim)`
   const xt::xtensor<double, 2>& points() const;
 
-  /// Return the number of interpolation points
-  int num_points() const;
-
   /// Return a matrix of weights interpolation
   /// To interpolate a function in this finite element, the functions
   /// should be evaluated at each point given by


### PR DESCRIPTION
Can get the data using `element.points().shape(0)`.