### PR TITLE
Avoid C++ errors

### DIFF
--- a/cpp/basix/e-nce-rtc.cpp
+++ b/cpp/basix/e-nce-rtc.cpp
@@ -27,6 +27,9 @@ FiniteElement basix::element::create_rtc(cell::type celltype, int degree,
     throw std::runtime_error("Unsupported cell type");
   }
 
+  if (degree < 1)
+    throw std::runtime_error("Degree must be at least 1");
+
   if (degree > 4)
   {
     // TODO: suggest alternative with non-uniform points once implemented
@@ -163,6 +166,9 @@ FiniteElement basix::element::create_nce(cell::type celltype, int degree,
   if (celltype != cell::type::quadrilateral
       and celltype != cell::type::hexahedron)
     throw std::runtime_error("Unsupported cell type");
+
+  if (degree < 1)
+    throw std::runtime_error("Degree must be at least 1");
 
   if (degree > 4)
   {

--- a/cpp/basix/e-nedelec.cpp
+++ b/cpp/basix/e-nedelec.cpp
@@ -156,6 +156,9 @@ xt::xtensor<double, 2> create_nedelec_3d_space(int degree)
 FiniteElement basix::element::create_nedelec(cell::type celltype, int degree,
                                              bool discontinuous)
 {
+  if (degree < 1)
+    throw std::runtime_error("Degree must be at least 1");
+
   std::array<std::vector<xt::xtensor<double, 3>>, 4> M;
   std::array<std::vector<xt::xtensor<double, 2>>, 4> x;
   xt::xtensor<double, 2> wcoeffs;
@@ -236,6 +239,9 @@ FiniteElement basix::element::create_nedelec2(cell::type celltype, int degree,
 {
   if (celltype != cell::type::triangle and celltype != cell::type::tetrahedron)
     throw std::runtime_error("Invalid celltype in Nedelec");
+
+  if (degree < 1)
+    throw std::runtime_error("Degree must be at least 1");
 
   std::array<std::vector<xt::xtensor<double, 3>>, 4> M;
   std::array<std::vector<xt::xtensor<double, 2>>, 4> x;

--- a/cpp/basix/e-raviart-thomas.cpp
+++ b/cpp/basix/e-raviart-thomas.cpp
@@ -24,6 +24,9 @@ FiniteElement basix::element::create_rt(cell::type celltype, int degree,
   if (celltype != cell::type::triangle and celltype != cell::type::tetrahedron)
     throw std::runtime_error("Unsupported cell type");
 
+  if (degree < 1)
+    throw std::runtime_error("Degree must be at least 1");
+
   const std::size_t tdim = cell::topological_dimension(celltype);
 
   const cell::type facettype

--- a/cpp/basix/e-serendipity.cpp
+++ b/cpp/basix/e-serendipity.cpp
@@ -109,10 +109,13 @@ serendipity_3d_indices(int total, int linear, std::vector<int> done = {})
 xt::xtensor<double, 2> make_serendipity_space_3d(int degree)
 {
   const std::size_t ndofs
-      = degree < 4 ? 12 * degree - 4
+      = degree == 0
+            ? 1
+            : (degree < 4
+                   ? 12 * degree - 4
                    : (degree < 6 ? 3 * degree * degree - 3 * degree + 14
                                  : degree * (degree - 1) * (degree + 1) / 6
-                                       + degree * degree + 5 * degree + 4);
+                                       + degree * degree + 5 * degree + 4));
   // Number of order (degree) polynomials
 
   // Evaluate the expansion polynomials at the quadrature points


### PR DESCRIPTION
Added test that when trying to create any element, either the element is created or a RuntimeError (eg invalid cell type) is thrown. Previously, some element/cell/order combinations would cause cryptic C++ errors.