### PR TITLE
Fix value shape for Lagrange elements

### DIFF
--- a/cpp/basix/e-lagrange.cpp
+++ b/cpp/basix/e-lagrange.cpp
@@ -141,7 +141,7 @@ FiniteElement create_d_lagrange(cell::type celltype, int degree,
     entity_transformations[cell::type::quadrilateral] = ft;
   }
 
-  return FiniteElement(element::family::P, celltype, degree, {1},
+  return FiniteElement(element::family::P, celltype, degree, {},
                        xt::eye<double>(ndofs), entity_transformations, x, M,
                        maps::type::identity, true, degree, degree);
 }
@@ -871,7 +871,7 @@ FiniteElement create_vtk_element(cell::type celltype, int degree,
         = element::make_discontinuous(x, M, entity_transformations, tdim, 1);
   }
 
-  return FiniteElement(element::family::P, celltype, degree, {1},
+  return FiniteElement(element::family::P, celltype, degree, {},
                        xt::eye<double>(ndofs), entity_transformations, x, M,
                        maps::type::identity, discontinuous, degree, degree);
 }
@@ -997,7 +997,7 @@ FiniteElement create_integral_lagrange(cell::type celltype, int degree,
         = element::make_discontinuous(x, M, entity_transformations, tdim, 1);
   }
 
-  return FiniteElement(element::family::P, celltype, degree, {1},
+  return FiniteElement(element::family::P, celltype, degree, {},
                        xt::eye<double>(ndofs), entity_transformations, x, M,
                        maps::type::identity, discontinuous, degree, degree, {},
                        variant);
@@ -1022,7 +1022,7 @@ FiniteElement basix::element::create_lagrange(cell::type celltype, int degree,
     std::map<cell::type, xt::xtensor<double, 3>> entity_transformations;
     xt::xtensor<double, 2> wcoeffs = {{1}};
 
-    return FiniteElement(element::family::P, cell::type::point, 0, {1}, wcoeffs,
+    return FiniteElement(element::family::P, cell::type::point, 0, {}, wcoeffs,
                          entity_transformations, x, M, maps::type::identity,
                          discontinuous, degree, degree);
   }
@@ -1196,7 +1196,7 @@ FiniteElement basix::element::create_lagrange(cell::type celltype, int degree,
   auto tensor_factors
       = create_tensor_product_factors(celltype, degree, variant);
 
-  return FiniteElement(element::family::P, celltype, degree, {1},
+  return FiniteElement(element::family::P, celltype, degree, {},
                        xt::eye<double>(ndofs), entity_transformations, x, M,
                        maps::type::identity, discontinuous, degree, degree,
                        tensor_factors, variant);
@@ -1274,7 +1274,7 @@ FiniteElement basix::element::create_dpc(cell::type celltype, int degree,
         = xt::xtensor<double, 3>({2, 0, 0});
   }
 
-  return FiniteElement(element::family::DPC, celltype, degree, {1}, wcoeffs,
+  return FiniteElement(element::family::DPC, celltype, degree, {}, wcoeffs,
                        entity_transformations, x, M, maps::type::identity,
                        discontinuous, degree, degree);
 }

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -555,7 +555,8 @@ FiniteElement::tabulate_shape(std::size_t nd, std::size_t num_points) const
     ndsize *= (_cell_tdim + i);
   for (std::size_t i = 1; i <= nd; ++i)
     ndsize /= i;
-  std::size_t vs = value_size();
+  std::size_t vs = std::accumulate(_value_shape.begin(), _value_shape.end(), 1,
+                                   std::multiplies<int>());
   std::size_t ndofs = _coeffs.shape(0);
   return {ndsize, num_points, ndofs, vs};
 }
@@ -589,7 +590,8 @@ void FiniteElement::tabulate(int nd, const xt::xarray<double>& x,
        static_cast<std::size_t>(polyset::dim(_cell_type, _degree))});
   polyset::tabulate(basis, _cell_type, _degree, nd, _x);
   const int psize = polyset::dim(_cell_type, _degree);
-  const int vs = value_size();
+  const int vs = std::accumulate(_value_shape.begin(), _value_shape.end(), 1,
+                                 std::multiplies<int>());
   xt::xtensor<double, 2> B, C;
   for (std::size_t p = 0; p < basis.shape(0); ++p)
   {
@@ -607,12 +609,6 @@ void FiniteElement::tabulate(int nd, const xt::xarray<double>& x,
 cell::type FiniteElement::cell_type() const { return _cell_type; }
 //-----------------------------------------------------------------------------
 int FiniteElement::degree() const { return _degree; }
-//-----------------------------------------------------------------------------
-int FiniteElement::value_size() const
-{
-  return std::accumulate(_value_shape.begin(), _value_shape.end(), 1,
-                         std::multiplies<int>());
-}
 //-----------------------------------------------------------------------------
 const std::vector<int>& FiniteElement::value_shape() const
 {
@@ -760,7 +756,9 @@ xt::xtensor<double, 3> FiniteElement::pull_back(
     const xt::xtensor<double, 3>& u, const xt::xtensor<double, 3>& J,
     const xtl::span<const double>& detJ, const xt::xtensor<double, 3>& K) const
 {
-  const std::size_t reference_value_size = value_size();
+  const std::size_t reference_value_size = std::accumulate(
+      _value_shape.begin(), _value_shape.end(), 1, std::multiplies<int>());
+
   xt::xtensor<double, 3> U({u.shape(0), u.shape(1), reference_value_size});
   using u_t = xt::xview<decltype(u)&, std::size_t, xt::xall<std::size_t>,
                         xt::xall<std::size_t>>;

--- a/cpp/basix/finite-element.h
+++ b/cpp/basix/finite-element.h
@@ -332,17 +332,13 @@ public:
   /// @return Polynomial degree
   int degree() const;
 
-  /// Get the element value size
-  /// This is just a convenience function returning product(value_shape)
-  /// @return Value size
-  int value_size() const;
-
-  /// Get the element value tensor shape, e.g. returning [1] for scalars.
+  /// The element value tensor shape, e.g. returning {} for scalars, {3}
+  /// for vectors in 3D, {2, 2} for a rank-2 tensor in 2D.
   /// @return Value shape
   const std::vector<int>& value_shape() const;
 
-  /// Dimension of the finite element space (number of degrees of
-  /// freedom for the element)
+  /// Dimension of the finite element space (number of
+  /// degrees-of-freedom for the element)
   /// @return Number of degrees of freedom
   int dim() const;
 
@@ -350,8 +346,8 @@ public:
   /// @return The family
   element::family family() const;
 
-  /// Get the Lagrange variant of the element, or throw an error if element has
-  /// no Lagrange variant
+  /// Get the Lagrange variant of the element.
+  /// @note Throws an error if element has no Lagrange variant
   /// @return The Lagrange variant
   element::lagrange_variant lagrange_variant() const;
 
@@ -360,8 +356,8 @@ public:
   maps::type map_type() const;
 
   /// Indicates whether this element is the discontinuous variant
-  /// @return True if this element is a discontinuous version
-  /// of the element
+  /// @return True if this element is a discontinuous version of the
+  /// element
   bool discontinuous() const;
 
   /// Indicates whether the dof transformations are all permutations
@@ -377,12 +373,12 @@ public:
   /// points that share a common Jacobian.
   /// @param[in] U The function values on the reference. The indices are
   /// [Jacobian index, point index, components].
-  /// @param[in] J The Jacobian of the mapping. The indices are [Jacobian
-  /// index, J_i, J_j].
-  /// @param[in] detJ The determinant of the Jacobian of the mapping. It has
-  /// length `J.shape(0)`
-  /// @param[in] K The inverse of the Jacobian of the mapping. The indices
-  /// are [Jacobian index, K_i, K_j].
+  /// @param[in] J The Jacobian of the mapping. The indices are
+  /// [Jacobian index, J_i, J_j].
+  /// @param[in] detJ The determinant of the Jacobian of the mapping. It
+  /// has length `J.shape(0)`
+  /// @param[in] K The inverse of the Jacobian of the mapping. The
+  /// indices are [Jacobian index, K_i, K_j].
   /// @return The function values on the cell. The indices are [Jacobian
   /// index, point index, components].
   xt::xtensor<double, 3> push_forward(const xt::xtensor<double, 3>& U,
@@ -726,19 +722,20 @@ public:
   /// coefficients = i_m * values
   /// \endcode
   ///
-  /// To interpolate into a Raviart-Thomas space, the following should be done:
+  /// To interpolate into a Raviart-Thomas space, the following should
+  /// be done:
   /// \code{.pseudo}
   /// i_m = element.interpolation_matrix()
   /// pts = element.points()
-  /// vs = element.value_size()
+  /// vs = prod(element.value_shape())
   /// values = VECTOR(pts.shape(0) * vs)
   /// FOR i, p IN ENUMERATE(pts):
   ///     values[i::pts.shape(0)] = f.evaluate_at(p)
   /// coefficients = i_m * values
   /// \endcode
   ///
-  /// To interpolate into a Lagrange space with a block size, the following
-  /// should be done:
+  /// To interpolate into a Lagrange space with a block size, the
+  /// following should be done:
   /// \code{.pseudo}
   /// i_m = element.interpolation_matrix()
   /// pts = element.points()
@@ -755,15 +752,15 @@ public:
 
   /// Get the dual matrix.
   ///
-  /// This is the matrix @f$BD^{T}@f$, as described in the documentation of the
-  /// `FiniteElement()` constructor.
+  /// This is the matrix @f$BD^{T}@f$, as described in the documentation
+  /// of the `FiniteElement()` constructor.
   /// @return The dual matrix
   xt::xtensor<double, 2> dual_matrix() const;
 
   /// Get the matrix of coefficients.
   ///
-  /// This is the matrix @f$C@f$, as described in the documentation of the
-  /// `FiniteElement()` constructor.
+  /// This is the matrix @f$C@f$, as described in the documentation of
+  /// the `FiniteElement()` constructor.
   /// @return The dual matrix
   xt::xtensor<double, 2> coefficient_matrix() const;
 
@@ -774,18 +771,20 @@ public:
   /// subspace of this element
   std::array<int, 2> degree_bounds() const;
 
-  /// Indicates whether or not this element has a tensor product representation.
+  /// Indicates whether or not this element has a tensor product
+  /// representation.
   bool has_tensor_product_factorisation() const;
 
-  /// Get the tensor product representation of this element, or throw an error
-  /// if no such factorisation exists.
+  /// Get the tensor product representation of this element, or throw an
+  /// error if no such factorisation exists.
   ///
-  /// The tensor product representation will be a vector of tuples. Each tuple
-  /// contains a vector of finite elements, and a vector on integers. The vector
-  /// of finite elements gives the elements on an interval that appear in the
-  /// tensor product representation. The vector of integers gives the
-  /// permutation between the numbering of the tensor product DOFs and the
-  /// number of the DOFs of this Basix element.
+  /// The tensor product representation will be a vector of tuples. Each
+  /// tuple contains a vector of finite elements, and a vector on
+  /// integers. The vector of finite elements gives the elements on an
+  /// interval that appear in the tensor product representation. The
+  /// vector of integers gives the permutation between the numbering of
+  /// the tensor product DOFs and the number of the DOFs of this Basix
+  /// element.
   /// @return The tensor product representation
   std::vector<std::tuple<std::vector<FiniteElement>, std::vector<int>>>
   get_tensor_product_representation() const;
@@ -830,7 +829,8 @@ private:
   // count on the associated entity, as listed by cell::topology.
   std::vector<std::vector<int>> _num_edofs;
 
-  // Number of dofs associated with the closure of each cell (sub-)entity
+  // Number of dofs associated with the closure of each cell
+  // (sub-)entity
   std::vector<std::vector<int>> _num_e_closure_dofs;
 
   // Dofs associated with each cell (sub-)entity
@@ -856,47 +856,49 @@ private:
   /// The interpolation weights and points
   xt::xtensor<double, 2> _matM;
 
-  /// Indicates whether or not the DOF transformations are all permutations
+  // Indicates whether or not the DOF transformations are all
+  // permutations
   bool _dof_transformations_are_permutations;
 
-  /// Indicates whether or not the DOF transformations are all identity
+  // Indicates whether or not the DOF transformations are all identity
   bool _dof_transformations_are_identity;
 
-  /// The entity permutations (factorised). This will only be set if
-  /// _dof_transformations_are_permutations is True and
-  /// _dof_transformations_are_identity is False
+  // The entity permutations (factorised). This will only be set if
+  // _dof_transformations_are_permutations is True and
+  // _dof_transformations_are_identity is False
   std::map<cell::type, std::vector<std::vector<std::size_t>>> _eperm;
 
-  /// The reverse entity permutations (factorised). This will only be set if
-  /// _dof_transformations_are_permutations is True and
-  /// _dof_transformations_are_identity is False
+  // The reverse entity permutations (factorised). This will only be set
+  // if _dof_transformations_are_permutations is True and
+  // _dof_transformations_are_identity is False
   std::map<cell::type, std::vector<std::vector<std::size_t>>> _eperm_rev;
 
-  /// The entity transformations in precomputed form
+  // The entity transformations in precomputed form
   std::map<cell::type,
            std::vector<std::tuple<std::vector<std::size_t>, std::vector<double>,
                                   xt::xtensor<double, 2>>>>
       _etrans;
 
-  /// The transposed entity transformations in precomputed form
+  // The transposed entity transformations in precomputed form
   std::map<cell::type,
            std::vector<std::tuple<std::vector<std::size_t>, std::vector<double>,
                                   xt::xtensor<double, 2>>>>
       _etransT;
 
-  /// The inverse entity transformations in precomputed form
+  // The inverse entity transformations in precomputed form
   std::map<cell::type,
            std::vector<std::tuple<std::vector<std::size_t>, std::vector<double>,
                                   xt::xtensor<double, 2>>>>
       _etrans_inv;
 
-  /// The inverse transpose entity transformations in precomputed form
+  // The inverse transpose entity transformations in precomputed form
   std::map<cell::type,
            std::vector<std::tuple<std::vector<std::size_t>, std::vector<double>,
                                   xt::xtensor<double, 2>>>>
       _etrans_invT;
 
-  // Indicates whether or not this is the discontinuous version of the element
+  // Indicates whether or not this is the discontinuous version of the
+  // element
   bool _discontinuous;
 
   // The dual matrix
@@ -909,10 +911,10 @@ private:
   std::array<int, 2> _degree_bounds;
 
   // Tensor product representation
-  // Entries of tuple are (list of elements on an interval, permutation of DOF
-  // numbers)
-  // @todo: For vector-valued elements, a tensor product type and a scaling
-  // factor may additionally be needed.
+  // Entries of tuple are (list of elements on an interval, permutation
+  // of DOF numbers)
+  // @todo: For vector-valued elements, a tensor product type and a
+  // scaling factor may additionally be needed.
   std::vector<std::tuple<std::vector<FiniteElement>, std::vector<int>>>
       _tensor_factors;
 };
@@ -932,18 +934,21 @@ FiniteElement create_element(element::family family, cell::type cell,
 
 /// Create an element
 /// @param[in] family The element family
-/// @param[in] cell The reference cell type that the element is defined on
+/// @param[in] cell The reference cell type that the element is defined
+/// on
 /// @param[in] degree The degree of the element
-/// @param[in] discontinuous Indicates whether the element is discontinuous
-/// between cells points of the element. The discontinuous element will have the
-/// same DOFs, but they will all be associated with the interior of the cell.
+/// @param[in] discontinuous Indicates whether the element is
+/// discontinuous between cells points of the element. The discontinuous
+/// element will have the same DOFs, but they will all be associated
+/// with the interior of the cell.
 /// @return A finite element
 FiniteElement create_element(element::family family, cell::type cell,
                              int degree, bool discontinuous);
 
 /// Create a continuous element using a given Lagrange variant
 /// @param[in] family The element family
-/// @param[in] cell The reference cell type that the element is defined on
+/// @param[in] cell The reference cell type that the element is defined
+/// on
 /// @param[in] degree The degree of the element
 /// @param[in] variant The variant of Lagrange to use
 /// @return A finite element
@@ -952,7 +957,8 @@ FiniteElement create_element(element::family family, cell::type cell,
 
 /// Create a continuous element
 /// @param[in] family The element family
-/// @param[in] cell The reference cell type that the element is defined on
+/// @param[in] cell The reference cell type that the element is defined
+/// on
 /// @param[in] degree The degree of the element
 /// @return A finite element
 FiniteElement create_element(element::family family, cell::type cell,
@@ -1062,8 +1068,8 @@ void FiniteElement::apply_inverse_transpose_dof_transformation(
 
   if (_cell_tdim >= 2)
   {
-    // This assumes 3 bits are used per face. This will need updating if 3D
-    // cells with faces with more than 4 sides are implemented
+    // This assumes 3 bits are used per face. This will need updating if
+    // 3D cells with faces with more than 4 sides are implemented
     int face_start = _cell_tdim == 3 ? 3 * _num_edofs[2].size() : 0;
     int dofstart
         = std::accumulate(_num_edofs[0].cbegin(), _num_edofs[0].cend(), 0);
@@ -1109,8 +1115,8 @@ void FiniteElement::apply_inverse_dof_transformation(
 
   if (_cell_tdim >= 2)
   {
-    // This assumes 3 bits are used per face. This will need updating if 3D
-    // cells with faces with more than 4 sides are implemented
+    // This assumes 3 bits are used per face. This will need updating if
+    // 3D cells with faces with more than 4 sides are implemented
     int face_start = _cell_tdim == 3 ? 3 * _num_edofs[2].size() : 0;
     int dofstart
         = std::accumulate(_num_edofs[0].cbegin(), _num_edofs[0].cend(), 0);

--- a/cpp/basix/interpolation.cpp
+++ b/cpp/basix/interpolation.cpp
@@ -28,33 +28,38 @@ basix::compute_interpolation_operator(const FiniteElement& element_from,
   const std::size_t dim_from = element_from.dim();
   const std::size_t npts = tab.shape(1);
 
-  if (element_from.value_size() != element_to.value_size())
+  const std::size_t vs_from = std::accumulate(
+      element_from.value_shape().begin(), element_from.value_shape().end(), 1,
+      std::multiplies<int>());
+  const std::size_t vs_to = std::accumulate(element_to.value_shape().begin(),
+                                            element_to.value_shape().end(), 1,
+                                            std::multiplies<int>());
+
+  if (vs_from != vs_to)
   {
-    if (element_to.value_size() == 1)
+    if (vs_to == 1)
     {
       // Map element_from's components into element_to
-      const std::size_t vs = element_from.value_size();
-      xt::xtensor<double, 2> out({dim_to * vs, dim_from});
+      xt::xtensor<double, 2> out({dim_to * vs_from, dim_from});
       out.fill(0);
-      for (std::size_t i = 0; i < vs; ++i)
+      for (std::size_t i = 0; i < vs_from; ++i)
         for (std::size_t j = 0; j < dim_to; ++j)
           for (std::size_t k = 0; k < dim_from; ++k)
             for (std::size_t l = 0; l < npts; ++l)
-              out(i + j * vs, k) += i_m(j, l) * tab(0, l, k, i);
+              out(i + j * vs_from, k) += i_m(j, l) * tab(0, l, k, i);
 
       return out;
     }
-    else if (element_from.value_size() == 1)
+    else if (vs_from == 1)
     {
       // Map duplicates of element_to to components of element_to
-      const std::size_t vs = element_to.value_size();
-      xt::xtensor<double, 2> out({dim_to, dim_from * vs});
+      xt::xtensor<double, 2> out({dim_to, dim_from * vs_to});
       out.fill(0);
-      for (std::size_t i = 0; i < vs; ++i)
+      for (std::size_t i = 0; i < vs_to; ++i)
         for (std::size_t j = 0; j < dim_from; ++j)
           for (std::size_t k = 0; k < dim_to; ++k)
             for (std::size_t l = 0; l < npts; ++l)
-              out(k, i + j * vs) += i_m(k, i * npts + l) * tab(0, l, j, 0);
+              out(k, i + j * vs_to) += i_m(k, i * npts + l) * tab(0, l, j, 0);
 
       return out;
     }
@@ -66,12 +71,11 @@ basix::compute_interpolation_operator(const FiniteElement& element_from,
   }
   else
   {
-    const std::size_t vs = element_from.value_size();
     xt::xtensor<double, 2> out({dim_to, dim_from});
     out.fill(0);
     for (std::size_t i = 0; i < dim_to; ++i)
       for (std::size_t j = 0; j < dim_from; ++j)
-        for (std::size_t k = 0; k < vs; ++k)
+        for (std::size_t k = 0; k < vs_from; ++k)
           for (std::size_t l = 0; l < npts; ++l)
             out(i, j) += i_m(i, k * npts + l) * tab(0, l, j, k);
 

--- a/cpp/basix/moments.cpp
+++ b/cpp/basix/moments.cpp
@@ -184,7 +184,10 @@ xt::xtensor<double, 3> moments::create_dot_moment_dof_transformations(
 
     // Apply interpolation matrix to transformed basis function values
     xt::xtensor<double, 2> Pview, phi_transformed;
-    for (int v = 0; v < moment_space.value_size(); ++v)
+    const int vs = std::accumulate(moment_space.value_shape().begin(),
+                                   moment_space.value_shape().end(), 1,
+                                   std::multiplies<int>());
+    for (int v = 0; v < vs; ++v)
     {
       Pview = xt::view(
           P, xt::range(0, P.shape(0)),
@@ -441,7 +444,9 @@ moments::make_integral_moments(const FiniteElement& V, cell::type celltype,
     pts = pts.reshape({pts.shape(0), 1});
 
   // Evaluate moment space at quadrature points
-  assert(V.value_size() == 1);
+  assert(std::accumulate(V.value_shape().begin(), V.value_shape().end(), 1,
+                         std::multiplies<int>())
+         == 1);
   const xt::xtensor<double, 2> phi
       = xt::view(V.tabulate(0, pts), 0, xt::all(), xt::all(), 0);
 
@@ -655,7 +660,9 @@ moments::make_tangent_integral_moments(const FiniteElement& V,
   auto wts = xt::adapt(_wts);
 
   // Evaluate moment space at quadrature points
-  assert(V.value_size() == 1);
+  assert(std::accumulate(V.value_shape().begin(), V.value_shape().end(), 1,
+                         std::multiplies<int>())
+         == 1);
   xt::xtensor<double, 2> phi
       = xt::view(V.tabulate(0, pts), 0, xt::all(), xt::all(), 0);
 
@@ -711,7 +718,9 @@ moments::make_normal_integral_moments(const FiniteElement& V,
   auto wts = xt::adapt(_wts);
 
   // Evaluate moment space at quadrature points
-  assert(V.value_size() == 1);
+  assert(std::accumulate(V.value_shape().begin(), V.value_shape().end(), 1,
+                         std::multiplies<int>())
+         == 1);
   xt::xtensor<double, 2> phi
       = xt::view(V.tabulate(0, pts), 0, xt::all(), xt::all(), 0);
 

--- a/python/docs.h
+++ b/python/docs.h
@@ -467,15 +467,16 @@ dict
 )";
 
 const std::string FiniteElement__get_tensor_product_representation = R"(
-Get the tensor product representation of this element, or throw an error
-if no such factorisation exists.
+Get the tensor product representation of this element, or throw an
+error if no such factorisation exists.
 
-The tensor product representation will be a vector of tuples. Each tuple
-contains a vector of finite elements, and a vector on integers. The vector
-of finite elements gives the elements on an interval that appear in the
-tensor product representation. The vector of integers gives the
-permutation between the numbering of the tensor product DOFs and the
-number of the DOFs of this Basix element.
+The tensor product representation will be a vector of tuples. Each
+tuple contains a vector of finite elements, and a vector on
+integers. The vector of finite elements gives the elements on an
+interval that appear in the tensor product representation. The
+vector of integers gives the permutation between the numbering of
+the tensor product DOFs and the number of the DOFs of this Basix
+element.
 
 Returns
 =======

--- a/python/wrapper.cpp
+++ b/python/wrapper.cpp
@@ -108,7 +108,8 @@ Interface to the Basix C++ library.
   m.def(
       "tabulate_polynomials",
       [](polynomials::type polytype, cell::type celltype, int d,
-         const py::array_t<double, py::array::c_style>& x) {
+         const py::array_t<double, py::array::c_style>& x)
+      {
         std::vector<std::size_t> shape;
         if (x.ndim() == 2 and x.shape(1) == 1)
           shape.push_back(x.shape(0));
@@ -230,7 +231,8 @@ Interface to the Basix C++ library.
       .def(
           "tabulate",
           [](const FiniteElement& self, int n,
-             const py::array_t<double, py::array::c_style>& x) {
+             const py::array_t<double, py::array::c_style>& x)
+          {
             auto _x = adapt_x(x);
             auto t = self.tabulate(n, _x);
             return py::array_t<double>(t.shape(), t.data());
@@ -243,7 +245,8 @@ Interface to the Basix C++ library.
              const py::array_t<double, py::array::c_style>& U,
              const py::array_t<double, py::array::c_style>& J,
              const py::array_t<double, py::array::c_style>& detJ,
-             const py::array_t<double, py::array::c_style>& K) {
+             const py::array_t<double, py::array::c_style>& K)
+          {
             auto u = self.push_forward(
                 adapt_x(U), adapt_x(J),
                 xtl::span<const double>(detJ.data(), detJ.size()), adapt_x(K));
@@ -256,7 +259,8 @@ Interface to the Basix C++ library.
              const py::array_t<double, py::array::c_style>& u,
              const py::array_t<double, py::array::c_style>& J,
              const py::array_t<double, py::array::c_style>& detJ,
-             const py::array_t<double, py::array::c_style>& K) {
+             const py::array_t<double, py::array::c_style>& K)
+          {
             auto U = self.pull_back(
                 adapt_x(u), adapt_x(J),
                 xtl::span<const double>(detJ.data(), detJ.size()), adapt_x(K));
@@ -266,7 +270,8 @@ Interface to the Basix C++ library.
       .def(
           "apply_dof_transformation",
           [](const FiniteElement& self, py::array_t<double>& data,
-             int block_size, std::uint32_t cell_info) {
+             int block_size, std::uint32_t cell_info)
+          {
             xtl::span<double> data_span(data.mutable_data(), data.size());
             self.apply_dof_transformation(data_span, block_size, cell_info);
             return py::array_t<double>(data_span.size(), data_span.data());
@@ -275,7 +280,8 @@ Interface to the Basix C++ library.
       .def(
           "apply_dof_transformation_to_transpose",
           [](const FiniteElement& self, py::array_t<double>& data,
-             int block_size, std::uint32_t cell_info) {
+             int block_size, std::uint32_t cell_info)
+          {
             xtl::span<double> data_span(data.mutable_data(), data.size());
             self.apply_dof_transformation_to_transpose(data_span, block_size,
                                                        cell_info);
@@ -286,7 +292,8 @@ Interface to the Basix C++ library.
       .def(
           "apply_inverse_transpose_dof_transformation",
           [](const FiniteElement& self, py::array_t<double>& data,
-             int block_size, std::uint32_t cell_info) {
+             int block_size, std::uint32_t cell_info)
+          {
             xtl::span<double> data_span(data.mutable_data(), data.size());
             self.apply_inverse_transpose_dof_transformation(
                 data_span, block_size, cell_info);
@@ -296,14 +303,16 @@ Interface to the Basix C++ library.
               FiniteElement__apply_inverse_transpose_dof_transformation.c_str())
       .def(
           "base_transformations",
-          [](const FiniteElement& self) {
+          [](const FiniteElement& self)
+          {
             xt::xtensor<double, 3> t = self.base_transformations();
             return py::array_t<double>(t.shape(), t.data());
           },
           basix::docstring::FiniteElement__base_transformations.c_str())
       .def(
           "entity_transformations",
-          [](const FiniteElement& self) {
+          [](const FiniteElement& self)
+          {
             std::map<cell::type, xt::xtensor<double, 3>> t
                 = self.entity_transformations();
             py::dict t2;
@@ -317,9 +326,8 @@ Interface to the Basix C++ library.
           basix::docstring::FiniteElement__entity_transformations.c_str())
       .def(
           "get_tensor_product_representation",
-          [](const FiniteElement& self) {
-            return self.get_tensor_product_representation();
-          },
+          [](const FiniteElement& self)
+          { return self.get_tensor_product_representation(); },
           basix::docstring::FiniteElement__get_tensor_product_representation
               .c_str())
       .def_property_readonly("degree", &FiniteElement::degree)
@@ -331,7 +339,14 @@ Interface to the Basix C++ library.
                              &FiniteElement::num_entity_closure_dofs)
       .def_property_readonly("entity_closure_dofs",
                              &FiniteElement::entity_closure_dofs)
-      .def_property_readonly("value_size", &FiniteElement::value_size)
+      .def_property_readonly("value_size",
+                             [](const FiniteElement& self)
+                             {
+                               return std::accumulate(
+                                   self.value_shape().begin(),
+                                   self.value_shape().end(), 1,
+                                   std::multiplies<int>());
+                             })
       .def_property_readonly("value_shape", &FiniteElement::value_shape)
       .def_property_readonly("family", &FiniteElement::family)
       .def_property_readonly("lagrange_variant",
@@ -344,26 +359,30 @@ Interface to the Basix C++ library.
       .def_property_readonly("map_type", &FiniteElement::map_type)
       .def_property_readonly("degree_bounds", &FiniteElement::degree_bounds)
       .def_property_readonly("points",
-                             [](const FiniteElement& self) {
+                             [](const FiniteElement& self)
+                             {
                                const xt::xtensor<double, 2>& x = self.points();
                                return py::array_t<double>(x.shape(), x.data(),
                                                           py::cast(self));
                              })
       .def_property_readonly(
           "interpolation_matrix",
-          [](const FiniteElement& self) {
+          [](const FiniteElement& self)
+          {
             const xt::xtensor<double, 2>& P = self.interpolation_matrix();
             return py::array_t<double>(P.shape(), P.data(), py::cast(self));
           })
       .def_property_readonly(
           "dual_matrix",
-          [](const FiniteElement& self) {
+          [](const FiniteElement& self)
+          {
             const xt::xtensor<double, 2>& P = self.dual_matrix();
             return py::array_t<double>(P.shape(), P.data(), py::cast(self));
           })
       .def_property_readonly(
           "coefficient_matrix",
-          [](const FiniteElement& self) {
+          [](const FiniteElement& self)
+          {
             const xt::xtensor<double, 2>& P = self.coefficient_matrix();
             return py::array_t<double>(P.shape(), P.data(), py::cast(self));
           })


### PR DESCRIPTION
`value_shape` should be empty for scalar elements. This allows the rank to be determined from the size of `value_shape` 

https://github.com/FEniCS/ffcx/pull/443 supports this change.