### PR TITLE
Fix value shape for Lagrange elements

### DIFF
--- a/cpp/basix/e-lagrange.cpp
+++ b/cpp/basix/e-lagrange.cpp
@@ -141,7 +141,7 @@ FiniteElement create_d_lagrange(cell::type celltype, int degree,
     entity_transformations[cell::type::quadrilateral] = ft;
   }
 
-  return FiniteElement(element::family::P, celltype, degree, {1},
+  return FiniteElement(element::family::P, celltype, degree, {},
                        xt::eye<double>(ndofs), entity_transformations, x, M,
                        maps::type::identity, true, degree, degree);
 }
@@ -871,7 +871,7 @@ FiniteElement create_vtk_element(cell::type celltype, int degree,
         = element::make_discontinuous(x, M, entity_transformations, tdim, 1);
   }
 
-  return FiniteElement(element::family::P, celltype, degree, {1},
+  return FiniteElement(element::family::P, celltype, degree, {},
                        xt::eye<double>(ndofs), entity_transformations, x, M,
                        maps::type::identity, discontinuous, degree, degree);
 }
@@ -1022,7 +1022,7 @@ FiniteElement basix::element::create_lagrange(cell::type celltype, int degree,
     std::map<cell::type, xt::xtensor<double, 3>> entity_transformations;
     xt::xtensor<double, 2> wcoeffs = {{1}};
 
-    return FiniteElement(element::family::P, cell::type::point, 0, {1}, wcoeffs,
+    return FiniteElement(element::family::P, cell::type::point, 0, {}, wcoeffs,
                          entity_transformations, x, M, maps::type::identity,
                          discontinuous, degree, degree);
   }
@@ -1196,7 +1196,7 @@ FiniteElement basix::element::create_lagrange(cell::type celltype, int degree,
   auto tensor_factors
       = create_tensor_product_factors(celltype, degree, variant);
 
-  return FiniteElement(element::family::P, celltype, degree, {1},
+  return FiniteElement(element::family::P, celltype, degree, {},
                        xt::eye<double>(ndofs), entity_transformations, x, M,
                        maps::type::identity, discontinuous, degree, degree,
                        tensor_factors, variant);
@@ -1274,7 +1274,7 @@ FiniteElement basix::element::create_dpc(cell::type celltype, int degree,
         = xt::xtensor<double, 3>({2, 0, 0});
   }
 
-  return FiniteElement(element::family::DPC, celltype, degree, {1}, wcoeffs,
+  return FiniteElement(element::family::DPC, celltype, degree, {}, wcoeffs,
                        entity_transformations, x, M, maps::type::identity,
                        discontinuous, degree, degree);
 }

--- a/cpp/basix/e-lagrange.cpp
+++ b/cpp/basix/e-lagrange.cpp
@@ -997,7 +997,7 @@ FiniteElement create_integral_lagrange(cell::type celltype, int degree,
         = element::make_discontinuous(x, M, entity_transformations, tdim, 1);
   }
 
-  return FiniteElement(element::family::P, celltype, degree, {1},
+  return FiniteElement(element::family::P, celltype, degree, {},
                        xt::eye<double>(ndofs), entity_transformations, x, M,
                        maps::type::identity, discontinuous, degree, degree, {},
                        variant);

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -611,12 +611,6 @@ cell::type FiniteElement::cell_type() const { return _cell_type; }
 //-----------------------------------------------------------------------------
 int FiniteElement::degree() const { return _degree; }
 //-----------------------------------------------------------------------------
-// int FiniteElement::value_size() const
-// {
-//   return std::accumulate(_value_shape.begin(), _value_shape.end(), 1,
-//                          std::multiplies<int>());
-// }
-//-----------------------------------------------------------------------------
 const std::vector<int>& FiniteElement::value_shape() const
 {
   return _value_shape;

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -557,7 +557,6 @@ FiniteElement::tabulate_shape(std::size_t nd, std::size_t num_points) const
     ndsize /= i;
   std::size_t vs = std::accumulate(_value_shape.begin(), _value_shape.end(), 1,
                                    std::multiplies<int>());
-
   std::size_t ndofs = _coeffs.shape(0);
   return {ndsize, num_points, ndofs, vs};
 }
@@ -757,9 +756,8 @@ xt::xtensor<double, 3> FiniteElement::pull_back(
     const xt::xtensor<double, 3>& u, const xt::xtensor<double, 3>& J,
     const xtl::span<const double>& detJ, const xt::xtensor<double, 3>& K) const
 {
-  const std::size_t reference_value_size = std::accumulate(
+  std::size_t reference_value_size = std::accumulate(
       _value_shape.begin(), _value_shape.end(), 1, std::multiplies<int>());
-
   xt::xtensor<double, 3> U({u.shape(0), u.shape(1), reference_value_size});
   using u_t = xt::xview<decltype(u)&, std::size_t, xt::xall<std::size_t>,
                         xt::xall<std::size_t>>;

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -555,7 +555,9 @@ FiniteElement::tabulate_shape(std::size_t nd, std::size_t num_points) const
     ndsize *= (_cell_tdim + i);
   for (std::size_t i = 1; i <= nd; ++i)
     ndsize /= i;
-  std::size_t vs = value_size();
+  std::size_t vs = std::accumulate(_value_shape.begin(), _value_shape.end(), 1,
+                                   std::multiplies<int>());
+
   std::size_t ndofs = _coeffs.shape(0);
   return {ndsize, num_points, ndofs, vs};
 }
@@ -589,7 +591,8 @@ void FiniteElement::tabulate(int nd, const xt::xarray<double>& x,
        static_cast<std::size_t>(polyset::dim(_cell_type, _degree))});
   polyset::tabulate(basis, _cell_type, _degree, nd, _x);
   const int psize = polyset::dim(_cell_type, _degree);
-  const int vs = value_size();
+  int vs = std::accumulate(_value_shape.begin(), _value_shape.end(), 1,
+                           std::multiplies<int>());
   xt::xtensor<double, 2> B, C;
   for (std::size_t p = 0; p < basis.shape(0); ++p)
   {
@@ -608,11 +611,11 @@ cell::type FiniteElement::cell_type() const { return _cell_type; }
 //-----------------------------------------------------------------------------
 int FiniteElement::degree() const { return _degree; }
 //-----------------------------------------------------------------------------
-int FiniteElement::value_size() const
-{
-  return std::accumulate(_value_shape.begin(), _value_shape.end(), 1,
-                         std::multiplies<int>());
-}
+// int FiniteElement::value_size() const
+// {
+//   return std::accumulate(_value_shape.begin(), _value_shape.end(), 1,
+//                          std::multiplies<int>());
+// }
 //-----------------------------------------------------------------------------
 const std::vector<int>& FiniteElement::value_shape() const
 {
@@ -760,7 +763,9 @@ xt::xtensor<double, 3> FiniteElement::pull_back(
     const xt::xtensor<double, 3>& u, const xt::xtensor<double, 3>& J,
     const xtl::span<const double>& detJ, const xt::xtensor<double, 3>& K) const
 {
-  const std::size_t reference_value_size = value_size();
+  const std::size_t reference_value_size = std::accumulate(
+      _value_shape.begin(), _value_shape.end(), 1, std::multiplies<int>());
+
   xt::xtensor<double, 3> U({u.shape(0), u.shape(1), reference_value_size});
   using u_t = xt::xview<decltype(u)&, std::size_t, xt::xall<std::size_t>,
                         xt::xall<std::size_t>>;

--- a/cpp/basix/finite-element.h
+++ b/cpp/basix/finite-element.h
@@ -332,10 +332,10 @@ public:
   /// @return Polynomial degree
   int degree() const;
 
-  /// Get the element value size
-  /// This is just a convenience function returning product(value_shape)
-  /// @return Value size
-  int value_size() const;
+  // /// Get the element value size
+  // /// This is just a convenience function returning product(value_shape)
+  // /// @return Value size
+  // int value_size() const;
 
   /// Get the element value tensor shape, e.g. returning [1] for scalars.
   /// @return Value shape

--- a/cpp/basix/finite-element.h
+++ b/cpp/basix/finite-element.h
@@ -332,11 +332,6 @@ public:
   /// @return Polynomial degree
   int degree() const;
 
-  // /// Get the element value size
-  // /// This is just a convenience function returning product(value_shape)
-  // /// @return Value size
-  // int value_size() const;
-
   /// Get the element value tensor shape, e.g. returning [1] for scalars.
   /// @return Value shape
   const std::vector<int>& value_shape() const;

--- a/cpp/basix/interpolation.cpp
+++ b/cpp/basix/interpolation.cpp
@@ -28,12 +28,18 @@ basix::compute_interpolation_operator(const FiniteElement& element_from,
   const std::size_t dim_from = element_from.dim();
   const std::size_t npts = tab.shape(1);
 
-  if (element_from.value_size() != element_to.value_size())
+  const int vs_from = std::accumulate(element_from.value_shape().begin(),
+                                      element_from.value_shape().end(), 1,
+                                      std::multiplies<int>());
+  const int vs_to = std::accumulate(element_to.value_shape().begin(),
+                                    element_to.value_shape().end(), 1,
+                                    std::multiplies<int>());
+  if (vs_from != vs_to)
   {
-    if (element_to.value_size() == 1)
+    if (vs_to == 1)
     {
       // Map element_from's components into element_to
-      const std::size_t vs = element_from.value_size();
+      const std::size_t vs = vs_from;
       xt::xtensor<double, 2> out({dim_to * vs, dim_from});
       out.fill(0);
       for (std::size_t i = 0; i < vs; ++i)
@@ -44,10 +50,10 @@ basix::compute_interpolation_operator(const FiniteElement& element_from,
 
       return out;
     }
-    else if (element_from.value_size() == 1)
+    else if (vs_from == 1)
     {
       // Map duplicates of element_to to components of element_to
-      const std::size_t vs = element_to.value_size();
+      const std::size_t vs = vs_to;
       xt::xtensor<double, 2> out({dim_to, dim_from * vs});
       out.fill(0);
       for (std::size_t i = 0; i < vs; ++i)
@@ -66,7 +72,7 @@ basix::compute_interpolation_operator(const FiniteElement& element_from,
   }
   else
   {
-    const std::size_t vs = element_from.value_size();
+    const std::size_t vs = vs_from;
     xt::xtensor<double, 2> out({dim_to, dim_from});
     out.fill(0);
     for (std::size_t i = 0; i < dim_to; ++i)

--- a/cpp/basix/moments.cpp
+++ b/cpp/basix/moments.cpp
@@ -184,7 +184,10 @@ xt::xtensor<double, 3> moments::create_dot_moment_dof_transformations(
 
     // Apply interpolation matrix to transformed basis function values
     xt::xtensor<double, 2> Pview, phi_transformed;
-    for (int v = 0; v < moment_space.value_size(); ++v)
+    int vs = std::accumulate(moment_space.value_shape().begin(),
+                             moment_space.value_shape().end(), 1,
+                             std::multiplies<int>());
+    for (int v = 0; v < vs; ++v)
     {
       Pview = xt::view(
           P, xt::range(0, P.shape(0)),

--- a/cpp/basix/moments.cpp
+++ b/cpp/basix/moments.cpp
@@ -444,7 +444,7 @@ moments::make_integral_moments(const FiniteElement& V, cell::type celltype,
     pts = pts.reshape({pts.shape(0), 1});
 
   // Evaluate moment space at quadrature points
-  assert(V.value_size() == 1);
+  assert(V.value_shape().size() == 0);
   const xt::xtensor<double, 2> phi
       = xt::view(V.tabulate(0, pts), 0, xt::all(), xt::all(), 0);
 
@@ -658,7 +658,7 @@ moments::make_tangent_integral_moments(const FiniteElement& V,
   auto wts = xt::adapt(_wts);
 
   // Evaluate moment space at quadrature points
-  assert(V.value_size() == 1);
+  assert(V.value_shape().size() == 0);
   xt::xtensor<double, 2> phi
       = xt::view(V.tabulate(0, pts), 0, xt::all(), xt::all(), 0);
 
@@ -714,7 +714,7 @@ moments::make_normal_integral_moments(const FiniteElement& V,
   auto wts = xt::adapt(_wts);
 
   // Evaluate moment space at quadrature points
-  assert(V.value_size() == 1);
+  assert(V.value_shape().size() == 0);
   xt::xtensor<double, 2> phi
       = xt::view(V.tabulate(0, pts), 0, xt::all(), xt::all(), 0);
 

--- a/python/wrapper.cpp
+++ b/python/wrapper.cpp
@@ -331,7 +331,7 @@ Interface to the Basix C++ library.
                              &FiniteElement::num_entity_closure_dofs)
       .def_property_readonly("entity_closure_dofs",
                              &FiniteElement::entity_closure_dofs)
-      .def_property_readonly("value_size", &FiniteElement::value_size)
+      // .def_property_readonly("value_size", &FiniteElement::value_size)
       .def_property_readonly("value_shape", &FiniteElement::value_shape)
       .def_property_readonly("family", &FiniteElement::family)
       .def_property_readonly("lagrange_variant",

--- a/python/wrapper.cpp
+++ b/python/wrapper.cpp
@@ -339,13 +339,13 @@ Interface to the Basix C++ library.
                              &FiniteElement::num_entity_closure_dofs)
       .def_property_readonly("entity_closure_dofs",
                              &FiniteElement::entity_closure_dofs)
-      .def_property_readonly("value_size",
-                             [](const FiniteElement& e)
-                             {
-                               return std::accumulate(e.value_shape().begin(),
-                                                      e.value_shape().end(), 1,
-                                                      std::multiplies<int>());
-                             })
+      .def("value_size",
+           [](const FiniteElement& e)
+           {
+             return std::accumulate(e.value_shape().begin(),
+                                    e.value_shape().end(), 1,
+                                    std::multiplies<int>());
+           })
       .def_property_readonly("value_shape", &FiniteElement::value_shape)
       .def_property_readonly("family", &FiniteElement::family)
       .def_property_readonly("lagrange_variant",

--- a/python/wrapper.cpp
+++ b/python/wrapper.cpp
@@ -339,13 +339,13 @@ Interface to the Basix C++ library.
                              &FiniteElement::num_entity_closure_dofs)
       .def_property_readonly("entity_closure_dofs",
                              &FiniteElement::entity_closure_dofs)
-      .def("value_size",
-           [](const FiniteElement& e)
-           {
-             return std::accumulate(e.value_shape().begin(),
-                                    e.value_shape().end(), 1,
-                                    std::multiplies<int>());
-           })
+      .def_property_readonly("value_size",
+                             [](const FiniteElement& e)
+                             {
+                               return std::accumulate(e.value_shape().begin(),
+                                                      e.value_shape().end(), 1,
+                                                      std::multiplies<int>());
+                             })
       .def_property_readonly("value_shape", &FiniteElement::value_shape)
       .def_property_readonly("family", &FiniteElement::family)
       .def_property_readonly("lagrange_variant",

--- a/python/wrapper.cpp
+++ b/python/wrapper.cpp
@@ -108,7 +108,8 @@ Interface to the Basix C++ library.
   m.def(
       "tabulate_polynomials",
       [](polynomials::type polytype, cell::type celltype, int d,
-         const py::array_t<double, py::array::c_style>& x) {
+         const py::array_t<double, py::array::c_style>& x)
+      {
         std::vector<std::size_t> shape;
         if (x.ndim() == 2 and x.shape(1) == 1)
           shape.push_back(x.shape(0));
@@ -230,7 +231,8 @@ Interface to the Basix C++ library.
       .def(
           "tabulate",
           [](const FiniteElement& self, int n,
-             const py::array_t<double, py::array::c_style>& x) {
+             const py::array_t<double, py::array::c_style>& x)
+          {
             auto _x = adapt_x(x);
             auto t = self.tabulate(n, _x);
             return py::array_t<double>(t.shape(), t.data());
@@ -243,7 +245,8 @@ Interface to the Basix C++ library.
              const py::array_t<double, py::array::c_style>& U,
              const py::array_t<double, py::array::c_style>& J,
              const py::array_t<double, py::array::c_style>& detJ,
-             const py::array_t<double, py::array::c_style>& K) {
+             const py::array_t<double, py::array::c_style>& K)
+          {
             auto u = self.push_forward(
                 adapt_x(U), adapt_x(J),
                 xtl::span<const double>(detJ.data(), detJ.size()), adapt_x(K));
@@ -256,7 +259,8 @@ Interface to the Basix C++ library.
              const py::array_t<double, py::array::c_style>& u,
              const py::array_t<double, py::array::c_style>& J,
              const py::array_t<double, py::array::c_style>& detJ,
-             const py::array_t<double, py::array::c_style>& K) {
+             const py::array_t<double, py::array::c_style>& K)
+          {
             auto U = self.pull_back(
                 adapt_x(u), adapt_x(J),
                 xtl::span<const double>(detJ.data(), detJ.size()), adapt_x(K));
@@ -266,7 +270,8 @@ Interface to the Basix C++ library.
       .def(
           "apply_dof_transformation",
           [](const FiniteElement& self, py::array_t<double>& data,
-             int block_size, std::uint32_t cell_info) {
+             int block_size, std::uint32_t cell_info)
+          {
             xtl::span<double> data_span(data.mutable_data(), data.size());
             self.apply_dof_transformation(data_span, block_size, cell_info);
             return py::array_t<double>(data_span.size(), data_span.data());
@@ -275,7 +280,8 @@ Interface to the Basix C++ library.
       .def(
           "apply_dof_transformation_to_transpose",
           [](const FiniteElement& self, py::array_t<double>& data,
-             int block_size, std::uint32_t cell_info) {
+             int block_size, std::uint32_t cell_info)
+          {
             xtl::span<double> data_span(data.mutable_data(), data.size());
             self.apply_dof_transformation_to_transpose(data_span, block_size,
                                                        cell_info);
@@ -286,7 +292,8 @@ Interface to the Basix C++ library.
       .def(
           "apply_inverse_transpose_dof_transformation",
           [](const FiniteElement& self, py::array_t<double>& data,
-             int block_size, std::uint32_t cell_info) {
+             int block_size, std::uint32_t cell_info)
+          {
             xtl::span<double> data_span(data.mutable_data(), data.size());
             self.apply_inverse_transpose_dof_transformation(
                 data_span, block_size, cell_info);
@@ -296,14 +303,16 @@ Interface to the Basix C++ library.
               FiniteElement__apply_inverse_transpose_dof_transformation.c_str())
       .def(
           "base_transformations",
-          [](const FiniteElement& self) {
+          [](const FiniteElement& self)
+          {
             xt::xtensor<double, 3> t = self.base_transformations();
             return py::array_t<double>(t.shape(), t.data());
           },
           basix::docstring::FiniteElement__base_transformations.c_str())
       .def(
           "entity_transformations",
-          [](const FiniteElement& self) {
+          [](const FiniteElement& self)
+          {
             std::map<cell::type, xt::xtensor<double, 3>> t
                 = self.entity_transformations();
             py::dict t2;
@@ -317,9 +326,8 @@ Interface to the Basix C++ library.
           basix::docstring::FiniteElement__entity_transformations.c_str())
       .def(
           "get_tensor_product_representation",
-          [](const FiniteElement& self) {
-            return self.get_tensor_product_representation();
-          },
+          [](const FiniteElement& self)
+          { return self.get_tensor_product_representation(); },
           basix::docstring::FiniteElement__get_tensor_product_representation
               .c_str())
       .def_property_readonly("degree", &FiniteElement::degree)
@@ -331,7 +339,13 @@ Interface to the Basix C++ library.
                              &FiniteElement::num_entity_closure_dofs)
       .def_property_readonly("entity_closure_dofs",
                              &FiniteElement::entity_closure_dofs)
-      // .def_property_readonly("value_size", &FiniteElement::value_size)
+      .def_property_readonly("value_size",
+                             [](const FiniteElement& e)
+                             {
+                               return std::accumulate(e.value_shape().begin(),
+                                                      e.value_shape().end(), 1,
+                                                      std::multiplies<int>());
+                             })
       .def_property_readonly("value_shape", &FiniteElement::value_shape)
       .def_property_readonly("family", &FiniteElement::family)
       .def_property_readonly("lagrange_variant",
@@ -344,26 +358,30 @@ Interface to the Basix C++ library.
       .def_property_readonly("map_type", &FiniteElement::map_type)
       .def_property_readonly("degree_bounds", &FiniteElement::degree_bounds)
       .def_property_readonly("points",
-                             [](const FiniteElement& self) {
+                             [](const FiniteElement& self)
+                             {
                                const xt::xtensor<double, 2>& x = self.points();
                                return py::array_t<double>(x.shape(), x.data(),
                                                           py::cast(self));
                              })
       .def_property_readonly(
           "interpolation_matrix",
-          [](const FiniteElement& self) {
+          [](const FiniteElement& self)
+          {
             const xt::xtensor<double, 2>& P = self.interpolation_matrix();
             return py::array_t<double>(P.shape(), P.data(), py::cast(self));
           })
       .def_property_readonly(
           "dual_matrix",
-          [](const FiniteElement& self) {
+          [](const FiniteElement& self)
+          {
             const xt::xtensor<double, 2>& P = self.dual_matrix();
             return py::array_t<double>(P.shape(), P.data(), py::cast(self));
           })
       .def_property_readonly(
           "coefficient_matrix",
-          [](const FiniteElement& self) {
+          [](const FiniteElement& self)
+          {
             const xt::xtensor<double, 2>& P = self.coefficient_matrix();
             return py::array_t<double>(P.shape(), P.data(), py::cast(self));
           })

--- a/test/test_dof_transformations.py
+++ b/test/test_dof_transformations.py
@@ -168,7 +168,7 @@ def test_transformation_of_tabulated_data_triangle(element_type, degree, element
         mapped_values = e.push_forward(reflected_values, J, detJ, K)
 
         for i, j in zip(values, mapped_values):
-            for d in range(e.value_size):
+            for d in range(e.value_size()):
                 i_slice = i[:, d]
                 j_slice = j[:, d]
                 assert np.allclose((bt[0].dot(i_slice))[start: start + ndofs],
@@ -197,7 +197,7 @@ def test_transformation_of_tabulated_data_quadrilateral(element_type, degree, el
         K = np.array([np.linalg.inv(_J) for p in points])
         mapped_values = e.push_forward(reflected_values, J, detJ, K)
         for i, j in zip(values, mapped_values):
-            for d in range(e.value_size):
+            for d in range(e.value_size()):
                 i_slice = i[:, d]
                 j_slice = j[:, d]
                 assert np.allclose((bt[0].dot(i_slice))[start: start + ndofs],
@@ -227,7 +227,7 @@ def test_transformation_of_tabulated_data_tetrahedron(element_type, degree, elem
         K = np.array([np.linalg.inv(_J) for p in points])
         mapped_values = e.push_forward(reflected_values, J, detJ, K)
         for i, j in zip(values, mapped_values):
-            for d in range(e.value_size):
+            for d in range(e.value_size()):
                 i_slice = i[:, d]
                 j_slice = j[:, d]
                 assert np.allclose((bt[0].dot(i_slice))[start: start + ndofs],
@@ -246,7 +246,7 @@ def test_transformation_of_tabulated_data_tetrahedron(element_type, degree, elem
         K = np.array([np.linalg.inv(_J) for p in points])
         mapped_values = e.push_forward(rotated_values, J, detJ, K)
         for i, j in zip(values, mapped_values):
-            for d in range(e.value_size):
+            for d in range(e.value_size()):
                 i_slice = i[:, d]
                 j_slice = j[:, d]
                 assert np.allclose(bt[6].dot(i_slice)[start: start + ndofs],
@@ -263,7 +263,7 @@ def test_transformation_of_tabulated_data_tetrahedron(element_type, degree, elem
         K = np.array([np.linalg.inv(_J) for p in points])
         mapped_values = e.push_forward(reflected_values, J, detJ, K)
         for i, j in zip(values, mapped_values):
-            for d in range(e.value_size):
+            for d in range(e.value_size()):
                 i_slice = i[:, d]
                 j_slice = j[:, d]
                 assert np.allclose((bt[7].dot(i_slice))[start: start + ndofs],
@@ -297,7 +297,7 @@ def test_transformation_of_tabulated_data_hexahedron(element_type, degree, eleme
         K = np.array([np.linalg.inv(_J) for p in points])
         mapped_values = e.push_forward(reflected_values, J, detJ, K)
         for i, j in zip(values, mapped_values):
-            for d in range(e.value_size):
+            for d in range(e.value_size()):
                 i_slice = i[:, d]
                 j_slice = j[:, d]
                 assert np.allclose((bt[0].dot(i_slice))[start: start + ndofs],
@@ -316,7 +316,7 @@ def test_transformation_of_tabulated_data_hexahedron(element_type, degree, eleme
         K = np.array([np.linalg.inv(_J) for p in points])
         mapped_values = e.push_forward(rotated_values, J, detJ, K)
         for i, j in zip(values, mapped_values):
-            for d in range(e.value_size):
+            for d in range(e.value_size()):
                 i_slice = i[:, d]
                 j_slice = j[:, d]
                 assert np.allclose(bt[12].dot(i_slice)[start: start + ndofs],
@@ -333,7 +333,7 @@ def test_transformation_of_tabulated_data_hexahedron(element_type, degree, eleme
         K = np.array([np.linalg.inv(_J) for p in points])
         mapped_values = e.push_forward(reflected_values, J, detJ, K)
         for i, j in zip(values, mapped_values):
-            for d in range(e.value_size):
+            for d in range(e.value_size()):
                 i_slice = i[:, d]
                 j_slice = j[:, d]
                 assert np.allclose((bt[13].dot(i_slice))[start: start + ndofs],
@@ -363,7 +363,7 @@ def test_transformation_of_tabulated_data_prism(element_type, degree, element_ar
         K = np.array([np.linalg.inv(_J) for p in points])
         mapped_values = e.push_forward(reflected_values, J, detJ, K)
         for i, j in zip(values, mapped_values):
-            for d in range(e.value_size):
+            for d in range(e.value_size()):
                 i_slice = i[:, d]
                 j_slice = j[:, d]
                 assert np.allclose((bt[0].dot(i_slice))[start: start + ndofs],
@@ -382,7 +382,7 @@ def test_transformation_of_tabulated_data_prism(element_type, degree, element_ar
         K = np.array([np.linalg.inv(_J) for p in points])
         mapped_values = e.push_forward(rotated_values, J, detJ, K)
         for i, j in zip(values, mapped_values):
-            for d in range(e.value_size):
+            for d in range(e.value_size()):
                 i_slice = i[:, d]
                 j_slice = j[:, d]
                 assert np.allclose(bt[10].dot(i_slice)[start: start + ndofs],
@@ -399,7 +399,7 @@ def test_transformation_of_tabulated_data_prism(element_type, degree, element_ar
         K = np.array([np.linalg.inv(_J) for p in points])
         mapped_values = e.push_forward(reflected_values, J, detJ, K)
         for i, j in zip(values, mapped_values):
-            for d in range(e.value_size):
+            for d in range(e.value_size()):
                 i_slice = i[:, d]
                 j_slice = j[:, d]
                 assert np.allclose((bt[11].dot(i_slice))[start: start + ndofs],
@@ -429,7 +429,7 @@ def test_transformation_of_tabulated_data_pyramid(element_type, degree, element_
         K = np.array([np.linalg.inv(_J) for p in points])
         mapped_values = e.push_forward(reflected_values, J, detJ, K)
         for i, j in zip(values, mapped_values):
-            for d in range(e.value_size):
+            for d in range(e.value_size()):
                 i_slice = i[:, d]
                 j_slice = j[:, d]
                 assert np.allclose((bt[0].dot(i_slice))[start: start + ndofs],
@@ -448,7 +448,7 @@ def test_transformation_of_tabulated_data_pyramid(element_type, degree, element_
         K = np.array([np.linalg.inv(_J) for p in points])
         mapped_values = e.push_forward(rotated_values, J, detJ, K)
         for i, j in zip(values, mapped_values):
-            for d in range(e.value_size):
+            for d in range(e.value_size()):
                 i_slice = i[:, d]
                 j_slice = j[:, d]
                 assert np.allclose(bt[8].dot(i_slice)[start: start + ndofs],
@@ -465,7 +465,7 @@ def test_transformation_of_tabulated_data_pyramid(element_type, degree, element_
         K = np.array([np.linalg.inv(_J) for p in points])
         mapped_values = e.push_forward(reflected_values, J, detJ, K)
         for i, j in zip(values, mapped_values):
-            for d in range(e.value_size):
+            for d in range(e.value_size()):
                 i_slice = i[:, d]
                 j_slice = j[:, d]
                 assert np.allclose((bt[9].dot(i_slice))[start: start + ndofs],

--- a/test/test_interpolation_between_elements.py
+++ b/test/test_interpolation_between_elements.py
@@ -36,7 +36,7 @@ def test_different_order_interpolation_lagrange(cell_type, orders):
     lower_element = basix.create_element(basix.ElementFamily.P, cell_type, orders[0], basix.LagrangeVariant.gll_warped)
     higher_element = basix.create_element(basix.ElementFamily.P, cell_type, orders[1], basix.LagrangeVariant.gll_warped)
 
-    run_test(lower_element, higher_element, orders[0], lower_element.value_size)
+    run_test(lower_element, higher_element, orders[0], lower_element.value_size())
 
 
 @pytest.mark.parametrize("variant1", [basix.LagrangeVariant.equispaced, basix.LagrangeVariant.gll_warped,
@@ -50,7 +50,7 @@ def test_different_variant_interpolation(cell_type, order, variant1, variant2):
     lower_element = basix.create_element(basix.ElementFamily.P, cell_type, order, variant1)
     higher_element = basix.create_element(basix.ElementFamily.P, cell_type, order, variant2)
 
-    run_test(lower_element, higher_element, order, lower_element.value_size)
+    run_test(lower_element, higher_element, order, lower_element.value_size())
 
 
 @pytest.mark.parametrize("family, args", [
@@ -66,7 +66,7 @@ def test_different_order_interpolation_vector(family, args, cell_type, orders):
     lower_element = basix.create_element(family, cell_type, orders[0], *args)
     higher_element = basix.create_element(family, cell_type, orders[1], *args)
 
-    run_test(lower_element, higher_element, orders[0] - 1, lower_element.value_size)
+    run_test(lower_element, higher_element, orders[0] - 1, lower_element.value_size())
 
 
 @pytest.mark.parametrize("family, args", [[basix.ElementFamily.Regge, tuple()]])
@@ -76,7 +76,7 @@ def test_different_order_interpolation_matrix(family, args, cell_type, orders):
     lower_element = basix.create_element(family, cell_type, orders[0], *args)
     higher_element = basix.create_element(family, cell_type, orders[1], *args)
 
-    run_test(lower_element, higher_element, orders[0] - 1, lower_element.value_size)
+    run_test(lower_element, higher_element, orders[0] - 1, lower_element.value_size())
 
 
 @pytest.mark.parametrize("family1, args1", [
@@ -98,7 +98,7 @@ def test_different_element_interpolation(family1, args1, family2, args2, cell_ty
     lower_element = basix.create_element(family1, cell_type, order, *args1)
     higher_element = basix.create_element(family2, cell_type, order, *args2)
 
-    run_test(lower_element, higher_element, order - 1, lower_element.value_size)
+    run_test(lower_element, higher_element, order - 1, lower_element.value_size())
 
 
 @pytest.mark.parametrize("cell_type", [basix.CellType.triangle, basix.CellType.tetrahedron,
@@ -110,20 +110,20 @@ def test_blocked_interpolation(cell_type, order):
     lagrange = basix.create_element(basix.ElementFamily.P, cell_type, order, basix.LagrangeVariant.gll_isaac)
 
     n_points = nedelec.points
-    if nedelec.value_size == 2:
+    if nedelec.value_size() == 2:
         n_eval = np.concatenate([n_points[:, 0] ** order, n_points[:, 1] ** order])
     else:
         n_eval = np.concatenate([n_points[:, 0] ** order, 0 * n_points[:, 0], n_points[:, 1] ** order])
     n_coeffs = nedelec.interpolation_matrix @ n_eval
 
     l_points = lagrange.points
-    if nedelec.value_size == 2:
+    if nedelec.value_size() == 2:
         values = [l_points[:, 0] ** order, l_points[:, 1] ** order]
     else:
         values = [l_points[:, 0] ** order, 0 * l_points[:, 0], l_points[:, 1] ** order]
-    l_coeffs = np.empty(lagrange.dim * nedelec.value_size)
+    l_coeffs = np.empty(lagrange.dim * nedelec.value_size())
     for i, v in enumerate(values):
-        l_coeffs[i::nedelec.value_size] = v
+        l_coeffs[i::nedelec.value_size()] = v
 
     # Test interpolation from Nedelec to blocked Lagrange
     i_m = basix.compute_interpolation_operator(nedelec, lagrange)
@@ -147,7 +147,7 @@ def test_degree_bounds(cell_type, degree, element_type, element_args):
     # degree element.degree_bounds[1]
     coeffs = np.random.rand(element.dim)
     values = np.array([tab[:, :, i] @ coeffs
-                       for i in range(element.value_size)])
+                       for i in range(element.value_size())])
 
     if element.degree_bounds[1] >= 0:
         # The element being tested should be a subset of this Lagrange space
@@ -155,8 +155,8 @@ def test_degree_bounds(cell_type, degree, element_type, element_args):
             basix.ElementFamily.P, cell_type, element.degree_bounds[1], basix.LagrangeVariant.equispaced, True)
         lagrange_coeffs = basix.compute_interpolation_operator(element, lagrange) @ coeffs
         lagrange_tab = lagrange.tabulate(0, points)[0]
-        lagrange_values = np.array([lagrange_tab[:, :, 0] @ lagrange_coeffs[i::element.value_size]
-                                    for i in range(element.value_size)])
+        lagrange_values = np.array([lagrange_tab[:, :, 0] @ lagrange_coeffs[i::element.value_size()]
+                                    for i in range(element.value_size())])
 
         assert np.allclose(values, lagrange_values)
 
@@ -167,8 +167,8 @@ def test_degree_bounds(cell_type, degree, element_type, element_args):
             basix.LagrangeVariant.equispaced, True)
         lagrange_coeffs = basix.compute_interpolation_operator(element, lagrange) @ coeffs
         lagrange_tab = lagrange.tabulate(0, points)[0]
-        lagrange_values = np.array([lagrange_tab[:, :, 0] @ lagrange_coeffs[i::element.value_size]
-                                    for i in range(element.value_size)])
+        lagrange_values = np.array([lagrange_tab[:, :, 0] @ lagrange_coeffs[i::element.value_size()]
+                                    for i in range(element.value_size())])
 
         assert not np.allclose(values, lagrange_values)
 
@@ -180,14 +180,14 @@ def test_degree_bounds(cell_type, degree, element_type, element_args):
         lagrange = basix.create_element(
             basix.ElementFamily.P, cell_type, element.degree_bounds[0],
             basix.LagrangeVariant.equispaced, True)
-        lagrange_coeffs = np.random.rand(lagrange.dim * element.value_size)
+        lagrange_coeffs = np.random.rand(lagrange.dim * element.value_size())
         lagrange_tab = lagrange.tabulate(0, points)[0]
-        lagrange_values = np.array([lagrange_tab[:, :, 0] @ lagrange_coeffs[i::element.value_size]
-                                    for i in range(element.value_size)])
+        lagrange_values = np.array([lagrange_tab[:, :, 0] @ lagrange_coeffs[i::element.value_size()]
+                                    for i in range(element.value_size())])
 
         coeffs = basix.compute_interpolation_operator(lagrange, element) @ lagrange_coeffs
         values = np.array([tab[:, :, i] @ coeffs
-                           for i in range(element.value_size)])
+                           for i in range(element.value_size())])
 
         assert np.allclose(values, lagrange_values)
 
@@ -196,13 +196,13 @@ def test_degree_bounds(cell_type, degree, element_type, element_args):
         lagrange = basix.create_element(
             basix.ElementFamily.P, cell_type, element.degree_bounds[0] + 1,
             basix.LagrangeVariant.equispaced, True)
-        lagrange_coeffs = np.random.rand(lagrange.dim * element.value_size)
+        lagrange_coeffs = np.random.rand(lagrange.dim * element.value_size())
         lagrange_tab = lagrange.tabulate(0, points)[0]
-        lagrange_values = np.array([lagrange_tab[:, :, 0] @ lagrange_coeffs[i::element.value_size]
-                                    for i in range(element.value_size)])
+        lagrange_values = np.array([lagrange_tab[:, :, 0] @ lagrange_coeffs[i::element.value_size()]
+                                    for i in range(element.value_size())])
 
         coeffs = basix.compute_interpolation_operator(lagrange, element) @ lagrange_coeffs
         values = np.array([tab[:, :, i] @ coeffs
-                           for i in range(element.value_size)])
+                           for i in range(element.value_size())])
 
         assert not np.allclose(values, lagrange_values)

--- a/test/test_mappings.py
+++ b/test/test_mappings.py
@@ -50,7 +50,7 @@ def test_mappings_2d_to_2d(element_type, element_args):
                   [random.random(), random.random()]])
     detJ = np.linalg.det(J)
     K = np.linalg.inv(J)
-    run_map_test(e, J, detJ, K, e.value_size, e.value_size)
+    run_map_test(e, J, detJ, K, e.value_size(), e.value_size())
 
 
 @pytest.mark.parametrize("element_type, element_args", elements)
@@ -62,13 +62,13 @@ def test_mappings_2d_to_3d(element_type, element_args):
     detJ = np.sqrt(6)
     K = np.array([[0.5, 0.5, 0.], [-0.5, 0.5, 0.]])
 
-    if e.value_size == 1:
+    if e.value_size() == 1:
         physical_vs = 1
-    elif e.value_size == 2:
+    elif e.value_size() == 2:
         physical_vs = 3
-    elif e.value_size == 4:
+    elif e.value_size() == 4:
         physical_vs = 9
-    run_map_test(e, J, detJ, K, e.value_size, physical_vs)
+    run_map_test(e, J, detJ, K, e.value_size(), physical_vs)
 
 
 @pytest.mark.parametrize("element_type, element_args", elements)
@@ -81,4 +81,4 @@ def test_mappings_3d_to_3d(element_type, element_args):
     detJ = np.linalg.det(J)
     K = np.linalg.inv(J)
 
-    run_map_test(e, J, detJ, K, e.value_size, e.value_size)
+    run_map_test(e, J, detJ, K, e.value_size(), e.value_size())


### PR DESCRIPTION
Value shape should be empty -> implies scalar element.

Fixes issue in DOLFINx with creating elements directly from Basix objects.