### PR TITLE
Change quadrature numbering to ijk

### DIFF
--- a/cpp/basix/quadrature.cpp
+++ b/cpp/basix/quadrature.cpp
@@ -331,9 +331,9 @@ make_gauss_jacobi_quadrature(cell::type celltype, std::size_t m)
     xt::xtensor<double, 2> Qpts({np * np, 2});
     std::vector<double> Qwts(np * np);
     int c = 0;
-    for (std::size_t j = 0; j < np; ++j)
+    for (std::size_t i = 0; i < np; ++i)
     {
-      for (std::size_t i = 0; i < np; ++i)
+      for (std::size_t j = 0; j < np; ++j)
       {
         Qpts(c, 0) = QptsL[i];
         Qpts(c, 1) = QptsL[j];
@@ -349,11 +349,11 @@ make_gauss_jacobi_quadrature(cell::type celltype, std::size_t m)
     xt::xtensor<double, 2> Qpts({np * np * np, 3});
     std::vector<double> Qwts(np * np * np);
     int c = 0;
-    for (std::size_t k = 0; k < np; ++k)
+    for (std::size_t i = 0; i < np; ++i)
     {
       for (std::size_t j = 0; j < np; ++j)
       {
-        for (std::size_t i = 0; i < np; ++i)
+        for (std::size_t k = 0; k < np; ++k)
         {
           Qpts(c, 0) = QptsL[i];
           Qpts(c, 1) = QptsL[j];
@@ -372,9 +372,9 @@ make_gauss_jacobi_quadrature(cell::type celltype, std::size_t m)
     xt::xtensor<double, 2> Qpts({np * QptsT.shape(0), 3});
     std::vector<double> Qwts(np * QptsT.shape(0));
     int c = 0;
-    for (std::size_t k = 0; k < np; ++k)
+    for (std::size_t i = 0; i < np; ++i)
     {
-      for (std::size_t i = 0; i < QptsT.shape(0); ++i)
+      for (std::size_t k = 0; k < QptsT.shape(0); ++k)
       {
         Qpts(c, 0) = QptsT(i, 0);
         Qpts(c, 1) = QptsT(i, 1);
@@ -440,9 +440,9 @@ make_gll_quadrature(cell::type celltype, std::size_t m)
     xt::xtensor<double, 2> Qpts({np * np, 2});
     std::vector<double> Qwts(np * np);
     int c = 0;
-    for (std::size_t j = 0; j < np; ++j)
+    for (std::size_t i = 0; i < np; ++i)
     {
-      for (std::size_t i = 0; i < np; ++i)
+      for (std::size_t j = 0; j < np; ++j)
       {
         Qpts(c, 0) = QptsL[i];
         Qpts(c, 1) = QptsL[j];
@@ -458,11 +458,11 @@ make_gll_quadrature(cell::type celltype, std::size_t m)
     xt::xtensor<double, 2> Qpts({np * np * np, 3});
     std::vector<double> Qwts(np * np * np);
     int c = 0;
-    for (std::size_t k = 0; k < np; ++k)
+    for (std::size_t i = 0; i < np; ++i)
     {
       for (std::size_t j = 0; j < np; ++j)
       {
-        for (std::size_t i = 0; i < np; ++i)
+        for (std::size_t k = 0; k < np; ++k)
         {
           Qpts(c, 0) = QptsL[i];
           Qpts(c, 1) = QptsL[j];

--- a/cpp/basix/quadrature.cpp
+++ b/cpp/basix/quadrature.cpp
@@ -372,9 +372,9 @@ make_gauss_jacobi_quadrature(cell::type celltype, std::size_t m)
     xt::xtensor<double, 2> Qpts({np * QptsT.shape(0), 3});
     std::vector<double> Qwts(np * QptsT.shape(0));
     int c = 0;
-    for (std::size_t i = 0; i < np; ++i)
+    for (std::size_t i = 0; i < QptsT.shape(0); ++i)
     {
-      for (std::size_t k = 0; k < QptsT.shape(0); ++k)
+      for (std::size_t k = 0; k < np; ++k)
       {
         Qpts(c, 0) = QptsT(i, 0);
         Qpts(c, 1) = QptsT(i, 1);

--- a/test/test_quadrature.py
+++ b/test/test_quadrature.py
@@ -126,7 +126,7 @@ def test_gll():
     # 2D quad
     pts, wts = basix.make_quadrature(basix.QuadratureType.gll, basix.CellType.quadrilateral, m+1)
     pts, wts = 2*pts-1, 4*wts
-    ref_pts2 = np.array([[x, y] for y in ref_pts for x in ref_pts])
+    ref_pts2 = np.array([[x, y] for x in ref_pts for y in ref_pts])
     assert (np.allclose(pts, ref_pts2))
     ref_wts2 = np.array([w1*w2 for w1 in ref_wts for w2 in ref_wts])
     assert (np.allclose(wts, ref_wts2))
@@ -136,7 +136,7 @@ def test_gll():
     # 3D hex
     pts, wts = basix.make_quadrature(basix.QuadratureType.gll, basix.CellType.hexahedron, m+1)
     pts, wts = 2*pts-1, 8*wts
-    ref_pts3 = np.array([[x, y, z] for z in ref_pts for y in ref_pts for x in ref_pts])
+    ref_pts3 = np.array([[x, y, z] for x in ref_pts for y in ref_pts for z in ref_pts])
     assert (np.allclose(pts, ref_pts3))
     ref_wts3 = np.array([w1*w2*w3 for w1 in ref_wts for w2 in ref_wts for w3 in ref_wts])
     assert (np.allclose(wts, ref_wts3))


### PR DESCRIPTION
If the quadrature rule has a tensor product structure use `ijk` ordering instead of reverse `kji` ordering.

Example of node ordering on a quadrilateral:
**ij ordering** 
```
2 -- 5 -- 8
|         |
1    4    7
|         |
0 -- 3 -- 6 
```

**ji ordering** 
```
6 -- 7 -- 8
|         |
3    4    5
|         |
0 -- 1 -- 2
```