### PR TITLE
Remove -DDEBUG definition that doesn't do anything.

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -159,9 +159,6 @@ list(APPEND basix_compiler_flags -Wall;-Werror;-Wextra;-Wno-comment;-pedantic;)
 target_compile_options(basix PRIVATE "$<$<OR:$<CONFIG:Debug>,$<CONFIG:Developer>>:${basix_compiler_flags}>")
 target_compile_options(basix PRIVATE $<$<CONFIG:Developer>:${BASIX_DEVELOPER_FLAGS}>)
 
-# Set debug definitions (private)
-target_compile_definitions(basix PRIVATE $<$<OR:$<CONFIG:Debug>,$<CONFIG:Developer>>:DEBUG>)
-
 # Install the Basix library
 install(TARGETS basix
   EXPORT BasixTargets


### PR DESCRIPTION
The standard is to use -DNDEBUG for non-debug builds