### PR TITLE
Variants of 2D and 3D serendipity

### DIFF
--- a/.github/workflows/dolfin-tests.yml
+++ b/.github/workflows/dolfin-tests.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install FEniCS Python components
         run: |
           python3 -m pip install git+https://github.com/FEniCS/ufl.git
-          python3 -m pip install git+https://github.com/FEniCS/ffcx.git@mscroggs/serendipity-variants2
+          python3 -m pip install git+https://github.com/FEniCS/ffcx.git
 
       - name: Run cpp demos
         run: |
@@ -48,7 +48,7 @@ jobs:
         with:
           path: ./dolfinx
           repository: FEniCS/dolfinx
-          ref: mscroggs/serendipity-variants2
+          ref: main
 
       - name: Install DOLFINx
         run: |

--- a/.github/workflows/dolfin-tests.yml
+++ b/.github/workflows/dolfin-tests.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install FEniCS Python components
         run: |
           python3 -m pip install git+https://github.com/FEniCS/ufl.git
-          python3 -m pip install git+https://github.com/FEniCS/ffcx.git
+          python3 -m pip install git+https://github.com/FEniCS/ffcx.git@mscroggs/serendipity-variants3
 
       - name: Run cpp demos
         run: |
@@ -48,7 +48,7 @@ jobs:
         with:
           path: ./dolfinx
           repository: FEniCS/dolfinx
-          ref: main
+          ref: mscroggs/serendipity-variants3
 
       - name: Install DOLFINx
         run: |

--- a/cpp/basix/e-serendipity.h
+++ b/cpp/basix/e-serendipity.h
@@ -15,11 +15,15 @@ namespace basix::element
 /// @param[in] degree The degree of the element
 /// @param[in] lvariant The variant of the Lagrange element to be used for
 /// integral moments on the edges of the cell
+/// @param[in] dvariant The variant of the DPC element to be used for
+/// integral moments on the interior of the cell (for quads and hexes). For
+/// elements on an interval element::dpc_variant::unset can be passed in
 /// @param[in] discontinuous Controls whether the element is continuous or
 /// discontinuous
 /// @return A finite element
 FiniteElement create_serendipity(cell::type celltype, int degree,
                                  element::lagrange_variant lvariant,
+                                 element::dpc_variant dvariant,
                                  bool discontinuous);
 
 /// Create a serendipity H(div) element on cell with given degree

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -198,12 +198,13 @@ basix::FiniteElement basix::create_element(element::family family,
     return element::create_bubble(cell, degree, discontinuous);
   case element::family::serendipity:
     return element::create_serendipity(
-        cell, degree, element::lagrange_variant::unset, discontinuous);
+        cell, degree, element::lagrange_variant::unset,
+        element::dpc_variant::unset, discontinuous);
   case element::family::DPC:
     return element::create_dpc(cell, degree, element::dpc_variant::unset,
                                discontinuous);
   default:
-    throw std::runtime_error("Element family not found");
+    throw std::runtime_error("Element family not found.");
   }
 }
 //-----------------------------------------------------------------------------
@@ -216,8 +217,12 @@ basix::FiniteElement basix::create_element(element::family family,
   {
   case element::family::DPC:
     return element::create_dpc(cell, degree, dvariant, discontinuous);
+  case element::family::serendipity:
+    return element::create_serendipity(cell, degree,
+                                       element::lagrange_variant::unset,
+                                       dvariant, discontinuous);
   default:
-    throw std::runtime_error("Cannot pass a DPC variant.");
+    throw std::runtime_error("Cannot pass a DPC variant to this element.");
   }
 }
 //-----------------------------------------------------------------------------
@@ -231,9 +236,27 @@ basix::FiniteElement basix::create_element(element::family family,
   case element::family::P:
     return element::create_lagrange(cell, degree, lvariant, discontinuous);
   case element::family::serendipity:
-    return element::create_serendipity(cell, degree, lvariant, discontinuous);
+    return element::create_serendipity(
+        cell, degree, lvariant, element::dpc_variant::unset, discontinuous);
   default:
-    throw std::runtime_error("Cannot pass a Lagrange variant.");
+    throw std::runtime_error("Cannot pass a Lagrange variant to this element.");
+  }
+}
+//-----------------------------------------------------------------------------
+basix::FiniteElement basix::create_element(element::family family,
+                                           cell::type cell, int degree,
+                                           element::lagrange_variant lvariant,
+                                           element::dpc_variant dvariant,
+                                           bool discontinuous)
+{
+  switch (family)
+  {
+  case element::family::serendipity:
+    return element::create_serendipity(cell, degree, lvariant, dvariant,
+                                       discontinuous);
+  default:
+    throw std::runtime_error(
+        "Cannot pass a Lagrange variant and a DPC variant to this element.");
   }
 }
 //-----------------------------------------------------------------------------
@@ -249,6 +272,14 @@ basix::FiniteElement basix::create_element(element::family family,
                                            element::dpc_variant dvariant)
 {
   return create_element(family, cell, degree, dvariant, false);
+}
+//-----------------------------------------------------------------------------
+basix::FiniteElement basix::create_element(element::family family,
+                                           cell::type cell, int degree,
+                                           element::lagrange_variant lvariant,
+                                           element::dpc_variant dvariant)
+{
+  return create_element(family, cell, degree, lvariant, dvariant, false);
 }
 //-----------------------------------------------------------------------------
 basix::FiniteElement basix::create_element(element::family family,

--- a/cpp/basix/finite-element.h
+++ b/cpp/basix/finite-element.h
@@ -940,6 +940,20 @@ FiniteElement create_element(element::family family, cell::type cell,
                              int degree, element::lagrange_variant lvariant,
                              bool discontinuous);
 
+/// Create an element using a given Lagrange variant and a given DPC variant
+/// @param[in] family The element family
+/// @param[in] cell The reference cell type that the element is defined on
+/// @param[in] degree The degree of the element
+/// @param[in] lvariant The variant of Lagrange to use
+/// @param[in] dvariant The variant of DPC to use
+/// @param[in] discontinuous Indicates whether the element is discontinuous
+/// between cells points of the element. The discontinuous element will have the
+/// same DOFs, but they will all be associated with the interior of the cell.
+/// @return A finite element
+FiniteElement create_element(element::family family, cell::type cell,
+                             int degree, element::lagrange_variant lvariant,
+                             element::dpc_variant dvariant, bool discontinuous);
+
 /// Create an element using a given DPC variant
 /// @param[in] family The element family
 /// @param[in] cell The reference cell type that the element is defined on
@@ -975,6 +989,19 @@ FiniteElement create_element(element::family family, cell::type cell,
 /// @return A finite element
 FiniteElement create_element(element::family family, cell::type cell,
                              int degree, element::lagrange_variant lvariant);
+
+/// Create a continuous element using a given Lagrange variant and a given DPC
+/// variant
+/// @param[in] family The element family
+/// @param[in] cell The reference cell type that the element is defined
+/// on
+/// @param[in] degree The degree of the element
+/// @param[in] lvariant The variant of Lagrange to use
+/// @param[in] dvariant The variant of DPC to use
+/// @return A finite element
+FiniteElement create_element(element::family family, cell::type cell,
+                             int degree, element::lagrange_variant lvariant,
+                             element::dpc_variant dvariant);
 
 /// Create a continuous element using a given DPC variant
 /// @param[in] family The element family

--- a/python/docs.h
+++ b/python/docs.h
@@ -570,6 +570,32 @@ basix.finite_element.FiniteElement
     A finite element
 )";
 
+const std::string
+    create_element__family_cell_degree_lvariant_dvariant_discontinuous
+    = R"(
+Create an element using a given Lagrange variant and a given DPC variant
+
+Parameters
+==========
+family : basix.ElementFamily
+    The element family
+cell : basix.CellType
+    The reference cell type that the element is defined on
+degree : int
+    The degree of the element
+lvariant : basix.LagrangeVariant
+    The variant of Lagrange to use
+dvariant : basix.DPCVariant
+    The variant of DPC to use
+discontinuous : bool
+    Indicates whether the element is discontinuous between cells points of the element. The discontinuous element will have the same DOFs, but they will all be associated with the interior of the cell.
+
+Returns
+=======
+basix.finite_element.FiniteElement
+    A finite element
+)";
+
 const std::string create_element__family_cell_degree_dvariant = R"(
 Create a continuous element using a given DPC variant
 
@@ -581,6 +607,29 @@ cell : basix.CellType
     The reference cell type that the element is defined on
 degree : int
     The degree of the element
+dvariant : basix.DPCVariant
+    The variant of DPC to use
+
+Returns
+=======
+basix.finite_element.FiniteElement
+    A finite element
+)";
+
+const std::string create_element__family_cell_degree_lvariant_dvariant = R"(
+Create a continuous element using a given Lagrange variant and a given DPC
+variant
+
+Parameters
+==========
+family : basix.ElementFamily
+    The element family
+cell : basix.CellType
+    The reference cell type that the element is defined on
+degree : int
+    The degree of the element
+lvariant : basix.LagrangeVariant
+    The variant of Lagrange to use
 dvariant : basix.DPCVariant
     The variant of DPC to use
 

--- a/python/docs.h.template
+++ b/python/docs.h.template
@@ -330,6 +330,25 @@ Returns
 {{finite-element.h > create_element(family, cell, degree, dvariant, discontinuous) > return : basix.finite_element.FiniteElement}}
 )";
 
+{{DOCTYPE}}
+    create_element__family_cell_degree_lvariant_dvariant_discontinuous
+    = R"(
+{{finite-element.h > create_element(family, cell, degree, lvariant, dvariant, discontinuous) > doc}}
+
+Parameters
+==========
+{{finite-element.h > create_element(family, cell, degree, lvariant, dvariant, discontinuous) > param > family : basix.ElementFamily}}
+{{finite-element.h > create_element(family, cell, degree, lvariant, dvariant, discontinuous) > param > cell : basix.CellType}}
+{{finite-element.h > create_element(family, cell, degree, lvariant, dvariant, discontinuous) > param > degree : int}}
+{{finite-element.h > create_element(family, cell, degree, lvariant, dvariant, discontinuous) > param > lvariant : basix.LagrangeVariant}}
+{{finite-element.h > create_element(family, cell, degree, lvariant, dvariant, discontinuous) > param > dvariant : basix.DPCVariant}}
+{{finite-element.h > create_element(family, cell, degree, lvariant, dvariant, discontinuous) > param > discontinuous : bool}}
+
+Returns
+=======
+{{finite-element.h > create_element(family, cell, degree, lvariant, dvariant, discontinuous) > return : basix.finite_element.FiniteElement}}
+)";
+
 {{DOCTYPE}} create_element__family_cell_degree_dvariant = R"(
 {{finite-element.h > create_element(family, cell, degree, dvariant) > doc}}
 
@@ -343,6 +362,22 @@ Parameters
 Returns
 =======
 {{finite-element.h > create_element(family, cell, degree, dvariant) > return : basix.finite_element.FiniteElement}}
+)";
+
+{{DOCTYPE}} create_element__family_cell_degree_lvariant_dvariant = R"(
+{{finite-element.h > create_element(family, cell, degree, lvariant, dvariant) > doc}}
+
+Parameters
+==========
+{{finite-element.h > create_element(family, cell, degree, lvariant, dvariant) > param > family : basix.ElementFamily}}
+{{finite-element.h > create_element(family, cell, degree, lvariant, dvariant) > param > cell : basix.CellType}}
+{{finite-element.h > create_element(family, cell, degree, lvariant, dvariant) > param > degree : int}}
+{{finite-element.h > create_element(family, cell, degree, lvariant, dvariant) > param > lvariant : basix.LagrangeVariant}}
+{{finite-element.h > create_element(family, cell, degree, lvariant, dvariant) > param > dvariant : basix.DPCVariant}}
+
+Returns
+=======
+{{finite-element.h > create_element(family, cell, degree, lvariant, dvariant) > return : basix.finite_element.FiniteElement}}
 )";
 
 {{DOCTYPE}} create_element__family_cell_degree = R"(

--- a/python/wrapper.cpp
+++ b/python/wrapper.cpp
@@ -437,6 +437,18 @@ Interface to the Basix C++ library.
 
   m.def(
       "create_element",
+      [](element::family family_name, cell::type cell_name, int degree,
+         element::lagrange_variant lvariant, element::dpc_variant dvariant,
+         bool discontinuous) -> FiniteElement {
+        return basix::create_element(family_name, cell_name, degree, lvariant,
+                                     dvariant, discontinuous);
+      },
+      basix::docstring::
+          create_element__family_cell_degree_lvariant_dvariant_discontinuous
+              .c_str());
+
+  m.def(
+      "create_element",
       [](element::family family_name, cell::type cell_name,
          int degree) -> FiniteElement
       { return basix::create_element(family_name, cell_name, degree); },
@@ -457,6 +469,17 @@ Interface to the Basix C++ library.
         return basix::create_element(family_name, cell_name, degree, dvariant);
       },
       basix::docstring::create_element__family_cell_degree_dvariant.c_str());
+
+  m.def(
+      "create_element",
+      [](element::family family_name, cell::type cell_name, int degree,
+         element::lagrange_variant lvariant,
+         element::dpc_variant dvariant) -> FiniteElement {
+        return basix::create_element(family_name, cell_name, degree, lvariant,
+                                     dvariant);
+      },
+      basix::docstring::create_element__family_cell_degree_lvariant_dvariant
+          .c_str());
 
   // Interpolate between elements
   m.def(

--- a/test/utils.py
+++ b/test/utils.py
@@ -43,8 +43,9 @@ def parametrize_over_elements(degree, reference=None, discontinuous=False):
 
         # Elements on tensor product cells
         for c in [CellType.interval, CellType.quadrilateral, CellType.hexahedron]:
-            elementlist.append((c, ElementFamily.serendipity, k, [LagrangeVariant.equispaced]))
-            elementlist.append((c, ElementFamily.serendipity, k, [LagrangeVariant.gll_warped]))
+            for lv in [LagrangeVariant.equispaced, LagrangeVariant.gll_warped]:
+                for dv in [DPCVariant.simplex_equispaced, DPCVariant.diagonal_gll]:
+                    elementlist.append((c, ElementFamily.serendipity, k, [lv, dv]))
 
         # Elements on quads and hexes
         for c in [CellType.quadrilateral, CellType.hexahedron]:


### PR DESCRIPTION
Allow user to provide variants for DPC and Lagrange spaces that define the moments of serendipity spaces.

Progress towards #72.

This is coupled with https://github.com/FEniCS/ffcx/pull/458 and https://github.com/FEniCS/dolfinx/pull/2017