### PR TITLE
Add & and const

### DIFF
--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -961,12 +961,12 @@ FiniteElement::entity_transformations() const
   return _entity_transformations;
 }
 //-----------------------------------------------------------------------------
-xt::xtensor<double, 2> FiniteElement::dual_matrix() const
+const xt::xtensor<double, 2>& FiniteElement::dual_matrix() const
 {
   return _dual_matrix;
 }
 //-----------------------------------------------------------------------------
-xt::xtensor<double, 2> FiniteElement::coefficient_matrix() const
+const xt::xtensor<double, 2>& FiniteElement::coefficient_matrix() const
 {
   return _coeffs;
 }

--- a/cpp/basix/finite-element.h
+++ b/cpp/basix/finite-element.h
@@ -760,14 +760,14 @@ public:
   /// This is the matrix @f$BD^{T}@f$, as described in the documentation
   /// of the `FiniteElement()` constructor.
   /// @return The dual matrix
-  xt::xtensor<double, 2> dual_matrix() const;
+  const xt::xtensor<double, 2>& dual_matrix() const;
 
   /// Get the matrix of coefficients.
   ///
   /// This is the matrix @f$C@f$, as described in the documentation of
   /// the `FiniteElement()` constructor.
   /// @return The dual matrix
-  xt::xtensor<double, 2> coefficient_matrix() const;
+  const xt::xtensor<double, 2>& coefficient_matrix() const;
 
   /// Get [0] the lowest degree n such that the highest degree
   /// polynomial in this element is contained in a Lagrange (or vector


### PR DESCRIPTION
Without this, the python wrappers to get these matrices were getting matrices with incorrect entries