### PR TITLE
Run DOLFINx C++ unit tests on PR CI

### DIFF
--- a/.github/workflows/dolfin-tests.yml
+++ b/.github/workflows/dolfin-tests.yml
@@ -57,5 +57,14 @@ jobs:
           cmake --install build
           python3 -m pip -v install --global-option build --global-option --debug dolfinx/python/
 
-      - name: Run DOLFINx unit tests
-        run: python3 -m pytest -v -n auto dolfinx/python/test/unit
+      - name: Build DOLFINx C++ unit tests
+        run: |
+          cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build/test/ -S build/test/
+          cmake --build build/test
+      - name: Run DOLFINx C++ unit tests
+        run: |
+          cd build/test
+          ctest -V --output-on-failure -R unittests
+
+      - name: Run DOLFINx Python unit tests
+        run: python3 -m pytest -n auto dolfinx/python/test/unit


### PR DESCRIPTION
An FFCx pull request just caused these tests to fail, so it would be sensible to automatically run them here too