### PR TITLE
Remove `compute_expansion_coefficients` and store dual matrix

### DIFF
--- a/cpp/basix/cell.cpp
+++ b/cpp/basix/cell.cpp
@@ -15,7 +15,7 @@ xt::xtensor<double, 2> cell::geometry(cell::type celltype)
   switch (celltype)
   {
   case cell::type::point:
-    return xt::xtensor<double, 2>({{0.0}});
+    return xt::xtensor<double, 2>({{}});
   case cell::type::interval:
     return xt::xtensor<double, 2>({{0.0}, {1.0}});
   case cell::type::triangle:

--- a/cpp/basix/e-brezzi-douglas-marini.cpp
+++ b/cpp/basix/e-brezzi-douglas-marini.cpp
@@ -76,13 +76,8 @@ FiniteElement basix::element::create_bdm(cell::type celltype, int degree,
         = element::make_discontinuous(x, M, entity_transformations, tdim, tdim);
   }
 
-  // Create coefficients for order (degree-1) vector polynomials
-  xt::xtensor<double, 3> coeffs = element::compute_expansion_coefficients(
-      celltype, xt::eye<double>(ndofs), {M[tdim - 1], M[tdim]},
-      {x[tdim - 1], x[tdim]}, degree);
-
-  return FiniteElement(element::family::BDM, celltype, degree, {tdim}, coeffs,
-                       entity_transformations, x, M,
+  return FiniteElement(element::family::BDM, celltype, degree, {tdim},
+                       xt::eye<double>(ndofs), entity_transformations, x, M,
                        maps::type::contravariantPiola, discontinuous);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/basix/e-bubble.cpp
+++ b/cpp/basix/e-bubble.cpp
@@ -159,9 +159,7 @@ FiniteElement basix::element::create_bubble(cell::type celltype, int degree,
   M[tdim].push_back(xt::xtensor<double, 3>({ndofs, 1, ndofs}));
   xt::view(M[tdim][0], xt::all(), 0, xt::all()) = xt::eye<double>(ndofs);
 
-  xt::xtensor<double, 3> coeffs = element::compute_expansion_coefficients(
-      celltype, wcoeffs, {M[tdim]}, {x[tdim]}, degree);
-  return FiniteElement(element::family::bubble, celltype, degree, {1}, coeffs,
+  return FiniteElement(element::family::bubble, celltype, degree, {1}, wcoeffs,
                        entity_transformations, x, M, maps::type::identity,
                        discontinuous);
 }

--- a/cpp/basix/e-crouzeix-raviart.cpp
+++ b/cpp/basix/e-crouzeix-raviart.cpp
@@ -70,10 +70,8 @@ FiniteElement basix::element::create_cr(cell::type celltype, int degree,
         = element::make_discontinuous(x, M, entity_transformations, tdim, 1);
   }
 
-  const xt::xtensor<double, 3> coeffs = element::compute_expansion_coefficients(
-      celltype, xt::eye<double>(ndofs), {M[tdim - 1]}, {x[tdim - 1]}, degree);
-  return FiniteElement(element::family::CR, celltype, 1, {1}, coeffs,
-                       entity_transformations, x, M, maps::type::identity,
-                       discontinuous);
+  return FiniteElement(element::family::CR, celltype, 1, {1},
+                       xt::eye<double>(ndofs), entity_transformations, x, M,
+                       maps::type::identity, discontinuous);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/basix/e-lagrange.cpp
+++ b/cpp/basix/e-lagrange.cpp
@@ -788,12 +788,12 @@ FiniteElement basix::element::create_lagrange(cell::type celltype, int degree,
 
     std::array<std::vector<xt::xtensor<double, 3>>, 4> M;
     std::array<std::vector<xt::xtensor<double, 2>>, 4> x;
-    x[0].push_back({{0}});
+    x[0].push_back(xt::zeros<double>({1, 0}));
     M[0].push_back({{{1}}});
     std::map<cell::type, xt::xtensor<double, 3>> entity_transformations;
-    xt::xtensor<double, 3> coeffs = {{{1}}};
+    xt::xtensor<double, 2> wcoeffs = {{1}};
 
-    return FiniteElement(element::family::P, cell::type::point, 0, {1}, coeffs,
+    return FiniteElement(element::family::P, cell::type::point, 0, {1}, wcoeffs,
                          entity_transformations, x, M, maps::type::identity,
                          discontinuous);
   }

--- a/cpp/basix/e-lagrange.cpp
+++ b/cpp/basix/e-lagrange.cpp
@@ -788,7 +788,7 @@ FiniteElement basix::element::create_lagrange(cell::type celltype, int degree,
 
     std::array<std::vector<xt::xtensor<double, 3>>, 4> M;
     std::array<std::vector<xt::xtensor<double, 2>>, 4> x;
-    x[0].push_back(xt::xtensor<double, 2>({1, 0}));
+    x[0].push_back({{0}});
     M[0].push_back({{{1}}});
     std::map<cell::type, xt::xtensor<double, 3>> entity_transformations;
     xt::xtensor<double, 3> coeffs = {{{1}}};

--- a/cpp/basix/e-lagrange.cpp
+++ b/cpp/basix/e-lagrange.cpp
@@ -139,12 +139,9 @@ FiniteElement create_d_lagrange(cell::type celltype, int degree,
     entity_transformations[cell::type::quadrilateral] = ft;
   }
 
-  xt::xtensor<double, 3> coeffs = element::compute_expansion_coefficients(
-      celltype, xt::eye<double>(ndofs), {M[0], M[1], M[2], M[3]},
-      {x[0], x[1], x[2], x[3]}, degree);
-  return FiniteElement(element::family::P, celltype, degree, {1}, coeffs,
-                       entity_transformations, x, M, maps::type::identity,
-                       true);
+  return FiniteElement(element::family::P, celltype, degree, {1},
+                       xt::eye<double>(ndofs), entity_transformations, x, M,
+                       maps::type::identity, true);
 }
 //-----------------------------------------------------------------------------
 xt::xtensor<double, 2> vtk_triangle_points(int degree)
@@ -772,12 +769,9 @@ FiniteElement create_vtk_element(cell::type celltype, int degree,
         = element::make_discontinuous(x, M, entity_transformations, tdim, 1);
   }
 
-  xt::xtensor<double, 3> coeffs = element::compute_expansion_coefficients(
-      celltype, xt::eye<double>(ndofs), {M[0], M[1], M[2], M[3]},
-      {x[0], x[1], x[2], x[3]}, degree);
-  return FiniteElement(element::family::P, celltype, degree, {1}, coeffs,
-                       entity_transformations, x, M, maps::type::identity,
-                       discontinuous);
+  return FiniteElement(element::family::P, celltype, degree, {1},
+                       xt::eye<double>(ndofs), entity_transformations, x, M,
+                       maps::type::identity, discontinuous);
 }
 //-----------------------------------------------------------------------------
 } // namespace
@@ -964,13 +958,9 @@ FiniteElement basix::element::create_lagrange(cell::type celltype, int degree,
         = element::make_discontinuous(x, M, entity_transformations, tdim, 1);
   }
 
-  xt::xtensor<double, 3> coeffs = element::compute_expansion_coefficients(
-      celltype, xt::eye<double>(ndofs), {M[0], M[1], M[2], M[3]},
-      {x[0], x[1], x[2], x[3]}, degree);
-
-  return FiniteElement(element::family::P, celltype, degree, {1}, coeffs,
-                       entity_transformations, x, M, maps::type::identity,
-                       discontinuous);
+  return FiniteElement(element::family::P, celltype, degree, {1},
+                       xt::eye<double>(ndofs), entity_transformations, x, M,
+                       maps::type::identity, discontinuous);
 }
 //-----------------------------------------------------------------------------
 FiniteElement basix::element::create_dpc(cell::type celltype, int degree,
@@ -1045,9 +1035,7 @@ FiniteElement basix::element::create_dpc(cell::type celltype, int degree,
         = xt::xtensor<double, 3>({2, 0, 0});
   }
 
-  xt::xtensor<double, 3> coeffs = element::compute_expansion_coefficients(
-      celltype, wcoeffs, {M[tdim]}, {x[tdim]}, degree);
-  return FiniteElement(element::family::DPC, celltype, degree, {1}, coeffs,
+  return FiniteElement(element::family::DPC, celltype, degree, {1}, wcoeffs,
                        entity_transformations, x, M, maps::type::identity,
                        discontinuous);
 }

--- a/cpp/basix/e-nce-rtc.cpp
+++ b/cpp/basix/e-nce-rtc.cpp
@@ -154,10 +154,7 @@ FiniteElement basix::element::create_rtc(cell::type celltype, int degree,
         = element::make_discontinuous(x, M, entity_transformations, tdim, tdim);
   }
 
-  xt::xtensor<double, 3> coeffs = element::compute_expansion_coefficients(
-      celltype, wcoeffs, {M[tdim - 1], M[tdim]}, {x[tdim - 1], x[tdim]},
-      degree);
-  return FiniteElement(element::family::RT, celltype, degree, {tdim}, coeffs,
+  return FiniteElement(element::family::RT, celltype, degree, {tdim}, wcoeffs,
                        entity_transformations, x, M,
                        maps::type::contravariantPiola, discontinuous);
 }
@@ -347,9 +344,7 @@ FiniteElement basix::element::create_nce(cell::type celltype, int degree,
         = element::make_discontinuous(x, M, entity_transformations, tdim, tdim);
   }
 
-  xt::xtensor<double, 3> coeffs = element::compute_expansion_coefficients(
-      celltype, wcoeffs, {M[1], M[2], M[3]}, {x[1], x[2], x[3]}, degree);
-  return FiniteElement(element::family::N1E, celltype, degree, {tdim}, coeffs,
+  return FiniteElement(element::family::N1E, celltype, degree, {tdim}, wcoeffs,
                        entity_transformations, x, M, maps::type::covariantPiola,
                        discontinuous);
 }

--- a/cpp/basix/e-nedelec.cpp
+++ b/cpp/basix/e-nedelec.cpp
@@ -394,9 +394,7 @@ FiniteElement basix::element::create_nedelec(cell::type celltype, int degree,
         = element::make_discontinuous(x, M, transforms, tdim, tdim);
   }
 
-  const xt::xtensor<double, 3> coeffs = element::compute_expansion_coefficients(
-      celltype, wcoeffs, {M[1], M[2], M[3]}, {x[1], x[2], x[3]}, degree);
-  return FiniteElement(element::family::N1E, celltype, degree, {tdim}, coeffs,
+  return FiniteElement(element::family::N1E, celltype, degree, {tdim}, wcoeffs,
                        transforms, x, M, maps::type::covariantPiola,
                        discontinuous);
 }
@@ -436,9 +434,7 @@ FiniteElement basix::element::create_nedelec2(cell::type celltype, int degree,
         = element::make_discontinuous(x, M, entity_transformations, tdim, tdim);
   }
 
-  const xt::xtensor<double, 3> coeffs = element::compute_expansion_coefficients(
-      celltype, wcoeffs, {M[1], M[2], M[3]}, {x[1], x[2], x[3]}, degree);
-  return FiniteElement(element::family::N2E, celltype, degree, {tdim}, coeffs,
+  return FiniteElement(element::family::N2E, celltype, degree, {tdim}, wcoeffs,
                        entity_transformations, x, M, maps::type::covariantPiola,
                        discontinuous);
 }

--- a/cpp/basix/e-raviart-thomas.cpp
+++ b/cpp/basix/e-raviart-thomas.cpp
@@ -120,9 +120,7 @@ FiniteElement basix::element::create_rt(cell::type celltype, int degree,
         = element::make_discontinuous(x, M, entity_transformations, tdim, tdim);
   }
 
-  xt::xtensor<double, 3> coeffs = element::compute_expansion_coefficients(
-      celltype, B, {M[tdim - 1], M[tdim]}, {x[tdim - 1], x[tdim]}, degree);
-  return FiniteElement(element::family::RT, celltype, degree, {tdim}, coeffs,
+  return FiniteElement(element::family::RT, celltype, degree, {tdim}, B,
                        entity_transformations, x, M,
                        maps::type::contravariantPiola, discontinuous);
 }

--- a/cpp/basix/e-regge.cpp
+++ b/cpp/basix/e-regge.cpp
@@ -190,11 +190,8 @@ FiniteElement basix::element::create_regge(cell::type celltype, int degree,
     entity_transformations[cell::type::triangle] = face_trans;
   }
 
-  const xt::xtensor<double, 3> coeffs = element::compute_expansion_coefficients(
-      celltype, wcoeffs, {M[1], M[2], M[3]}, {x[1], x[2], x[3]}, degree);
-
   return FiniteElement(element::family::Regge, celltype, degree, {tdim, tdim},
-                       coeffs, entity_transformations, x, M,
+                       wcoeffs, entity_transformations, x, M,
                        maps::type::doubleCovariantPiola, discontinuous);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/basix/e-serendipity.cpp
+++ b/cpp/basix/e-serendipity.cpp
@@ -647,11 +647,8 @@ FiniteElement basix::element::create_serendipity(cell::type celltype,
         = element::make_discontinuous(x, M, entity_transformations, tdim, 1);
   }
 
-  xt::xtensor<double, 3> coeffs = element::compute_expansion_coefficients(
-      celltype, wcoeffs, {M[0], M[1], M[2], M[3]}, {x[0], x[1], x[2], x[3]},
-      degree);
   return FiniteElement(element::family::serendipity, celltype, degree, {1},
-                       coeffs, entity_transformations, x, M,
+                       wcoeffs, entity_transformations, x, M,
                        maps::type::identity, discontinuous);
 }
 //-----------------------------------------------------------------------------
@@ -724,12 +721,8 @@ FiniteElement basix::element::create_serendipity_div(cell::type celltype,
         = element::make_discontinuous(x, M, entity_transformations, tdim, tdim);
   }
 
-  xt::xtensor<double, 3> coeffs = element::compute_expansion_coefficients(
-      celltype, wcoeffs, {M[tdim - 1], M[tdim]}, {x[tdim - 1], x[tdim]},
-      degree + 1);
-
   return FiniteElement(element::family::BDM, celltype, degree + 1, {tdim},
-                       coeffs, entity_transformations, x, M,
+                       wcoeffs, entity_transformations, x, M,
                        maps::type::contravariantPiola, discontinuous);
 }
 //-----------------------------------------------------------------------------
@@ -820,10 +813,8 @@ FiniteElement basix::element::create_serendipity_curl(cell::type celltype,
         = element::make_discontinuous(x, M, entity_transformations, tdim, tdim);
   }
 
-  xt::xtensor<double, 3> coeffs = element::compute_expansion_coefficients(
-      celltype, wcoeffs, {M[1], M[2], M[3]}, {x[1], x[2], x[3]}, degree + 1);
   return FiniteElement(element::family::N2E, celltype, degree + 1, {tdim},
-                       coeffs, entity_transformations, x, M,
+                       wcoeffs, entity_transformations, x, M,
                        maps::type::covariantPiola, discontinuous);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -311,7 +311,7 @@ FiniteElement::FiniteElement(
       _cell_tdim(cell::topological_dimension(cell_type)),
       _cell_subentity_types(cell::subentity_types(cell_type)), _family(family),
       _degree(degree), _map_type(map_type),
-      _entity_transformations(entity_transformations), _x(x), _matM_new(M),
+      _entity_transformations(entity_transformations), _x(x),
       _discontinuous(discontinuous)
 {
   _dual_matrix = compute_dual_matrix(cell_type, wcoeffs, M, x, degree);
@@ -853,6 +853,11 @@ FiniteElement::entity_transformations() const
 xt::xtensor<double, 2> FiniteElement::dual_matrix() const
 {
   return _dual_matrix;
+}
+//-----------------------------------------------------------------------------
+xt::xtensor<double, 2> FiniteElement::coefficient_matrix() const
+{
+  return _coeffs;
 }
 //-----------------------------------------------------------------------------
 std::string basix::version()

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -102,13 +102,13 @@ compute_dual_matrix(cell::type cell_type, const xt::xtensor<double, 2>& B,
       // Evaluate polynomial basis at x[d]
       const xt::xtensor<double, 2>& x_e = x[d][e];
       xt::xtensor<double, 2> P;
-      if (x_e.shape(1) == 1 and x_e.size() != 0)
+      if (x_e.shape(1) == 1 and x_e.shape(0) != 0)
       {
         auto pts = xt::view(x_e, xt::all(), 0);
         P = xt::view(polyset::tabulate(cell_type, degree, 0, pts), 0, xt::all(),
                      xt::all());
       }
-      else if (x_e.size() != 0)
+      else if (x_e.shape(0) != 0)
       {
         P = xt::view(polyset::tabulate(cell_type, degree, 0, x_e), 0, xt::all(),
                      xt::all());
@@ -123,8 +123,6 @@ compute_dual_matrix(cell::type cell_type, const xt::xtensor<double, 2>& B,
           for (std::size_t k = 0; k < Me.shape(2); ++k)  // Point
             for (std::size_t l = 0; l < P.shape(1); ++l) // Polynomial term
               D(dof_index + i, j, l) += Me(i, j, k) * P(k, l);
-
-      // Dtmp += basix::math::dot(Me, P);
 
       dof_index += M[d][e].shape(0);
     }
@@ -319,7 +317,6 @@ FiniteElement::FiniteElement(
   _dual_matrix = compute_dual_matrix(cell_type, wcoeffs, M, x, degree);
   xt::xtensor<double, 2> B_cmajor({wcoeffs.shape(0), wcoeffs.shape(1)});
   B_cmajor.assign(wcoeffs);
-
   // Compute C = (BD^T)^{-1} B
   auto result = math::solve(_dual_matrix, B_cmajor);
 

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -319,6 +319,7 @@ FiniteElement::FiniteElement(
   _dual_matrix = compute_dual_matrix(cell_type, wcoeffs, M, x, degree);
   xt::xtensor<double, 2> B_cmajor({wcoeffs.shape(0), wcoeffs.shape(1)});
   B_cmajor.assign(wcoeffs);
+
   // Compute C = (BD^T)^{-1} B
   auto result = math::solve(_dual_matrix, B_cmajor);
 

--- a/cpp/basix/finite-element.h
+++ b/cpp/basix/finite-element.h
@@ -763,6 +763,8 @@ public:
   /// @return The dual matrix
   xt::xtensor<double, 2> dual_matrix() const;
 
+  xt::xtensor<double, 2> coefficient_matrix() const;
+
   /// Element map type
   maps::type map_type;
 
@@ -828,9 +830,6 @@ private:
 
   /// The interpolation weights and points
   xt::xtensor<double, 2> _matM;
-
-  /// Interpolation matrices
-  std::array<std::vector<xt::xtensor<double, 3>>, 4> _matM_new;
 
   /// Indicates whether or not the DOF transformations are all permutations
   bool _dof_transformations_are_permutations;

--- a/cpp/basix/finite-element.h
+++ b/cpp/basix/finite-element.h
@@ -23,162 +23,6 @@ namespace basix
 namespace element
 {
 
-/// Calculates the basis functions of the finite element, in terms of the
-/// polynomial basis.
-///
-/// The below explanation uses Einstein notation.
-///
-/// The basis functions @f${\phi_i}@f$ of a finite element are represented
-/// as a linear combination of polynomials @f$\{p_j\}@f$ in an underlying
-/// polynomial basis that span the space of all d-dimensional polynomials up
-/// to order @f$k \ (P_k^d)@f$:
-/// \f[ \phi_i = c_{ij} p_j \f]
-///
-/// In some cases, the basis functions @f$\{\phi_i\}@f$ do not span the
-/// full space @f$P_k@f$, in which case we denote space spanned by the
-/// basis functions by @f$\{q_k\}@f$, which can be represented by:
-/// @f[  q_i = b_{ij} p_j. @f]
-///  This leads to
-/// @f[  \phi_i = c^{\prime}_{ij} q_j = c^{\prime}_{ij} b_{jk} p_k,  @f]
-/// and in matrix form:
-/// \f[
-/// \phi = C^{\prime} B p
-/// \f]
-///
-/// If the basis functions span the full space, then @f$ B @f$ is simply
-/// the identity.
-///
-/// The basis functions @f$\phi_i@f$ are defined by a dual set of functionals
-/// @f$\{f_i\}@f$. The basis functions are the functions in span{@f$q_k@f$} such
-/// that
-///   @f[ f_i(\phi_j) = \delta_{ij} @f]
-/// and inserting the expression for @f$\phi_{j}@f$:
-///   @f[ f_i(c^{\prime}_{jk}b_{kl}p_{l}) = c^{\prime}_{jk} b_{kl} f_i \left(
-///   p_{l} \right) @f]
-///
-/// Defining a matrix D given by applying the functionals to each
-/// polynomial @f$p_j@f$:
-///  @f[ [D] = d_{ij},\mbox{ where } d_{ij} = f_i(p_j), @f]
-/// we have:
-/// @f[ C^{\prime} B D^{T} = I @f]
-///
-/// and
-///
-/// @f[ C^{\prime} = (B D^{T})^{-1}. @f]
-///
-/// Recalling that @f$C = C^{\prime} B@f$, where @f$C@f$ is the matrix
-/// form of @f$c_{ij}@f$,
-///
-/// @f[ C = (B D^{T})^{-1} B @f]
-///
-/// This function takes the matrices B (span_coeffs) and D (dual) as
-/// inputs and returns the matrix C.
-///
-/// Example: Order 1 Lagrange elements on a triangle
-/// ------------------------------------------------
-/// On a triangle, the scalar expansion basis is:
-///  @f[ p_0 = \sqrt{2}/2 \qquad
-///   p_1 = \sqrt{3}(2x + y - 1) \qquad
-///   p_2 = 3y - 1 @f]
-/// These span the space @f$P_1@f$.
-///
-/// Lagrange order 1 elements span the space P_1, so in this example,
-/// B (span_coeffs) is the identity matrix:
-///   @f[ B = \begin{bmatrix}
-///                   1 & 0 & 0 \\
-///                   0 & 1 & 0 \\
-///                   0 & 0 & 1 \end{bmatrix} @f]
-///
-/// The functionals defining the Lagrange order 1 space are point
-/// evaluations at the three vertices of the triangle. The matrix D
-/// (dual) given by applying these to p_0 to p_2 is:
-///  @f[ \mbox{dual} = \begin{bmatrix}
-///              \sqrt{2}/2 &  -\sqrt{3} & -1 \\
-///              \sqrt{2}/2 &   \sqrt{3} & -1 \\
-///              \sqrt{2}/2 &          0 &  2 \end{bmatrix} @f]
-///
-/// For this example, this function outputs the matrix:
-///  @f[ C = \begin{bmatrix}
-///            \sqrt{2}/3 & -\sqrt{3}/6 &  -1/6 \\
-///            \sqrt{2}/3 & \sqrt{3}/6  &  -1/6 \\
-///            \sqrt{2}/3 &          0  &   1/3 \end{bmatrix} @f]
-/// The basis functions of the finite element can be obtained by applying
-/// the matrix C to the vector @f$[p_0, p_1, p_2]@f$, giving:
-///   @f[ \begin{bmatrix} 1 - x - y \\ x \\ y \end{bmatrix} @f]
-///
-/// Example: Order 1 Raviart-Thomas on a triangle
-/// ---------------------------------------------
-/// On a triangle, the 2D vector expansion basis is:
-///  @f[ \begin{matrix}
-///   p_0 & = & (\sqrt{2}/2, 0) \\
-///   p_1 & = & (\sqrt{3}(2x + y - 1), 0) \\
-///   p_2 & = & (3y - 1, 0) \\
-///   p_3 & = & (0, \sqrt{2}/2) \\
-///   p_4 & = & (0, \sqrt{3}(2x + y - 1)) \\
-///   p_5 & = & (0, 3y - 1)
-///  \end{matrix}
-/// @f]
-/// These span the space @f$ P_1^2 @f$.
-///
-/// Raviart-Thomas order 1 elements span a space smaller than @f$ P_1^2 @f$,
-/// so B (span_coeffs) is not the identity. It is given by:
-///   @f[ B = \begin{bmatrix}
-///  1 &  0 &  0 &    0 &  0 &   0 \\
-///  0 &  0 &  0 &    1 &  0 &     0 \\
-///  1/12 &  \sqrt{6}/48 &  -\sqrt{2}/48 &  1/12 &  0 &  \sqrt{2}/24
-///  \end{bmatrix}
-///  @f]
-/// Applying the matrix B to the vector @f$[p_0, p_1, ..., p_5]@f$ gives the
-/// basis of the polynomial space for Raviart-Thomas:
-///   @f[ \begin{bmatrix}
-///  \sqrt{2}/2 &  0 \\
-///   0 &  \sqrt{2}/2 \\
-///   \sqrt{2}x/8  & \sqrt{2}y/8
-///  \end{bmatrix} @f]
-///
-/// The functionals defining the Raviart-Thomas order 1 space are integral
-/// of the normal components along each edge. The matrix D (dual) given
-/// by applying these to @f$p_0@f$ to @f$p_5@f$ is:
-/// @f[ D = \begin{bmatrix}
-/// -\sqrt{2}/2 & -\sqrt{3}/2 & -1/2 & -\sqrt{2}/2 & -\sqrt{3}/2 & -1/2 \\
-/// -\sqrt{2}/2 &  \sqrt{3}/2 & -1/2 &          0  &          0 &    0 \\
-///           0 &         0   &    0 &  \sqrt{2}/2 &          0 &   -1
-/// \end{bmatrix} @f]
-///
-/// In this example, this function outputs the matrix:
-///  @f[  C = \begin{bmatrix}
-///  -\sqrt{2}/2 & -\sqrt{3}/2 & -1/2 & -\sqrt{2}/2 & -\sqrt{3}/2 & -1/2 \\
-///  -\sqrt{2}/2 &  \sqrt{3}/2 & -1/2 &          0  &          0  &    0 \\
-///            0 &          0  &    0 &  \sqrt{2}/2 &          0  &   -1
-/// \end{bmatrix} @f]
-/// The basis functions of the finite element can be obtained by applying
-/// the matrix C to the vector @f$[p_0, p_1, ..., p_5]@f$, giving:
-///   @f[ \begin{bmatrix}
-///   -x & -y \\
-///   x - 1 & y \\
-///   -x & 1 - y \end{bmatrix} @f]
-///
-/// @param[in] cell_type The cells shape
-/// @param[in] B Matrices for the kth value index containing the
-/// expansion coefficients defining a polynomial basis spanning the
-/// polynomial space for this element
-/// @param[in] M The interpolation tensor, such that the dual matrix
-/// \f$D\f$ is computed by \f$D = MP\f$
-/// @param[in] x The interpolation points. The vector index is for
-/// points on entities of the same dimension, ordered with the lowest
-/// topological dimension being first. Each 3D tensor hold the points on
-/// cell entities of a common dimension. The shape of the 3d tensors is
-/// (num_entities, num_points_per_entity, tdim).
-/// @param[in] degree The degree of the polynomial basis P used to
-/// create the element (before applying B)
-/// @return The matrix C of expansion coefficients that define the basis
-/// functions of the finite element space. The shape is (num_dofs,
-/// value_size, basis_dim)
-xt::xtensor<double, 3> compute_expansion_coefficients(
-    cell::type cell_type, const xt::xtensor<double, 2>& B,
-    const std::vector<std::vector<xt::xtensor<double, 3>>>& M,
-    const std::vector<std::vector<xt::xtensor<double, 2>>>& x, int degree);
-
 /// Creates a version of the interpolation points, interpolation
 /// matrices and entity transformation that represent a discontinuous
 /// version of the element. This discontinuous version will have the
@@ -213,13 +57,152 @@ class FiniteElement
 
 public:
   /// A finite element
+  ///
+  /// Initialising a finite element calculates the basis functions of the finite
+  /// element, in terms of the polynomial basis.
+  ///
+  /// The below explanation uses Einstein notation.
+  ///
+  /// The basis functions @f${\phi_i}@f$ of a finite element are represented
+  /// as a linear combination of polynomials @f$\{p_j\}@f$ in an underlying
+  /// polynomial basis that span the space of all d-dimensional polynomials up
+  /// to order @f$k \ (P_k^d)@f$:
+  /// \f[ \phi_i = c_{ij} p_j \f]
+  ///
+  /// In some cases, the basis functions @f$\{\phi_i\}@f$ do not span the
+  /// full space @f$P_k@f$, in which case we denote space spanned by the
+  /// basis functions by @f$\{q_k\}@f$, which can be represented by:
+  /// @f[  q_i = b_{ij} p_j. @f]
+  ///  This leads to
+  /// @f[  \phi_i = c^{\prime}_{ij} q_j = c^{\prime}_{ij} b_{jk} p_k,  @f]
+  /// and in matrix form:
+  /// \f[
+  /// \phi = C^{\prime} B p
+  /// \f]
+  ///
+  /// If the basis functions span the full space, then @f$ B @f$ is simply
+  /// the identity.
+  ///
+  /// The basis functions @f$\phi_i@f$ are defined by a dual set of functionals
+  /// @f$\{f_i\}@f$. The basis functions are the functions in span{@f$q_k@f$}
+  /// such that
+  ///   @f[ f_i(\phi_j) = \delta_{ij} @f]
+  /// and inserting the expression for @f$\phi_{j}@f$:
+  ///   @f[ f_i(c^{\prime}_{jk}b_{kl}p_{l}) = c^{\prime}_{jk} b_{kl} f_i \left(
+  ///   p_{l} \right) @f]
+  ///
+  /// Defining a matrix D given by applying the functionals to each
+  /// polynomial @f$p_j@f$:
+  ///  @f[ [D] = d_{ij},\mbox{ where } d_{ij} = f_i(p_j), @f]
+  /// we have:
+  /// @f[ C^{\prime} B D^{T} = I @f]
+  ///
+  /// and
+  ///
+  /// @f[ C^{\prime} = (B D^{T})^{-1}. @f]
+  ///
+  /// Recalling that @f$C = C^{\prime} B@f$, where @f$C@f$ is the matrix
+  /// form of @f$c_{ij}@f$,
+  ///
+  /// @f[ C = (B D^{T})^{-1} B @f]
+  ///
+  /// This function takes the matrices @f$B@f$ (`wcoeffs`) and @f$D@f$ (`M`) as
+  /// inputs and will internally compute @f$C@f$.
+  ///
+  /// The matrix @f$BD^{T}@f$ can be obtained from an element by using the
+  /// function `dual_matrix()`.
+  ///
+  /// Example: Order 1 Lagrange elements on a triangle
+  /// ------------------------------------------------
+  /// On a triangle, the scalar expansion basis is:
+  ///  @f[ p_0 = \sqrt{2}/2 \qquad
+  ///   p_1 = \sqrt{3}(2x + y - 1) \qquad
+  ///   p_2 = 3y - 1 @f]
+  /// These span the space @f$P_1@f$.
+  ///
+  /// Lagrange order 1 elements span the space P_1, so in this example,
+  /// B (span_coeffs) is the identity matrix:
+  ///   @f[ B = \begin{bmatrix}
+  ///                   1 & 0 & 0 \\
+  ///                   0 & 1 & 0 \\
+  ///                   0 & 0 & 1 \end{bmatrix} @f]
+  ///
+  /// The functionals defining the Lagrange order 1 space are point
+  /// evaluations at the three vertices of the triangle. The matrix D
+  /// (dual) given by applying these to p_0 to p_2 is:
+  ///  @f[ \mbox{dual} = \begin{bmatrix}
+  ///              \sqrt{2}/2 &  -\sqrt{3} & -1 \\
+  ///              \sqrt{2}/2 &   \sqrt{3} & -1 \\
+  ///              \sqrt{2}/2 &          0 &  2 \end{bmatrix} @f]
+  ///
+  /// For this example, this function outputs the matrix:
+  ///  @f[ C = \begin{bmatrix}
+  ///            \sqrt{2}/3 & -\sqrt{3}/6 &  -1/6 \\
+  ///            \sqrt{2}/3 & \sqrt{3}/6  &  -1/6 \\
+  ///            \sqrt{2}/3 &          0  &   1/3 \end{bmatrix} @f]
+  /// The basis functions of the finite element can be obtained by applying
+  /// the matrix C to the vector @f$[p_0, p_1, p_2]@f$, giving:
+  ///   @f[ \begin{bmatrix} 1 - x - y \\ x \\ y \end{bmatrix} @f]
+  ///
+  /// Example: Order 1 Raviart-Thomas on a triangle
+  /// ---------------------------------------------
+  /// On a triangle, the 2D vector expansion basis is:
+  ///  @f[ \begin{matrix}
+  ///   p_0 & = & (\sqrt{2}/2, 0) \\
+  ///   p_1 & = & (\sqrt{3}(2x + y - 1), 0) \\
+  ///   p_2 & = & (3y - 1, 0) \\
+  ///   p_3 & = & (0, \sqrt{2}/2) \\
+  ///   p_4 & = & (0, \sqrt{3}(2x + y - 1)) \\
+  ///   p_5 & = & (0, 3y - 1)
+  ///  \end{matrix}
+  /// @f]
+  /// These span the space @f$ P_1^2 @f$.
+  ///
+  /// Raviart-Thomas order 1 elements span a space smaller than @f$ P_1^2 @f$,
+  /// so B (span_coeffs) is not the identity. It is given by:
+  ///   @f[ B = \begin{bmatrix}
+  ///  1 &  0 &  0 &    0 &  0 &   0 \\
+  ///  0 &  0 &  0 &    1 &  0 &     0 \\
+  ///  1/12 &  \sqrt{6}/48 &  -\sqrt{2}/48 &  1/12 &  0 &  \sqrt{2}/24
+  ///  \end{bmatrix}
+  ///  @f]
+  /// Applying the matrix B to the vector @f$[p_0, p_1, ..., p_5]@f$ gives the
+  /// basis of the polynomial space for Raviart-Thomas:
+  ///   @f[ \begin{bmatrix}
+  ///  \sqrt{2}/2 &  0 \\
+  ///   0 &  \sqrt{2}/2 \\
+  ///   \sqrt{2}x/8  & \sqrt{2}y/8
+  ///  \end{bmatrix} @f]
+  ///
+  /// The functionals defining the Raviart-Thomas order 1 space are integral
+  /// of the normal components along each edge. The matrix D (dual) given
+  /// by applying these to @f$p_0@f$ to @f$p_5@f$ is:
+  /// @f[ D = \begin{bmatrix}
+  /// -\sqrt{2}/2 & -\sqrt{3}/2 & -1/2 & -\sqrt{2}/2 & -\sqrt{3}/2 & -1/2 \\
+  /// -\sqrt{2}/2 &  \sqrt{3}/2 & -1/2 &          0  &          0 &    0 \\
+  ///           0 &         0   &    0 &  \sqrt{2}/2 &          0 &   -1
+  /// \end{bmatrix} @f]
+  ///
+  /// In this example, this function outputs the matrix:
+  ///  @f[  C = \begin{bmatrix}
+  ///  -\sqrt{2}/2 & -\sqrt{3}/2 & -1/2 & -\sqrt{2}/2 & -\sqrt{3}/2 & -1/2 \\
+  ///  -\sqrt{2}/2 &  \sqrt{3}/2 & -1/2 &          0  &          0  &    0 \\
+  ///            0 &          0  &    0 &  \sqrt{2}/2 &          0  &   -1
+  /// \end{bmatrix} @f]
+  /// The basis functions of the finite element can be obtained by applying
+  /// the matrix C to the vector @f$[p_0, p_1, ..., p_5]@f$, giving:
+  ///   @f[ \begin{bmatrix}
+  ///   -x & -y \\
+  ///   x - 1 & y \\
+  ///   -x & 1 - y \end{bmatrix} @f]
+  ///
   /// @param[in] family The element family
   /// @param[in] cell_type The cell type
   /// @param[in] degree The degree of the element
   /// @param[in] value_shape The value shape of the element
-  /// @param[in] coeffs Expansion coefficients of the basis functions in
-  /// the underlying polynomial set. The shape is (num_dofs, value_size,
-  /// basis_dim)
+  /// @param[in] wcoeffs Matrices for the kth value index containing the
+  /// expansion coefficients defining a polynomial basis spanning the
+  /// polynomial space for this element
   /// @param[in] entity_transformations Entity transformations
   /// representing the effect rotating and reflecting subentities of the
   /// cell has on the DOFs.
@@ -233,7 +216,7 @@ public:
   /// discontinuous version of the element
   FiniteElement(element::family family, cell::type cell_type, int degree,
                 const std::vector<std::size_t>& value_shape,
-                const xt::xtensor<double, 3>& coeffs,
+                const xt::xtensor<double, 2>& wcoeffs,
                 const std::map<cell::type, xt::xtensor<double, 3>>&
                     entity_transformations,
                 const std::array<std::vector<xt::xtensor<double, 2>>, 4>& x,
@@ -773,6 +756,13 @@ public:
   void interpolate(const xtl::span<T>& coefficients,
                    const xtl::span<const T>& data, const int block_size) const;
 
+  /// Get the dual matrix.
+  ///
+  /// This is the matrix @f$BD^{T}@f$, as described in the documentation of the
+  /// `FiniteElement()` constructor.
+  /// @return The dual matrix
+  xt::xtensor<double, 2> dual_matrix() const;
+
   /// Element map type
   maps::type map_type;
 
@@ -884,6 +874,9 @@ private:
 
   // Indicates whether or not this is the discontinuous version of the element
   bool _discontinuous;
+
+  // The dual matrix
+  xt::xtensor<double, 2> _dual_matrix;
 };
 
 /// Create an element using a given Lagrange variant

--- a/cpp/basix/finite-element.h
+++ b/cpp/basix/finite-element.h
@@ -110,7 +110,8 @@ public:
   /// inputs and will internally compute @f$C@f$.
   ///
   /// The matrix @f$BD^{T}@f$ can be obtained from an element by using the
-  /// function `dual_matrix()`.
+  /// function `dual_matrix()`. The matrix @f$C@f$ can be obtained from an
+  /// element by using the function `coefficient_matrix()`.
   ///
   /// Example: Order 1 Lagrange elements on a triangle
   /// ------------------------------------------------
@@ -763,6 +764,11 @@ public:
   /// @return The dual matrix
   xt::xtensor<double, 2> dual_matrix() const;
 
+  /// Get the matrix of coefficients.
+  ///
+  /// This is the matrix @f$C@f$, as described in the documentation of the
+  /// `FiniteElement()` constructor.
+  /// @return The dual matrix
   xt::xtensor<double, 2> coefficient_matrix() const;
 
   /// Element map type

--- a/python/wrapper.cpp
+++ b/python/wrapper.cpp
@@ -312,10 +312,17 @@ Interface to the Basix C++ library.
             const xt::xtensor<double, 2>& P = self.interpolation_matrix();
             return py::array_t<double>(P.shape(), P.data(), py::cast(self));
           })
-      .def_property_readonly("dual_matrix", [](const FiniteElement& self) {
-        const xt::xtensor<double, 2>& P = self.dual_matrix();
-        return py::array_t<double>(P.shape(), P.data(), py::cast(self));
-      });
+      .def_property_readonly(
+          "dual_matrix",
+          [](const FiniteElement& self) {
+            const xt::xtensor<double, 2>& P = self.dual_matrix();
+            return py::array_t<double>(P.shape(), P.data(), py::cast(self));
+          })
+      .def_property_readonly(
+          "coefficient_matrix", [](const FiniteElement& self) {
+            const xt::xtensor<double, 2>& P = self.coefficient_matrix();
+            return py::array_t<double>(P.shape(), P.data(), py::cast(self));
+          });
 
   py::enum_<element::lagrange_variant>(m, "LagrangeVariant")
       .value("equispaced", element::lagrange_variant::equispaced)

--- a/python/wrapper.cpp
+++ b/python/wrapper.cpp
@@ -307,10 +307,15 @@ Interface to the Basix C++ library.
                                                           py::cast(self));
                              })
       .def_property_readonly(
-          "interpolation_matrix", [](const FiniteElement& self) {
+          "interpolation_matrix",
+          [](const FiniteElement& self) {
             const xt::xtensor<double, 2>& P = self.interpolation_matrix();
             return py::array_t<double>(P.shape(), P.data(), py::cast(self));
-          });
+          })
+      .def_property_readonly("dual_matrix", [](const FiniteElement& self) {
+        const xt::xtensor<double, 2>& P = self.dual_matrix();
+        return py::array_t<double>(P.shape(), P.data(), py::cast(self));
+      });
 
   py::enum_<element::lagrange_variant>(m, "LagrangeVariant")
       .value("equispaced", element::lagrange_variant::equispaced)


### PR DESCRIPTION
Removed the `compute_expansion_coefficients` function, and move the computation it did inside the `FiniteElement` constructor.

Removed `_matM_new` from `FiniteElement` as is it unused.

Added `dual_matrix()` and `coefficient_matrix()` methods so these matrices can be accessed from Python