### PR TITLE
Remove `highest_degree`

### DIFF
--- a/cpp/basix/e-brezzi-douglas-marini.cpp
+++ b/cpp/basix/e-brezzi-douglas-marini.cpp
@@ -54,8 +54,8 @@ FiniteElement basix::element::create_bdm(cell::type celltype, int degree,
     std::tie(x, M) = element::make_discontinuous(x, M, tdim, tdim);
   }
 
-  return FiniteElement(
-      element::family::BDM, celltype, degree, {tdim}, xt::eye<double>(ndofs), x,
-      M, maps::type::contravariantPiola, discontinuous, degree, degree);
+  return FiniteElement(element::family::BDM, celltype, degree, {tdim},
+                       xt::eye<double>(ndofs), x, M,
+                       maps::type::contravariantPiola, discontinuous, degree);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/basix/e-bubble.cpp
+++ b/cpp/basix/e-bubble.cpp
@@ -147,6 +147,6 @@ FiniteElement basix::element::create_bubble(cell::type celltype, int degree,
   xt::view(M[tdim][0], xt::all(), 0, xt::all()) = xt::eye<double>(ndofs);
 
   return FiniteElement(element::family::bubble, celltype, degree, {1}, wcoeffs,
-                       x, M, maps::type::identity, discontinuous, degree, -1);
+                       x, M, maps::type::identity, discontinuous, -1);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/basix/e-crouzeix-raviart.cpp
+++ b/cpp/basix/e-crouzeix-raviart.cpp
@@ -59,6 +59,6 @@ FiniteElement basix::element::create_cr(cell::type celltype, int degree,
 
   return FiniteElement(element::family::CR, celltype, 1, {1},
                        xt::eye<double>(ndofs), x, M, maps::type::identity,
-                       discontinuous, degree, degree);
+                       discontinuous, degree);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/basix/e-lagrange.cpp
+++ b/cpp/basix/e-lagrange.cpp
@@ -115,7 +115,7 @@ FiniteElement create_d_lagrange(cell::type celltype, int degree,
 
   return FiniteElement(element::family::P, celltype, degree, {},
                        xt::eye<double>(ndofs), x, M, maps::type::identity, true,
-                       degree, degree, {}, variant);
+                       degree, {}, variant);
 }
 //----------------------------------------------------------------------------
 std::vector<std::tuple<std::vector<FiniteElement>, std::vector<int>>>
@@ -818,7 +818,7 @@ FiniteElement create_vtk_element(cell::type celltype, int degree,
 
   return FiniteElement(element::family::P, celltype, degree, {},
                        xt::eye<double>(ndofs), x, M, maps::type::identity,
-                       discontinuous, degree, degree);
+                       discontinuous, degree);
 }
 //-----------------------------------------------------------------------------
 FiniteElement create_legendre(cell::type celltype, int degree,
@@ -863,7 +863,7 @@ FiniteElement create_legendre(cell::type celltype, int degree,
 
   return FiniteElement(element::family::P, celltype, degree, {},
                        xt::eye<double>(ndofs), x, M, maps::type::identity,
-                       discontinuous, degree, degree, {},
+                       discontinuous, degree, {},
                        element::lagrange_variant::legendre);
 }
 //-----------------------------------------------------------------------------
@@ -957,8 +957,8 @@ FiniteElement create_legendre_dpc(cell::type celltype, int degree,
   }
 
   return FiniteElement(element::family::DPC, celltype, degree, {}, wcoeffs, x,
-                       M, maps::type::identity, discontinuous, degree, degree,
-                       {}, element::lagrange_variant::unset,
+                       M, maps::type::identity, discontinuous, degree, {},
+                       element::lagrange_variant::unset,
                        element::dpc_variant::legendre);
 }
 //-----------------------------------------------------------------------------
@@ -1173,8 +1173,7 @@ FiniteElement basix::element::create_lagrange(cell::type celltype, int degree,
     xt::xtensor<double, 2> wcoeffs = {{1}};
 
     return FiniteElement(element::family::P, cell::type::point, 0, {}, wcoeffs,
-                         x, M, maps::type::identity, discontinuous, degree,
-                         degree);
+                         x, M, maps::type::identity, discontinuous, degree);
   }
 
   if (variant == element::lagrange_variant::unset)
@@ -1301,7 +1300,7 @@ FiniteElement basix::element::create_lagrange(cell::type celltype, int degree,
 
   return FiniteElement(element::family::P, celltype, degree, {},
                        xt::eye<double>(ndofs), x, M, maps::type::identity,
-                       discontinuous, degree, degree, tensor_factors, variant);
+                       discontinuous, degree, tensor_factors, variant);
 }
 //-----------------------------------------------------------------------------
 FiniteElement basix::element::create_dpc(cell::type celltype, int degree,
@@ -1390,7 +1389,7 @@ FiniteElement basix::element::create_dpc(cell::type celltype, int degree,
   x[tdim].push_back(pt);
 
   return FiniteElement(element::family::DPC, celltype, degree, {}, wcoeffs, x,
-                       M, maps::type::identity, discontinuous, degree, degree,
-                       {}, element::lagrange_variant::unset, variant);
+                       M, maps::type::identity, discontinuous, degree, {},
+                       element::lagrange_variant::unset, variant);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/basix/e-nce-rtc.cpp
+++ b/cpp/basix/e-nce-rtc.cpp
@@ -141,7 +141,7 @@ FiniteElement basix::element::create_rtc(cell::type celltype, int degree,
 
   return FiniteElement(element::family::RT, celltype, degree, {tdim}, wcoeffs,
                        x, M, maps::type::contravariantPiola, discontinuous,
-                       degree, degree - 1);
+                       degree - 1);
 }
 //-----------------------------------------------------------------------------
 FiniteElement basix::element::create_nce(cell::type celltype, int degree,
@@ -306,7 +306,7 @@ FiniteElement basix::element::create_nce(cell::type celltype, int degree,
   }
 
   return FiniteElement(element::family::N1E, celltype, degree, {tdim}, wcoeffs,
-                       x, M, maps::type::covariantPiola, discontinuous, degree,
+                       x, M, maps::type::covariantPiola, discontinuous,
                        degree - 1);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/basix/e-nedelec.cpp
+++ b/cpp/basix/e-nedelec.cpp
@@ -213,7 +213,7 @@ FiniteElement basix::element::create_nedelec(cell::type celltype, int degree,
   }
 
   return FiniteElement(element::family::N1E, celltype, degree, {tdim}, wcoeffs,
-                       x, M, maps::type::covariantPiola, discontinuous, degree,
+                       x, M, maps::type::covariantPiola, discontinuous,
                        degree - 1);
 }
 //-----------------------------------------------------------------------------
@@ -264,7 +264,6 @@ FiniteElement basix::element::create_nedelec2(cell::type celltype, int degree,
   }
 
   return FiniteElement(element::family::N2E, celltype, degree, {tdim}, wcoeffs,
-                       x, M, maps::type::covariantPiola, discontinuous, degree,
-                       degree);
+                       x, M, maps::type::covariantPiola, discontinuous, degree);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/basix/e-raviart-thomas.cpp
+++ b/cpp/basix/e-raviart-thomas.cpp
@@ -105,7 +105,7 @@ FiniteElement basix::element::create_rt(cell::type celltype, int degree,
   }
 
   return FiniteElement(element::family::RT, celltype, degree, {tdim}, B, x, M,
-                       maps::type::contravariantPiola, discontinuous, degree,
+                       maps::type::contravariantPiola, discontinuous,
                        degree - 1);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/basix/e-regge.cpp
+++ b/cpp/basix/e-regge.cpp
@@ -153,6 +153,6 @@ FiniteElement basix::element::create_regge(cell::type celltype, int degree,
 
   return FiniteElement(element::family::Regge, celltype, degree, {tdim, tdim},
                        wcoeffs, x, M, maps::type::doubleCovariantPiola,
-                       discontinuous, degree, -1);
+                       discontinuous, -1);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/basix/e-serendipity.cpp
+++ b/cpp/basix/e-serendipity.cpp
@@ -617,7 +617,6 @@ FiniteElement basix::element::create_serendipity(
 
   return FiniteElement(element::family::serendipity, celltype, degree, {1},
                        wcoeffs, x, M, maps::type::identity, discontinuous,
-                       degree,
                        degree < static_cast<int>(tdim) ? 1 : degree / tdim, {},
                        lvariant, dvariant);
 }
@@ -676,7 +675,7 @@ FiniteElement basix::element::create_serendipity_div(cell::type celltype,
 
   return FiniteElement(element::family::BDM, celltype, degree + 1, {tdim},
                        wcoeffs, x, M, maps::type::contravariantPiola,
-                       discontinuous, degree + 1, degree / tdim);
+                       discontinuous, degree / tdim);
 }
 //-----------------------------------------------------------------------------
 FiniteElement basix::element::create_serendipity_curl(cell::type celltype,
@@ -745,7 +744,6 @@ FiniteElement basix::element::create_serendipity_curl(cell::type celltype,
 
   return FiniteElement(element::family::N2E, celltype, degree + 1, {tdim},
                        wcoeffs, x, M, maps::type::covariantPiola, discontinuous,
-                       degree + 1,
                        (degree == 2 && tdim == 3) ? 1 : degree / tdim);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -379,6 +379,10 @@ FiniteElement::FiniteElement(
       _degree_bounds({highest_complete_degree, highest_degree}),
       _tensor_factors(tensor_factors)
 {
+
+  if (highest_degree != degree)
+    throw std::runtime_error("degree != highest degree (!)");
+
   _dual_matrix = compute_dual_matrix(cell_type, wcoeffs, M, x, degree);
   xt::xtensor<double, 2> B_cmajor({wcoeffs.shape(0), wcoeffs.shape(1)});
   B_cmajor.assign(wcoeffs);

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -352,12 +352,11 @@ basix::FiniteElement basix::create_custom_element(
     const xt::xtensor<double, 2>& wcoeffs,
     const std::array<std::vector<xt::xtensor<double, 2>>, 4>& x,
     const std::array<std::vector<xt::xtensor<double, 3>>, 4>& M,
-    maps::type map_type, bool discontinuous, int highest_degree,
-    int highest_complete_degree)
+    maps::type map_type, bool discontinuous, int highest_complete_degree)
 {
-  return basix::FiniteElement(
-      element::family::custom, cell_type, degree, value_shape, wcoeffs, x, M,
-      map_type, discontinuous, highest_degree, highest_complete_degree);
+  return basix::FiniteElement(element::family::custom, cell_type, degree,
+                              value_shape, wcoeffs, x, M, map_type,
+                              discontinuous, highest_complete_degree);
 }
 
 //-----------------------------------------------------------------------------
@@ -367,8 +366,7 @@ FiniteElement::FiniteElement(
     const xt::xtensor<double, 2>& wcoeffs,
     const std::array<std::vector<xt::xtensor<double, 2>>, 4>& x,
     const std::array<std::vector<xt::xtensor<double, 3>>, 4>& M,
-    maps::type map_type, bool discontinuous, int highest_degree,
-    int highest_complete_degree,
+    maps::type map_type, bool discontinuous, int highest_complete_degree,
     std::vector<std::tuple<std::vector<FiniteElement>, std::vector<int>>>
         tensor_factors,
     element::lagrange_variant lvariant, element::dpc_variant dvariant)
@@ -376,13 +374,9 @@ FiniteElement::FiniteElement(
       _cell_subentity_types(cell::subentity_types(cell_type)), _family(family),
       _lagrange_variant(lvariant), _dpc_variant(dvariant), _degree(degree),
       _map_type(map_type), _x(x), _discontinuous(discontinuous),
-      _degree_bounds({highest_complete_degree, highest_degree}),
+      _degree_bounds({highest_complete_degree, degree}),
       _tensor_factors(tensor_factors)
 {
-
-  if (highest_degree != degree)
-    throw std::runtime_error("degree != highest degree (!)");
-
   _dual_matrix = compute_dual_matrix(cell_type, wcoeffs, M, x, degree);
   xt::xtensor<double, 2> B_cmajor({wcoeffs.shape(0), wcoeffs.shape(1)});
   B_cmajor.assign(wcoeffs);

--- a/cpp/basix/finite-element.h
+++ b/cpp/basix/finite-element.h
@@ -209,9 +209,6 @@ public:
   /// the reference to a cell
   /// @param[in] discontinuous Indicates whether or not this is the
   /// discontinuous version of the element
-  /// @param[in] highest_degree The lowest degree n such that the highest degree
-  /// polynomial in this element is contained in a Lagrange (or vector Lagrange)
-  /// element of degree n
   /// @param[in] highest_complete_degree The highest degree n such that a
   /// Lagrange (or vector Lagrange) element of degree n is a subspace of this
   /// element
@@ -225,8 +222,7 @@ public:
       const xt::xtensor<double, 2>& wcoeffs,
       const std::array<std::vector<xt::xtensor<double, 2>>, 4>& x,
       const std::array<std::vector<xt::xtensor<double, 3>>, 4>& M,
-      maps::type map_type, bool discontinuous, int highest_degree,
-      int highest_complete_degree,
+      maps::type map_type, bool discontinuous, int highest_complete_degree,
       std::vector<std::tuple<std::vector<FiniteElement>, std::vector<int>>>
           tensor_factors
       = {},
@@ -940,9 +936,6 @@ private:
 /// the reference to a cell
 /// @param[in] discontinuous Indicates whether or not this is the
 /// discontinuous version of the element
-/// @param[in] highest_degree The lowest degree n such that the highest degree
-/// polynomial in this element is contained in a Lagrange (or vector Lagrange)
-/// element of degree n
 /// @param[in] highest_complete_degree The highest degree n such that a
 /// Lagrange (or vector Lagrange) element of degree n is a subspace of this
 /// element
@@ -953,8 +946,7 @@ FiniteElement create_custom_element(
     const xt::xtensor<double, 2>& wcoeffs,
     const std::array<std::vector<xt::xtensor<double, 2>>, 4>& x,
     const std::array<std::vector<xt::xtensor<double, 3>>, 4>& M,
-    maps::type map_type, bool discontinuous, int highest_degree,
-    int highest_complete_degree);
+    maps::type map_type, bool discontinuous, int highest_complete_degree);
 
 /// Create an element using a given Lagrange variant
 /// @param[in] family The element family

--- a/python/docs.h
+++ b/python/docs.h
@@ -505,8 +505,6 @@ map_type : basix.MapType
     The type of map to be used to map values from the reference to a cell
 discontinuous : bool
     Indicates whether or not this is the discontinuous version of the element
-highest_degree : int
-    The lowest degree n such that the highest degree polynomial in this element is contained in a Lagrange (or vector Lagrange) element of degree n
 highest_complete_degree : int
     The highest degree n such that a Lagrange (or vector Lagrange) element of degree n is a subspace of this element
 

--- a/python/docs.h.template
+++ b/python/docs.h.template
@@ -267,24 +267,23 @@ Returns
 )";
 
 {{DOCTYPE}} create_custom_element = R"(
-{{finite-element.h > create_custom_element(cell_type, degree, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_degree, highest_complete_degree) > doc}}
+{{finite-element.h > create_custom_element(cell_type, degree, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_complete_degree) > doc}}
 
 Parameters
 ==========
-{{finite-element.h > create_custom_element(cell_type, degree, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_degree, highest_complete_degree) > param > cell_type : basix.CellType}}
-{{finite-element.h > create_custom_element(cell_type, degree, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_degree, highest_complete_degree) > param > degree : int}}
-{{finite-element.h > create_custom_element(cell_type, degree, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_degree, highest_complete_degree) > param > value_shape : List[int]}}
-{{finite-element.h > create_custom_element(cell_type, degree, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_degree, highest_complete_degree) > param > wcoeffs : numpy.ndarray[numpy.float64]}}
-{{finite-element.h > create_custom_element(cell_type, degree, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_degree, highest_complete_degree) > param > x : List[List[numpy.ndarray[numpy.float64]]]}}
-{{finite-element.h > create_custom_element(cell_type, degree, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_degree, highest_complete_degree) > param > M : List[List[numpy.ndarray[numpy.float64]]]}}
-{{finite-element.h > create_custom_element(cell_type, degree, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_degree, highest_complete_degree) > param > map_type : basix.MapType}}
-{{finite-element.h > create_custom_element(cell_type, degree, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_degree, highest_complete_degree) > param > discontinuous : bool}}
-{{finite-element.h > create_custom_element(cell_type, degree, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_degree, highest_complete_degree) > param > highest_degree : int}}
-{{finite-element.h > create_custom_element(cell_type, degree, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_degree, highest_complete_degree) > param > highest_complete_degree : int}}
+{{finite-element.h > create_custom_element(cell_type, degree, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_complete_degree) > param > cell_type : basix.CellType}}
+{{finite-element.h > create_custom_element(cell_type, degree, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_complete_degree) > param > degree : int}}
+{{finite-element.h > create_custom_element(cell_type, degree, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_complete_degree) > param > value_shape : List[int]}}
+{{finite-element.h > create_custom_element(cell_type, degree, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_complete_degree) > param > wcoeffs : numpy.ndarray[numpy.float64]}}
+{{finite-element.h > create_custom_element(cell_type, degree, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_complete_degree) > param > x : List[List[numpy.ndarray[numpy.float64]]]}}
+{{finite-element.h > create_custom_element(cell_type, degree, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_complete_degree) > param > M : List[List[numpy.ndarray[numpy.float64]]]}}
+{{finite-element.h > create_custom_element(cell_type, degree, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_complete_degree) > param > map_type : basix.MapType}}
+{{finite-element.h > create_custom_element(cell_type, degree, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_complete_degree) > param > discontinuous : bool}}
+{{finite-element.h > create_custom_element(cell_type, degree, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_complete_degree) > param > highest_complete_degree : int}}
 
 Returns
 =======
-{{finite-element.h > create_custom_element(cell_type, degree, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_degree, highest_complete_degree) > return : basix.finite_element.FiniteElement}}
+{{finite-element.h > create_custom_element(cell_type, degree, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_complete_degree) > return : basix.finite_element.FiniteElement}}
 )";
 
 {{DOCTYPE}} create_element__family_cell_degree_discontinuous = R"(

--- a/python/wrapper.cpp
+++ b/python/wrapper.cpp
@@ -415,8 +415,9 @@ Interface to the Basix C++ library.
              std::vector<py::array_t<double, py::array::c_style>>>& x,
          const std::vector<
              std::vector<py::array_t<double, py::array::c_style>>>& M,
-         maps::type map_type, bool discontinuous, int highest_degree,
-         int highest_complete_degree) -> FiniteElement {
+         maps::type map_type, bool discontinuous,
+         int highest_complete_degree) -> FiniteElement
+      {
         if (x.size() != 4)
           throw std::runtime_error("x has the wrong size");
         if (M.size() != 4)
@@ -442,9 +443,9 @@ Interface to the Basix C++ library.
         for (std::size_t i = 0; i < value_shape.size(); ++i)
           _vs[i] = static_cast<std::size_t>(value_shape[i]);
 
-        return basix::create_custom_element(
-            cell_type, degree, _vs, _wco, _x, _M, map_type, discontinuous,
-            highest_degree, highest_complete_degree);
+        return basix::create_custom_element(cell_type, degree, _vs, _wco, _x,
+                                            _M, map_type, discontinuous,
+                                            highest_complete_degree);
       },
       basix::docstring::create_custom_element.c_str());
 

--- a/test/test_custom_element.py
+++ b/test/test_custom_element.py
@@ -22,7 +22,7 @@ def test_lagrange_custom_triangle_degree1():
 
     element = basix.create_custom_element(
         basix.CellType.triangle, 1, [], wcoeffs,
-        x, M, basix.MapType.identity, False, 1, 1)
+        x, M, basix.MapType.identity, False, 1)
 
     points = basix.create_lattice(basix.CellType.triangle, 5, basix.LatticeType.equispaced, True)
     assert np.allclose(lagrange.tabulate(1, points), element.tabulate(1, points))

--- a/test/test_custom_element.py
+++ b/test/test_custom_element.py
@@ -46,7 +46,7 @@ def test_lagrange_custom_triangle_degree4():
 
     element = basix.create_custom_element(
         basix.CellType.triangle, 4, [], wcoeffs,
-        x, M, basix.MapType.identity, False, 3, 3)
+        x, M, basix.MapType.identity, False, 4, 4)
 
     points = basix.create_lattice(basix.CellType.triangle, 5, basix.LatticeType.equispaced, True)
     assert np.allclose(lagrange.tabulate(1, points), element.tabulate(1, points))

--- a/test/test_custom_element.py
+++ b/test/test_custom_element.py
@@ -46,7 +46,7 @@ def test_lagrange_custom_triangle_degree4():
 
     element = basix.create_custom_element(
         basix.CellType.triangle, 4, [], wcoeffs,
-        x, M, basix.MapType.identity, False, 4, 4)
+        x, M, basix.MapType.identity, False, 4)
 
     points = basix.create_lattice(basix.CellType.triangle, 5, basix.LatticeType.equispaced, True)
     assert np.allclose(lagrange.tabulate(1, points), element.tabulate(1, points))
@@ -69,7 +69,7 @@ def test_lagrange_custom_quadrilateral_degree1():
 
     element = basix.create_custom_element(
         basix.CellType.quadrilateral, 1, [], wcoeffs,
-        x, M, basix.MapType.identity, False, 1, 1)
+        x, M, basix.MapType.identity, False, 1)
 
     points = basix.create_lattice(basix.CellType.quadrilateral, 5, basix.LatticeType.equispaced, True)
     assert np.allclose(lagrange.tabulate(1, points), element.tabulate(1, points))


### PR DESCRIPTION
`highest_degree` is necessarily the same as the degree of the element, so does not need to be provided as an additional input