### PR TITLE
Add tensor product representation of Lagrange on quads and hexes

### DIFF
--- a/cpp/basix/e-lagrange.cpp
+++ b/cpp/basix/e-lagrange.cpp
@@ -179,7 +179,67 @@ create_tensor_product_factors(cell::type celltype, int degree,
   }
   if (celltype == cell::type::hexahedron)
   {
-    return {};
+    FiniteElement sub_element
+        = element::create_lagrange(cell::type::interval, degree, variant, true);
+    std::vector<int> perm((degree + 1) * (degree + 1) * (degree + 1));
+    if (degree == 0)
+      perm[0] = 0;
+    else
+    {
+      int p = 0;
+      int n = degree - 1;
+      perm[p++] = 0;
+      perm[p++] = 4;
+      for (int i = 0; i < n; ++i)
+        perm[p++] = 8 + 2 * n + i;
+      perm[p++] = 2;
+      perm[p++] = 6;
+      for (int i = 0; i < n; ++i)
+        perm[p++] = 8 + 6 * n + i;
+      for (int i = 0; i < n; ++i)
+      {
+        perm[p++] = 8 + n + i;
+        perm[p++] = 8 + 9 * n + i;
+        for (int j = 0; j < n; ++j)
+          perm[p++] = 8 + 12 * n + 2 * n * n + i + n * j;
+      }
+      perm[p++] = 1;
+      perm[p++] = 5;
+      for (int i = 0; i < n; ++i)
+        perm[p++] = 8 + 4 * n + i;
+      perm[p++] = 3;
+      perm[p++] = 7;
+      for (int i = 0; i < n; ++i)
+        perm[p++] = 8 + 7 * n + i;
+      for (int i = 0; i < n; ++i)
+      {
+        perm[p++] = 8 + 3 * n + i;
+        perm[p++] = 8 + 10 * n + i;
+        for (int j = 0; j < n; ++j)
+          perm[p++] = 8 + 12 * n + 3 * n * n + i + n * j;
+      }
+      for (int i = 0; i < n; ++i)
+      {
+        perm[p++] = 8 + i;
+        perm[p++] = 8 + 8 * n + i;
+        for (int j = 0; j < n; ++j)
+          perm[p++] = 8 + 12 * n + n * n + i + n * j;
+        perm[p++] = 8 + 5 * n + i;
+        perm[p++] = 8 + 11 * n + i;
+        for (int j = 0; j < n; ++j)
+          perm[p++] = 8 + 12 * n + 4 * n * n + i + n * j;
+        for (int j = 0; j < n; ++j)
+        {
+          perm[p++] = 8 + 12 * n + i + n * j;
+          perm[p++] = 8 + 12 * n + 5 * n * n + i + n * j;
+          for (int k = 0; k < n; ++k)
+          {
+            perm[p++] = 8 + 12 * n + 6 * n * n + i + n * j + n * n * k;
+          }
+        }
+      }
+    }
+    return {{{sub_element, sub_element, sub_element}, perm}};
   }
   return {};
 }

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -307,13 +307,16 @@ FiniteElement::FiniteElement(
     const std::array<std::vector<xt::xtensor<double, 2>>, 4>& x,
     const std::array<std::vector<xt::xtensor<double, 3>>, 4>& M,
     maps::type map_type, bool discontinuous, int highest_degree,
-    int highest_complete_degree)
+    int highest_complete_degree,
+    std::vector<std::tuple<std::vector<FiniteElement>, std::vector<int>>>
+        tensor_factors)
     : _cell_type(cell_type), _cell_tdim(cell::topological_dimension(cell_type)),
       _cell_subentity_types(cell::subentity_types(cell_type)), _family(family),
       _degree(degree), _map_type(map_type),
       _entity_transformations(entity_transformations), _x(x),
       _discontinuous(discontinuous),
-      _degree_bounds({highest_complete_degree, highest_degree})
+      _degree_bounds({highest_complete_degree, highest_degree}),
+      _tensor_factors(tensor_factors)
 {
   _dual_matrix = compute_dual_matrix(cell_type, wcoeffs, M, x, degree);
   xt::xtensor<double, 2> B_cmajor({wcoeffs.shape(0), wcoeffs.shape(1)});
@@ -898,6 +901,19 @@ xt::xtensor<double, 2> FiniteElement::coefficient_matrix() const
 std::array<int, 2> FiniteElement::degree_bounds() const
 {
   return _degree_bounds;
+}
+//-----------------------------------------------------------------------------
+bool FiniteElement::has_tensor_product_factorisation() const
+{
+  return _tensor_factors.size() > 0;
+}
+//-----------------------------------------------------------------------------
+std::vector<std::tuple<std::vector<FiniteElement>, std::vector<int>>>
+FiniteElement::get_tensor_product_representation() const
+{
+  if (!has_tensor_product_factorisation())
+    throw std::runtime_error("Element has no tensor product representation.");
+  return _tensor_factors;
 }
 //-----------------------------------------------------------------------------
 std::string basix::version()

--- a/cpp/basix/finite-element.h
+++ b/cpp/basix/finite-element.h
@@ -222,15 +222,21 @@ public:
   /// @param[in] highest_complete_degree The highest degree n such that a
   /// Lagrange (or vector Lagrange) element of degree n is a subspace of this
   /// element
-  FiniteElement(element::family family, cell::type cell_type, int degree,
-                const std::vector<std::size_t>& value_shape,
-                const xt::xtensor<double, 2>& wcoeffs,
-                const std::map<cell::type, xt::xtensor<double, 3>>&
-                    entity_transformations,
-                const std::array<std::vector<xt::xtensor<double, 2>>, 4>& x,
-                const std::array<std::vector<xt::xtensor<double, 3>>, 4>& M,
-                maps::type map_type, bool discontinuous, int highest_degree,
-                int highest_complete_degree);
+  /// @param[in] tensor_factors The factors in the tensor product representation
+  /// of this element
+  FiniteElement(
+      element::family family, cell::type cell_type, int degree,
+      const std::vector<std::size_t>& value_shape,
+      const xt::xtensor<double, 2>& wcoeffs,
+      const std::map<cell::type, xt::xtensor<double, 3>>&
+          entity_transformations,
+      const std::array<std::vector<xt::xtensor<double, 2>>, 4>& x,
+      const std::array<std::vector<xt::xtensor<double, 3>>, 4>& M,
+      maps::type map_type, bool discontinuous, int highest_degree,
+      int highest_complete_degree,
+      std::vector<std::tuple<std::vector<FiniteElement>, std::vector<int>>>
+          tensor_factors
+      = {});
 
   /// Copy constructor
   FiniteElement(const FiniteElement& element) = default;
@@ -754,6 +760,16 @@ public:
   /// subspace of this element
   std::array<int, 2> degree_bounds() const;
 
+  /// Indicates whether or not this element has a tensor product representation.
+  bool has_tensor_product_factorisation() const;
+
+  /// Get the tensor product representation of this element, or throw an error
+  /// if no such factorisation exists.
+  /// @todo Document the output of this
+  /// @return The tensor product representation
+  std::vector<std::tuple<std::vector<FiniteElement>, std::vector<int>>>
+  get_tensor_product_representation() const;
+
 private:
   // Cell type
   cell::type _cell_type;
@@ -863,12 +879,19 @@ private:
   // The dual matrix
   xt::xtensor<double, 2> _dual_matrix;
 
-
   // Polynomial degree bounds
   // [0]: highest degree n such that Lagrange order n is a subspace of
   // this space
   // [1]: highest polynomial degree
   std::array<int, 2> _degree_bounds;
+
+  // Tensor product representation
+  // Entries of tuple are (list of elements on an interval, permutation of DOF
+  // numbers)
+  // @todo: For vector-valued elements, a tensor prodcut type and a scaling
+  // factor may additionally be needed.
+  std::vector<std::tuple<std::vector<FiniteElement>, std::vector<int>>>
+      _tensor_factors;
 };
 
 /// Create an element using a given Lagrange variant

--- a/cpp/basix/finite-element.h
+++ b/cpp/basix/finite-element.h
@@ -765,7 +765,13 @@ public:
 
   /// Get the tensor product representation of this element, or throw an error
   /// if no such factorisation exists.
-  /// @todo Document the output of this
+  ///
+  /// The tensor product representation will be a vector of tuples. Each tuple
+  /// contains a vector of finite elements, and a vector on integers. The vector
+  /// of finite elements gives the elements on an interval that appear in the
+  /// tensor product representation. The vector of integers gives the
+  /// permutation between the numbering of the tensor product DOFs and the
+  /// number of the DOFs of this Basix element.
   /// @return The tensor product representation
   std::vector<std::tuple<std::vector<FiniteElement>, std::vector<int>>>
   get_tensor_product_representation() const;
@@ -888,7 +894,7 @@ private:
   // Tensor product representation
   // Entries of tuple are (list of elements on an interval, permutation of DOF
   // numbers)
-  // @todo: For vector-valued elements, a tensor prodcut type and a scaling
+  // @todo: For vector-valued elements, a tensor product type and a scaling
   // factor may additionally be needed.
   std::vector<std::tuple<std::vector<FiniteElement>, std::vector<int>>>
       _tensor_factors;

--- a/python/docs.h
+++ b/python/docs.h
@@ -467,8 +467,15 @@ dict
 )";
 
 const std::string FiniteElement__get_tensor_product_representation = R"(
-Get the tensor product representation of this element, or throw an error if no such factorisation exists.
-TODO: Document the output of this
+Get the tensor product representation of this element, or throw an error
+if no such factorisation exists.
+
+The tensor product representation will be a vector of tuples. Each tuple
+contains a vector of finite elements, and a vector on integers. The vector
+of finite elements gives the elements on an interval that appear in the
+tensor product representation. The vector of integers gives the
+permutation between the numbering of the tensor product DOFs and the
+number of the DOFs of this Basix element.
 
 Returns
 =======

--- a/python/docs.h
+++ b/python/docs.h
@@ -466,6 +466,16 @@ dict
     The base transformations for this element
 )";
 
+const std::string FiniteElement__get_tensor_product_representation = R"(
+Get the tensor product representation of this element, or throw an error if no such factorisation exists.
+TODO: Document the output of this
+
+Returns
+=======
+List[Tuple[List[basix.FiniteElement], List[int]]]
+    The tensor product representation
+)";
+
 const std::string create_element__family_cell_degree_discontinuous = R"(
 Create an element
 

--- a/python/docs.h.template
+++ b/python/docs.h.template
@@ -258,6 +258,14 @@ Returns
 {{finite-element.h > base_transformations > return : dict}}
 )";
 
+{{DOCTYPE}} FiniteElement__get_tensor_product_representation = R"(
+{{finite-element.h > get_tensor_product_representation > doc}}
+
+Returns
+=======
+{{finite-element.h > get_tensor_product_representation > return : List[Tuple[List[basix.FiniteElement], List[int]]]}}
+)";
+
 {{DOCTYPE}} create_element__family_cell_degree_discontinuous = R"(
 {{finite-element.h > create_element(family, cell, degree, discontinuous) > doc}}
 

--- a/python/wrapper.cpp
+++ b/python/wrapper.cpp
@@ -290,6 +290,13 @@ Interface to the Basix C++ library.
             return t2;
           },
           basix::docstring::FiniteElement__entity_transformations.c_str())
+      .def(
+          "get_tensor_product_representation",
+          [](const FiniteElement& self) {
+            return self.get_tensor_product_representation();
+          },
+          basix::docstring::FiniteElement__get_tensor_product_representation
+              .c_str())
       .def_property_readonly("degree", &FiniteElement::degree)
       .def_property_readonly("cell_type", &FiniteElement::cell_type)
       .def_property_readonly("dim", &FiniteElement::dim)
@@ -328,10 +335,13 @@ Interface to the Basix C++ library.
             return py::array_t<double>(P.shape(), P.data(), py::cast(self));
           })
       .def_property_readonly(
-          "coefficient_matrix", [](const FiniteElement& self) {
+          "coefficient_matrix",
+          [](const FiniteElement& self) {
             const xt::xtensor<double, 2>& P = self.coefficient_matrix();
             return py::array_t<double>(P.shape(), P.data(), py::cast(self));
-          });
+          })
+      .def_property_readonly("has_tensor_product_factorisation",
+                             &FiniteElement::has_tensor_product_factorisation);
 
   py::enum_<element::lagrange_variant>(m, "LagrangeVariant")
       .value("equispaced", element::lagrange_variant::equispaced)

--- a/test/test_tensor_products.py
+++ b/test/test_tensor_products.py
@@ -16,14 +16,21 @@ def tensor_product(*data):
         return tensor_product(tensor_product(data[0], data[1]), *data[2:])
 
     a, b = data
-    assert a.shape[1] == b.shape[1] == 1  # TODO: implement for non-scalar elements
-    return np.outer(a[:, 0], b[:, 0]).reshape(-1)
+    return np.outer(a, b).reshape(-1)
 
 
 @parametrize_over_elements(4)
 def test_tensor_product_factorisation(cell_type, degree, element_type, element_args):
     element = basix.create_element(element_type, cell_type, degree, *element_args)
     tdim = len(basix.topology(cell_type)) - 1
+
+    # These elements should have a factorisation
+    if cell_type in [
+        basix.CellType.quadrilateral, basix.CellType.hexahedron
+    ] and element_type in [
+        basix.ElementFamily.P
+    ]:
+        assert element.has_tensor_product_factorisation
 
     if not element.has_tensor_product_factorisation:
         with pytest.raises(RuntimeError):
@@ -33,19 +40,20 @@ def test_tensor_product_factorisation(cell_type, degree, element_type, element_a
     factors = element.get_tensor_product_representation()
 
     lattice = basix.create_lattice(cell_type, 1, basix.LatticeType.equispaced, True)
-
-    tab1 = element.tabulate(0, lattice)
+    tab1 = element.tabulate(1, lattice)
 
     for i, point in enumerate(lattice):
-        values1 = tab1[0, i, :, :]
+        for ds in product(range(2), repeat=tdim):
+            if sum(ds) > 1:
+                continue
+            deriv = basix.index(*ds)
+            values1 = tab1[deriv, i, :, :]
 
-        values2 = np.empty((element.dim, 1))
-
-        for fs, perm in factors:
-            evals = [e.tabulate(0, [p]) for e, p in zip(fs, point)]
-            tab2 = tensor_product(*evals)
-            for i, j in enumerate(perm):
-                if j != -1:
-                    values2[j, 0] = tab2[i]
-
-        assert np.allclose(values1, values2)
+            values2 = np.empty((element.dim, 1))
+            for fs, perm in factors:
+                evals = [e.tabulate(d, [p])[d, 0, :, 0] for e, p, d in zip(fs, point, ds)]
+                tab2 = tensor_product(*evals)
+                for a, b in enumerate(perm):
+                    if b != -1:
+                        values2[b, 0] = tab2[a]
+            assert np.allclose(values1, values2)

--- a/test/test_tensor_products.py
+++ b/test/test_tensor_products.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Matthew Scroggs
+# Copyright (c) 2021 Matthew Scroggs, Igor A. Baratta
 # FEniCS Project
 # SPDX-License-Identifier: MIT
 
@@ -6,6 +6,7 @@ import numpy as np
 import basix
 import pytest
 from itertools import product
+import numpy
 from .utils import parametrize_over_elements
 
 
@@ -57,3 +58,113 @@ def test_tensor_product_factorisation(cell_type, degree, element_type, element_a
                     if b != -1:
                         values2[b, 0] = tab2[a]
             assert np.allclose(values1, values2)
+
+
+@pytest.mark.parametrize("degree", range(1, 9))
+def test_tensor_product_factorisation_quadrilateral(degree):
+    P = degree
+    cell_type = basix.CellType.quadrilateral
+    element = basix.create_element(basix.ElementFamily.P, cell_type,
+                                   P, basix.LagrangeVariant.gll_warped)
+    factors = element.get_tensor_product_representation()[0]
+
+    # Quadrature degree
+    Q = 2 * P + 2
+    points, w = basix.make_quadrature(basix.QuadratureType.Default, cell_type, Q)
+    data = element.tabulate(1, points)
+    dphi_x = data[1, :, :, 0]
+    dphi_y = data[2, :, :, 0]
+
+    assert points.shape[0] == (P+2) * (P+2)
+
+    # FIXME: This test assumes all factors formed by a single element
+    perm = factors[1]
+    element0 = factors[0][0]
+    cell1d = element0.cell_type
+    points, w = basix.make_quadrature(basix.QuadratureType.Default, cell1d, Q)
+    data = element0.tabulate(1, points)
+    phi0 = data[0, :, :, 0]
+    dphi0 = data[1, :, :, 0]
+
+    # number of dofs in each direction
+    Nd = P + 1
+    # number of quadrature points in each direction
+    Nq = P + 2
+
+    # Compute derivative of basis function in the x direction
+    dphi_tensor = numpy.zeros([Nq, Nq, Nd, Nd])
+    for q0 in range(Nq):
+        for q1 in range(Nq):
+            for i0 in range(Nd):
+                for i1 in range(Nd):
+                    dphi_tensor[q0, q1, i0, i1] = dphi0[q0, i0]*phi0[q1, i1]
+    dphi_tensor = dphi_tensor.reshape([Nq*Nq, Nd*Nd])
+    assert numpy.allclose(dphi_x[:, perm], dphi_tensor)
+
+    # Compute derivative of basis function in the y direction
+    dphi_tensor = numpy.zeros([Nq, Nq, Nd, Nd])
+    for q0 in range(Nq):
+        for q1 in range(Nq):
+            for i0 in range(Nd):
+                for i1 in range(Nd):
+                    dphi_tensor[q0, q1, i0, i1] = phi0[q0, i0]*dphi0[q1, i1]
+
+    dphi_tensor = dphi_tensor.reshape([Nq*Nq, Nd*Nd])
+    assert numpy.allclose(dphi_y[:, perm], dphi_tensor)
+
+
+@pytest.mark.parametrize("degree", range(1, 6))
+def test_tensor_product_factorisation_hexahedron(degree):
+    P = degree
+    element = basix.create_element(basix.ElementFamily.P, basix.CellType.hexahedron,
+                                   P, basix.LagrangeVariant.gll_warped)
+    factors = element.get_tensor_product_representation()[0]
+
+    # Quadrature degree
+    Q = 2 * P + 2
+    points, w = basix.make_quadrature(basix.QuadratureType.Default, basix.CellType.hexahedron, Q)
+    data = element.tabulate(1, points)
+    dphi_x = data[1, :, :, 0]
+    dphi_y = data[2, :, :, 0]
+
+    assert points.shape[0] == (P+2) * (P+2) * (P+2)
+
+    # FIXME: This test assumes all factors formed by a single element
+    perm = factors[1]
+    element0 = factors[0][0]
+    cell1d = element0.cell_type
+    points, w = basix.make_quadrature(basix.QuadratureType.Default, cell1d, Q)
+    data = element0.tabulate(1, points)
+    phi0 = data[0, :, :, 0]
+    dphi0 = data[1, :, :, 0]
+
+    # number of dofs in each direction
+    Nd = P + 1
+    # number of quadrature points in each direction
+    Nq = P + 2
+
+    # Compute derivative of basis function in the x direction
+    dphi_tensor = numpy.zeros([Nq, Nq, Nq, Nd, Nd, Nd])
+    for q0 in range(Nq):
+        for q1 in range(Nq):
+            for q2 in range(Nq):
+                for i0 in range(Nd):
+                    for i1 in range(Nd):
+                        for i2 in range(Nd):
+                            dphi_tensor[q0, q1, q2, i0, i1, i2] = dphi0[q0, i0]*phi0[q1, i1]*phi0[q2, i2]
+
+    dphi_tensor = dphi_tensor.reshape([Nq*Nq*Nq, Nd*Nd*Nd])
+    assert numpy.allclose(dphi_x[:, perm], dphi_tensor)
+
+    # Compute derivative of basis function in the y direction
+    dphi_tensor = numpy.zeros([Nq, Nq, Nq, Nd, Nd, Nd])
+    for q0 in range(Nq):
+        for q1 in range(Nq):
+            for q2 in range(Nq):
+                for i0 in range(Nd):
+                    for i1 in range(Nd):
+                        for i2 in range(Nd):
+                            dphi_tensor[q0, q1, q2, i0, i1, i2] = phi0[q0, i0]*dphi0[q1, i1]*phi0[q2, i2]
+
+    dphi_tensor = dphi_tensor.reshape([Nq*Nq*Nq, Nd*Nd*Nd])
+    assert numpy.allclose(dphi_y[:, perm], dphi_tensor)

--- a/test/test_tensor_products.py
+++ b/test/test_tensor_products.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2021 Matthew Scroggs
+# FEniCS Project
+# SPDX-License-Identifier: MIT
+
+import numpy as np
+import basix
+import pytest
+from itertools import product
+from .utils import parametrize_over_elements
+
+
+def tensor_product(*data):
+    if len(data) == 1:
+        return data[0]
+    if len(data) > 2:
+        return tensor_product(tensor_product(data[0], data[1]), *data[2:])
+
+    a, b = data
+    assert a.shape[0] == b.shape[0] == 1  # TODO: implement for derivatives too
+    assert a.shape[3] == b.shape[3] == 1  # TODO: implement for non-scalar elements
+    out = np.empty((1, a.shape[1] * b.shape[1], a.shape[2] * b.shape[2], 1))
+    for n, (i, j) in enumerate(product(range(a.shape[1]), range(b.shape[1]))):
+        out[0, n, :, 0] = np.outer(a[0, i, :, 0], b[0, j, :, 0]).reshape(-1)
+    return out
+
+
+@parametrize_over_elements(4)
+def test_tensor_product_factorisation(cell_type, degree, element_type, element_args):
+    element = basix.create_element(element_type, cell_type, degree, *element_args)
+    tdim = len(basix.topology(cell_type)) - 1
+
+    if not element.has_tensor_product_factorisation:
+        with pytest.raises(RuntimeError):
+            element.get_tensor_product_representation()
+        pytest.skip()
+
+    factors = element.get_tensor_product_representation()
+
+    lattice_1d = basix.create_lattice(basix.CellType.interval, 1, basix.LatticeType.equispaced, True)
+    lattice_nd = np.array(list(product(*[lattice_1d for i in range(tdim)])))
+
+    tab1 = element.tabulate(0, lattice_nd)
+
+    tab2 = np.empty((1, lattice_nd.shape[0], element.dim, 1))
+
+    for fs, perm in factors:
+        evals = [e.tabulate(0, lattice_1d) for e in fs]
+        tab = tensor_product(*evals)
+        for i, j in enumerate(perm):
+            if j != -1:
+                tab2[:, :, j, :] = tab[:, :, i, :]
+
+    assert np.allclose(tab1, tab2)

--- a/test/test_tensor_products.py
+++ b/test/test_tensor_products.py
@@ -16,12 +16,8 @@ def tensor_product(*data):
         return tensor_product(tensor_product(data[0], data[1]), *data[2:])
 
     a, b = data
-    assert a.shape[0] == b.shape[0] == 1  # TODO: implement for derivatives too
-    assert a.shape[3] == b.shape[3] == 1  # TODO: implement for non-scalar elements
-    out = np.empty((1, a.shape[1] * b.shape[1], a.shape[2] * b.shape[2], 1))
-    for n, (i, j) in enumerate(product(range(a.shape[1]), range(b.shape[1]))):
-        out[0, n, :, 0] = np.outer(a[0, i, :, 0], b[0, j, :, 0]).reshape(-1)
-    return out
+    assert a.shape[1] == b.shape[1] == 1  # TODO: implement for non-scalar elements
+    return np.outer(a[:, 0], b[:, 0]).reshape(-1)
 
 
 @parametrize_over_elements(4)
@@ -36,18 +32,20 @@ def test_tensor_product_factorisation(cell_type, degree, element_type, element_a
 
     factors = element.get_tensor_product_representation()
 
-    lattice_1d = basix.create_lattice(basix.CellType.interval, 1, basix.LatticeType.equispaced, True)
-    lattice_nd = np.array(list(product(*[lattice_1d for i in range(tdim)])))
+    lattice = basix.create_lattice(cell_type, 1, basix.LatticeType.equispaced, True)
 
-    tab1 = element.tabulate(0, lattice_nd)
+    tab1 = element.tabulate(0, lattice)
 
-    tab2 = np.empty((1, lattice_nd.shape[0], element.dim, 1))
+    for i, point in enumerate(lattice):
+        values1 = tab1[0, i, :, :]
 
-    for fs, perm in factors:
-        evals = [e.tabulate(0, lattice_1d) for e in fs]
-        tab = tensor_product(*evals)
-        for i, j in enumerate(perm):
-            if j != -1:
-                tab2[:, :, j, :] = tab[:, :, i, :]
+        values2 = np.empty((element.dim, 1))
 
-    assert np.allclose(tab1, tab2)
+        for fs, perm in factors:
+            evals = [e.tabulate(0, [p]) for e, p in zip(fs, point)]
+            tab2 = tensor_product(*evals)
+            for i, j in enumerate(perm):
+                if j != -1:
+                    values2[j, 0] = tab2[i]
+
+        assert np.allclose(values1, values2)


### PR DESCRIPTION
Added function that returns information about the tensor product factorisation of elements (or throws an error for elements without a TP factorisation)

Fixes #347.