### PR TITLE
Add FFCx tests workflow

### DIFF
--- a/.github/workflows/ffcx-tests.yml
+++ b/.github/workflows/ffcx-tests.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    name: Run FFC tests
+    name: Run FFCx tests
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ffcx-tests.yml
+++ b/.github/workflows/ffcx-tests.yml
@@ -1,0 +1,46 @@
+# This workflow will install Basix and FFCx and run the FFCx unit tests.
+
+name: FFCx integration
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Run FFC tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Install Basix
+        run: |
+          cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build-dir -S ./cpp
+          cmake --build build-dir
+          cmake --install build-dir
+          python3 -m pip install ./python
+      - name: Install FEniCS Python components
+        run: |
+          python3 -m pip install git+https://github.com/FEniCS/ufl.git
+
+      - name: Get FFCx
+        uses: actions/checkout@v2
+        with:
+          path: ./ffcx
+          repository: FEniCS/ffcx
+          ref: main
+
+      - name: Install FFCx
+        run: |
+          cd ffcx
+          python -m pip install .[ci]
+
+      - name: Build FFCx unit tests
+        run: |
+          python -m pytest -n auto ffcx/test

--- a/.github/workflows/ffcx-tests.yml
+++ b/.github/workflows/ffcx-tests.yml
@@ -22,15 +22,10 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get install -y libopenblas-dev liblapack-dev ninja-build
 
+      - name: Install UFL
+        run: pip install git+https://github.com/FEniCS/ufl.git
       - name: Install Basix
-        run: |
-          cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build-dir -S ./cpp
-          cmake --build build-dir
-          cmake --install build-dir
-          python3 -m pip install ./python
-      - name: Install FEniCS Python components
-        run: |
-          python3 -m pip install git+https://github.com/FEniCS/ufl.git
+        run: pip -v install .[ci]
 
       - name: Get FFCx
         uses: actions/checkout@v2
@@ -42,7 +37,7 @@ jobs:
       - name: Install FFCx
         run: |
           cd ffcx
-          python -m pip install .[ci]
+          pip install .[ci]
 
       - name: Build FFCx unit tests
         run: |

--- a/.github/workflows/ffcx-tests.yml
+++ b/.github/workflows/ffcx-tests.yml
@@ -20,7 +20,8 @@ jobs:
           python-version: 3.9
 
       - name: Install dependencies
-        run: sudo apt-get install -y libopenblas-dev liblapack-dev ninja-build
+        run: |
+          sudo apt-get install -y libopenblas-dev liblapack-dev ninja-build graphviz libgraphviz-dev pkg-config
 
       - name: Install UFL
         run: pip install git+https://github.com/FEniCS/ufl.git

--- a/.github/workflows/ffcx-tests.yml
+++ b/.github/workflows/ffcx-tests.yml
@@ -19,6 +19,9 @@ jobs:
         with:
           python-version: 3.9
 
+      - name: Install dependencies
+        run: sudo apt-get install -y libopenblas-dev liblapack-dev ninja-build
+
       - name: Install Basix
         run: |
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build-dir -S ./cpp


### PR DESCRIPTION
Add workflow that runs the FFCx tests (to avoid issues like that fixed in https://github.com/FEniCS/ffcx/pull/479 where Basix caused a FFCx test to fail but none of the DOLFINx tests failed so this was missed)