### PR TITLE
Remove assumption that degree == highest_degree

### DIFF
--- a/.github/workflows/dolfin-tests.yml
+++ b/.github/workflows/dolfin-tests.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install FEniCS Python components
         run: |
           python3 -m pip install git+https://github.com/FEniCS/ufl.git
-          python3 -m pip install git+https://github.com/FEniCS/ffcx.git
+          python3 -m pip install git+https://github.com/FEniCS/ffcx.git@mscroggs/degree
 
       - name: Run cpp demos
         run: |
@@ -48,7 +48,7 @@ jobs:
         with:
           path: ./dolfinx
           repository: FEniCS/dolfinx
-          ref: main
+          ref: mscroggs/degree
 
       - name: Install DOLFINx
         run: |

--- a/.github/workflows/ffcx-tests.yml
+++ b/.github/workflows/ffcx-tests.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           path: ./ffcx
           repository: FEniCS/ffcx
-          ref: main
+          ref: mscroggs/degree
 
       - name: Install FFCx
         run: |

--- a/cpp/basix/e-brezzi-douglas-marini.cpp
+++ b/cpp/basix/e-brezzi-douglas-marini.cpp
@@ -73,8 +73,9 @@ FiniteElement basix::element::create_bdm(cell::type celltype, int degree,
     std::tie(x, M) = element::make_discontinuous(x, M, tdim, tdim);
   }
 
-  return FiniteElement(
-      element::family::BDM, celltype, degree, {tdim}, xt::eye<double>(ndofs), x,
-      M, maps::type::contravariantPiola, discontinuous, degree, {}, lvariant);
+  return FiniteElement(element::family::BDM, celltype, degree, {tdim},
+                       xt::eye<double>(ndofs), x, M,
+                       maps::type::contravariantPiola, discontinuous, degree,
+                       degree, lvariant);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/basix/e-bubble.cpp
+++ b/cpp/basix/e-bubble.cpp
@@ -155,6 +155,6 @@ FiniteElement basix::element::create_bubble(cell::type celltype, int degree,
   xt::view(M[tdim][0], xt::all(), 0, xt::all()) = xt::eye<double>(ndofs);
 
   return FiniteElement(element::family::bubble, celltype, degree, {1}, wcoeffs,
-                       x, M, maps::type::identity, discontinuous, -1);
+                       x, M, maps::type::identity, discontinuous, -1, degree);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/basix/e-crouzeix-raviart.cpp
+++ b/cpp/basix/e-crouzeix-raviart.cpp
@@ -72,6 +72,6 @@ FiniteElement basix::element::create_cr(cell::type celltype, int degree,
 
   return FiniteElement(element::family::CR, celltype, 1, {1},
                        xt::eye<double>(ndofs), x, M, maps::type::identity,
-                       discontinuous, degree);
+                       discontinuous, degree, degree);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/basix/e-hhj.cpp
+++ b/cpp/basix/e-hhj.cpp
@@ -161,6 +161,6 @@ FiniteElement basix::element::create_hhj(cell::type celltype, int degree,
 
   return FiniteElement(element::family::HHJ, celltype, degree, {tdim, tdim},
                        wcoeffs, x, M, maps::type::doubleContravariantPiola,
-                       discontinuous, -1);
+                       discontinuous, -1, degree);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/basix/e-lagrange.cpp
+++ b/cpp/basix/e-lagrange.cpp
@@ -123,7 +123,7 @@ FiniteElement create_d_lagrange(cell::type celltype, int degree,
 
   return FiniteElement(element::family::P, celltype, degree, {},
                        xt::eye<double>(ndofs), x, M, maps::type::identity, true,
-                       degree, {}, variant);
+                       degree, degree, variant);
 }
 //----------------------------------------------------------------------------
 std::vector<std::tuple<std::vector<FiniteElement>, std::vector<int>>>
@@ -827,7 +827,7 @@ FiniteElement create_vtk_element(cell::type celltype, int degree,
 
   return FiniteElement(element::family::P, celltype, degree, {},
                        xt::eye<double>(ndofs), x, M, maps::type::identity,
-                       discontinuous, degree);
+                       discontinuous, degree, degree);
 }
 //-----------------------------------------------------------------------------
 FiniteElement create_legendre(cell::type celltype, int degree,
@@ -880,7 +880,7 @@ FiniteElement create_legendre(cell::type celltype, int degree,
 
   return FiniteElement(element::family::P, celltype, degree, {},
                        xt::eye<double>(ndofs), x, M, maps::type::identity,
-                       discontinuous, degree, {},
+                       discontinuous, degree, degree,
                        element::lagrange_variant::legendre);
 }
 //-----------------------------------------------------------------------------
@@ -903,7 +903,8 @@ FiniteElement basix::element::create_lagrange(cell::type celltype, int degree,
     xt::xtensor<double, 2> wcoeffs = {{1}};
 
     return FiniteElement(element::family::P, cell::type::point, 0, {}, wcoeffs,
-                         x, M, maps::type::identity, discontinuous, degree);
+                         x, M, maps::type::identity, discontinuous, degree,
+                         degree);
   }
 
   if (variant == element::lagrange_variant::unset)
@@ -1041,6 +1042,7 @@ FiniteElement basix::element::create_lagrange(cell::type celltype, int degree,
 
   return FiniteElement(element::family::P, celltype, degree, {},
                        xt::eye<double>(ndofs), x, M, maps::type::identity,
-                       discontinuous, degree, tensor_factors, variant);
+                       discontinuous, degree, degree, variant,
+                       basix::element::dpc_variant::unset, tensor_factors);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/basix/e-nce-rtc.cpp
+++ b/cpp/basix/e-nce-rtc.cpp
@@ -160,7 +160,7 @@ FiniteElement basix::element::create_rtc(cell::type celltype, int degree,
 
   return FiniteElement(element::family::RT, celltype, degree, {tdim}, wcoeffs,
                        x, M, maps::type::contravariantPiola, discontinuous,
-                       degree - 1, {}, lvariant);
+                       degree - 1, degree, lvariant);
 }
 //-----------------------------------------------------------------------------
 FiniteElement basix::element::create_nce(cell::type celltype, int degree,
@@ -351,6 +351,6 @@ FiniteElement basix::element::create_nce(cell::type celltype, int degree,
 
   return FiniteElement(element::family::N1E, celltype, degree, {tdim}, wcoeffs,
                        x, M, maps::type::covariantPiola, discontinuous,
-                       degree - 1, {}, lvariant);
+                       degree - 1, degree, lvariant);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/basix/e-nedelec.cpp
+++ b/cpp/basix/e-nedelec.cpp
@@ -239,7 +239,7 @@ FiniteElement basix::element::create_nedelec(cell::type celltype, int degree,
 
   return FiniteElement(element::family::N1E, celltype, degree, {tdim}, wcoeffs,
                        x, M, maps::type::covariantPiola, discontinuous,
-                       degree - 1, {}, lvariant);
+                       degree - 1, degree, lvariant);
 }
 //-----------------------------------------------------------------------------
 FiniteElement
@@ -317,6 +317,6 @@ basix::element::create_nedelec2(cell::type celltype, int degree,
 
   return FiniteElement(element::family::N2E, celltype, degree, {tdim}, wcoeffs,
                        x, M, maps::type::covariantPiola, discontinuous, degree,
-                       {}, lvariant);
+                       degree, lvariant);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/basix/e-raviart-thomas.cpp
+++ b/cpp/basix/e-raviart-thomas.cpp
@@ -124,6 +124,6 @@ FiniteElement basix::element::create_rt(cell::type celltype, int degree,
 
   return FiniteElement(element::family::RT, celltype, degree, {tdim}, B, x, M,
                        maps::type::contravariantPiola, discontinuous,
-                       degree - 1, {}, lvariant);
+                       degree - 1, degree, lvariant);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/basix/e-regge.cpp
+++ b/cpp/basix/e-regge.cpp
@@ -160,6 +160,6 @@ FiniteElement basix::element::create_regge(cell::type celltype, int degree,
 
   return FiniteElement(element::family::Regge, celltype, degree, {tdim, tdim},
                        wcoeffs, x, M, maps::type::doubleCovariantPiola,
-                       discontinuous, -1);
+                       discontinuous, -1, degree);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/basix/e-serendipity.cpp
+++ b/cpp/basix/e-serendipity.cpp
@@ -627,7 +627,7 @@ FiniteElement create_legendre_dpc(cell::type celltype, int degree,
   }
 
   return FiniteElement(element::family::DPC, celltype, degree, {}, wcoeffs, x,
-                       M, maps::type::identity, discontinuous, degree, {},
+                       M, maps::type::identity, discontinuous, degree, degree,
                        element::lagrange_variant::unset,
                        element::dpc_variant::legendre);
 }
@@ -945,8 +945,8 @@ FiniteElement basix::element::create_serendipity(
 
   return FiniteElement(element::family::serendipity, celltype, degree, {1},
                        wcoeffs, x, M, maps::type::identity, discontinuous,
-                       degree < static_cast<int>(tdim) ? 1 : degree / tdim, {},
-                       lvariant, dvariant);
+                       degree < static_cast<int>(tdim) ? 1 : degree / tdim,
+                       degree, lvariant, dvariant);
 }
 //----------------------------------------------------------------------------
 FiniteElement basix::element::create_dpc(cell::type celltype, int degree,
@@ -1044,7 +1044,7 @@ FiniteElement basix::element::create_dpc(cell::type celltype, int degree,
   x[tdim].push_back(pt);
 
   return FiniteElement(element::family::DPC, celltype, degree, {}, wcoeffs, x,
-                       M, maps::type::identity, discontinuous, degree, {},
+                       M, maps::type::identity, discontinuous, degree, degree,
                        element::lagrange_variant::unset, variant);
 }
 //-----------------------------------------------------------------------------
@@ -1083,14 +1083,14 @@ FiniteElement basix::element::create_serendipity_div(
             ? element::create_lagrange(facettype, degree, lvariant, true)
             : element::create_dpc(facettype, degree, dvariant, true);
   std::tie(x[tdim - 1], M[tdim - 1]) = moments::make_normal_integral_moments(
-      facet_moment_space, celltype, tdim, 2 * degree);
+      facet_moment_space, celltype, tdim, 2 * degree + 1);
 
   if (degree >= 2)
   {
     FiniteElement cell_moment_space
         = element::create_dpc(celltype, degree - 2, dvariant, true);
     std::tie(x[tdim], M[tdim]) = moments::make_integral_moments(
-        cell_moment_space, celltype, tdim, 2 * degree - 2);
+        cell_moment_space, celltype, tdim, 2 * degree - 1);
   }
   else
   {
@@ -1114,9 +1114,9 @@ FiniteElement basix::element::create_serendipity_div(
     std::tie(x, M) = element::make_discontinuous(x, M, tdim, tdim);
   }
 
-  return FiniteElement(element::family::BDM, celltype, degree + 1, {tdim},
-                       wcoeffs, x, M, maps::type::contravariantPiola,
-                       discontinuous, degree / tdim, {}, lvariant, dvariant);
+  return FiniteElement(element::family::BDM, celltype, degree, {tdim}, wcoeffs,
+                       x, M, maps::type::contravariantPiola, discontinuous,
+                       degree / tdim, degree + 1, lvariant, dvariant);
 }
 //-----------------------------------------------------------------------------
 FiniteElement basix::element::create_serendipity_curl(
@@ -1135,10 +1135,11 @@ FiniteElement basix::element::create_serendipity_curl(
 
   // Evaluate the expansion polynomials at the quadrature points
   auto [Qpts, _wts] = quadrature::make_quadrature(quadrature::type::Default,
-                                                  celltype, 2 * degree);
+                                                  celltype, 2 * degree + 1);
   auto wts = xt::adapt(_wts);
-  xt::xtensor<double, 2> polyset_at_Qpts = xt::view(
-      polyset::tabulate(celltype, degree, 0, Qpts), 0, xt::all(), xt::all());
+  xt::xtensor<double, 2> polyset_at_Qpts
+      = xt::view(polyset::tabulate(celltype, degree + 1, 0, Qpts), 0, xt::all(),
+                 xt::all());
 
   xt::xtensor<double, 2> wcoeffs;
   if (tdim == 2)
@@ -1159,7 +1160,7 @@ FiniteElement basix::element::create_serendipity_curl(
       = element::create_lagrange(cell::type::interval, degree, lvariant, true);
 
   std::tie(x[1], M[1]) = moments::make_tangent_integral_moments(
-      edge_moment_space, celltype, tdim, 2 * degree);
+      edge_moment_space, celltype, tdim, 2 * degree + 1);
 
   if (degree >= 2)
   {
@@ -1167,7 +1168,7 @@ FiniteElement basix::element::create_serendipity_curl(
     FiniteElement moment_space = element::create_dpc(
         cell::type::quadrilateral, degree - 2, dvariant, true);
     std::tie(x[2], M[2]) = moments::make_integral_moments(
-        moment_space, celltype, tdim, 2 * degree - 2);
+        moment_space, celltype, tdim, 2 * degree - 1);
   }
   else
   {
@@ -1186,7 +1187,7 @@ FiniteElement basix::element::create_serendipity_curl(
       std::tie(x[3], M[3]) = moments::make_integral_moments(
           element::create_dpc(cell::type::hexahedron, degree - 4, dvariant,
                               true),
-          celltype, tdim, 2 * degree - 4);
+          celltype, tdim, 2 * degree - 3);
     }
     else
     {
@@ -1207,9 +1208,9 @@ FiniteElement basix::element::create_serendipity_curl(
     std::tie(x, M) = element::make_discontinuous(x, M, tdim, tdim);
   }
 
-  return FiniteElement(element::family::N2E, celltype, degree + 1, {tdim},
-                       wcoeffs, x, M, maps::type::covariantPiola, discontinuous,
-                       (degree == 2 && tdim == 3) ? 1 : degree / tdim, {},
-                       lvariant, dvariant);
+  return FiniteElement(element::family::N2E, celltype, degree, {tdim}, wcoeffs,
+                       x, M, maps::type::covariantPiola, discontinuous,
+                       (degree == 2 && tdim == 3) ? 1 : degree / tdim,
+                       degree + 1, lvariant, dvariant);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -395,15 +395,15 @@ basix::element::make_discontinuous(
 }
 //-----------------------------------------------------------------------------
 basix::FiniteElement basix::create_custom_element(
-    cell::type cell_type, int degree,
-    const std::vector<std::size_t>& value_shape,
+    cell::type cell_type, const std::vector<std::size_t>& value_shape,
     const xt::xtensor<double, 2>& wcoeffs,
     const std::array<std::vector<xt::xtensor<double, 2>>, 4>& x,
     const std::array<std::vector<xt::xtensor<double, 3>>, 4>& M,
-    maps::type map_type, bool discontinuous, int highest_complete_degree)
+    maps::type map_type, bool discontinuous, int highest_complete_degree,
+    int highest_degree)
 {
   // Check that inputs are valid
-  const std::size_t psize = polyset::dim(cell_type, degree);
+  const std::size_t psize = polyset::dim(cell_type, highest_degree);
   std::size_t value_size = 1;
   for (std::size_t i = 0; i < value_shape.size(); ++i)
     value_size *= value_shape[i];
@@ -456,14 +456,14 @@ basix::FiniteElement basix::create_custom_element(
   }
 
   xt::xtensor<double, 2> dual_matrix
-      = compute_dual_matrix(cell_type, wcoeffs, M, x, degree);
+      = compute_dual_matrix(cell_type, wcoeffs, M, x, highest_degree);
   if (math::is_singular(dual_matrix))
     throw std::runtime_error(
         "Dual matrix is singular, there is an error in your inputs");
 
-  return basix::FiniteElement(element::family::custom, cell_type, degree,
-                              value_shape, wcoeffs, x, M, map_type,
-                              discontinuous, highest_complete_degree, degree);
+  return basix::FiniteElement(
+      element::family::custom, cell_type, -1, value_shape, wcoeffs, x, M,
+      map_type, discontinuous, highest_complete_degree, highest_degree);
 }
 
 //-----------------------------------------------------------------------------

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -462,8 +462,8 @@ basix::FiniteElement basix::create_custom_element(
         "Dual matrix is singular, there is an error in your inputs");
 
   return basix::FiniteElement(
-      element::family::custom, cell_type, -1, value_shape, wcoeffs, x, M,
-      map_type, discontinuous, highest_complete_degree, highest_degree);
+      element::family::custom, cell_type, highest_degree, value_shape, wcoeffs,
+      x, M, map_type, discontinuous, highest_complete_degree, highest_degree);
 }
 
 //-----------------------------------------------------------------------------
@@ -810,7 +810,11 @@ void FiniteElement::tabulate(int nd, const xt::xarray<double>& x,
 //-----------------------------------------------------------------------------
 cell::type FiniteElement::cell_type() const { return _cell_type; }
 //-----------------------------------------------------------------------------
-int FiniteElement::degree() const { return _degree; }
+int FiniteElement::degree() const
+{
+  throw std::runtime_error("here");
+  return _degree;
+}
 //-----------------------------------------------------------------------------
 int FiniteElement::highest_degree() const { return _highest_degree; }
 //-----------------------------------------------------------------------------

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -463,7 +463,7 @@ basix::FiniteElement basix::create_custom_element(
 
   return basix::FiniteElement(element::family::custom, cell_type, degree,
                               value_shape, wcoeffs, x, M, map_type,
-                              discontinuous, highest_complete_degree);
+                              discontinuous, highest_complete_degree, degree);
 }
 
 //-----------------------------------------------------------------------------
@@ -474,15 +474,16 @@ FiniteElement::FiniteElement(
     const std::array<std::vector<xt::xtensor<double, 2>>, 4>& x,
     const std::array<std::vector<xt::xtensor<double, 3>>, 4>& M,
     maps::type map_type, bool discontinuous, int highest_complete_degree,
+    int highest_degree, element::lagrange_variant lvariant,
+    element::dpc_variant dvariant,
     std::vector<std::tuple<std::vector<FiniteElement>, std::vector<int>>>
-        tensor_factors,
-    element::lagrange_variant lvariant, element::dpc_variant dvariant)
+        tensor_factors)
     : _cell_type(cell_type), _cell_tdim(cell::topological_dimension(cell_type)),
       _cell_subentity_types(cell::subentity_types(cell_type)), _family(family),
       _lagrange_variant(lvariant), _dpc_variant(dvariant), _degree(degree),
-      _map_type(map_type), _x(x), _discontinuous(discontinuous),
-      _degree_bounds({highest_complete_degree, degree}),
-      _tensor_factors(tensor_factors)
+      _highest_degree(highest_degree),
+      _highest_complete_degree(highest_complete_degree), _map_type(map_type),
+      _x(x), _discontinuous(discontinuous), _tensor_factors(tensor_factors)
 {
   // Check that discontinuous elements only have DOFs on interior
   if (discontinuous)
@@ -494,7 +495,7 @@ FiniteElement::FiniteElement(
               "Discontinuous element can only have interior DOFs.");
   }
 
-  _dual_matrix = compute_dual_matrix(cell_type, wcoeffs, M, x, degree);
+  _dual_matrix = compute_dual_matrix(cell_type, wcoeffs, M, x, highest_degree);
 
   if (family == element::family::custom)
   {
@@ -540,7 +541,7 @@ FiniteElement::FiniteElement(
   }
 
   _entity_transformations = doftransforms::compute_entity_transformations(
-      cell_type, x, M, _coeffs, degree, value_size, map_type);
+      cell_type, x, M, _coeffs, highest_degree, value_size, map_type);
 
   _matM = xt::zeros<double>({num_dofs, value_size * num_points1});
   auto Mview = xt::reshape_view(_matM, {num_dofs, value_size, num_points1});
@@ -737,6 +738,10 @@ FiniteElement::FiniteElement(
 //-----------------------------------------------------------------------------
 bool FiniteElement::operator==(const FiniteElement& e) const
 {
+  if (family() == basix::element::family::custom
+      and e.family() == basix::element::family::custom)
+    throw std::runtime_error("== not implemented for custom elements yet.");
+
   return cell_type() == e.cell_type() and family() == e.family()
          and degree() == e.degree() and discontinuous() == e.discontinuous()
          and lagrange_variant() == e.lagrange_variant()
@@ -782,10 +787,11 @@ void FiniteElement::tabulate(int nd, const xt::xarray<double>& x,
     throw std::runtime_error("Point dim does not match element dim.");
 
   xt::xtensor<double, 3> basis(
-      {static_cast<std::size_t>(polyset::nderivs(_cell_type, nd)), x_copy.shape(0),
-       static_cast<std::size_t>(polyset::dim(_cell_type, _degree))});
-  polyset::tabulate(basis, _cell_type, _degree, nd, x_copy);
-  const int psize = polyset::dim(_cell_type, _degree);
+      {static_cast<std::size_t>(polyset::nderivs(_cell_type, nd)),
+       x_copy.shape(0),
+       static_cast<std::size_t>(polyset::dim(_cell_type, _highest_degree))});
+  polyset::tabulate(basis, _cell_type, _highest_degree, nd, x_copy);
+  const int psize = polyset::dim(_cell_type, _highest_degree);
   const int vs = std::accumulate(_value_shape.begin(), _value_shape.end(), 1,
                                  std::multiplies<int>());
   xt::xtensor<double, 2> B, C;
@@ -805,6 +811,13 @@ void FiniteElement::tabulate(int nd, const xt::xarray<double>& x,
 cell::type FiniteElement::cell_type() const { return _cell_type; }
 //-----------------------------------------------------------------------------
 int FiniteElement::degree() const { return _degree; }
+//-----------------------------------------------------------------------------
+int FiniteElement::highest_degree() const { return _highest_degree; }
+//-----------------------------------------------------------------------------
+int FiniteElement::highest_complete_degree() const
+{
+  return _highest_complete_degree;
+}
 //-----------------------------------------------------------------------------
 const std::vector<int>& FiniteElement::value_shape() const
 {
@@ -1123,11 +1136,6 @@ FiniteElement::M() const
 const xt::xtensor<double, 2>& FiniteElement::coefficient_matrix() const
 {
   return _coeffs;
-}
-//-----------------------------------------------------------------------------
-std::array<int, 2> FiniteElement::degree_bounds() const
-{
-  return _degree_bounds;
 }
 //-----------------------------------------------------------------------------
 bool FiniteElement::has_tensor_product_factorisation() const

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -810,11 +810,7 @@ void FiniteElement::tabulate(int nd, const xt::xarray<double>& x,
 //-----------------------------------------------------------------------------
 cell::type FiniteElement::cell_type() const { return _cell_type; }
 //-----------------------------------------------------------------------------
-int FiniteElement::degree() const
-{
-  throw std::runtime_error("here");
-  return _degree;
-}
+int FiniteElement::degree() const { return _degree;}
 //-----------------------------------------------------------------------------
 int FiniteElement::highest_degree() const { return _highest_degree; }
 //-----------------------------------------------------------------------------

--- a/cpp/basix/finite-element.h
+++ b/cpp/basix/finite-element.h
@@ -212,10 +212,12 @@ public:
   /// @param[in] highest_complete_degree The highest degree n such that a
   /// Lagrange (or vector Lagrange) element of degree n is a subspace of this
   /// element
-  /// @param[in] tensor_factors The factors in the tensor product representation
-  /// of this element
+  /// @param[in] highest_degree The highest degree n such that at least one
+  /// polynomial of degree n is included in this element's polymonial set
   /// @param[in] lvariant The Lagrange variant of the element
   /// @param[in] dvariant The DPC variant of the element
+  /// @param[in] tensor_factors The factors in the tensor product representation
+  /// of this element
   FiniteElement(
       element::family family, cell::type cell_type, int degree,
       const std::vector<std::size_t>& value_shape,
@@ -223,11 +225,12 @@ public:
       const std::array<std::vector<xt::xtensor<double, 2>>, 4>& x,
       const std::array<std::vector<xt::xtensor<double, 3>>, 4>& M,
       maps::type map_type, bool discontinuous, int highest_complete_degree,
+      int highest_degree,
+      element::lagrange_variant lvariant = element::lagrange_variant::unset,
+      element::dpc_variant dvariant = element::dpc_variant::unset,
       std::vector<std::tuple<std::vector<FiniteElement>, std::vector<int>>>
           tensor_factors
-      = {},
-      element::lagrange_variant lvariant = element::lagrange_variant::unset,
-      element::dpc_variant dvariant = element::dpc_variant::unset);
+      = {});
 
   /// Copy constructor
   FiniteElement(const FiniteElement& element) = default;
@@ -320,6 +323,17 @@ public:
   /// Get the element polynomial degree
   /// @return Polynomial degree
   int degree() const;
+
+  /// Get the lowest degree n such that the highest degree
+  /// polynomial in this element is contained in a Lagrange (or vector
+  /// Lagrange) element of degree n
+  /// @return Polynomial degree
+  int highest_degree() const;
+
+  /// Get the highest degree n such that a Lagrange (or vector Lagrange) element
+  /// of degree n is a subspace of this element
+  /// @return Polynomial degree
+  int highest_complete_degree() const;
 
   /// The element value tensor shape, eg returning {} for scalars, {3}
   /// for vectors in 3D, {2, 2} for a rank-2 tensor in 2D.
@@ -836,12 +850,6 @@ public:
   /// @return The dual matrix
   const xt::xtensor<double, 2>& coefficient_matrix() const;
 
-  /// Get [0] the lowest degree n such that the highest degree
-  /// polynomial in this element is contained in a Lagrange (or vector
-  /// Lagrange) element of degree n, and [1] the highest degree n such
-  /// that a Lagrange (or vector Lagrange) element of degree n is a
-  /// subspace of this element
-  std::array<int, 2> degree_bounds() const;
 
   /// Indicates whether or not this element has a tensor product
   /// representation.
@@ -884,8 +892,14 @@ private:
   // Lagrange variant
   element::dpc_variant _dpc_variant;
 
-  // Degree
+  // Degree that was input when creating the element
   int _degree;
+
+  // Highest degree polynomial in element's polyset
+  int _highest_degree;
+
+  // Highest degree space that is a subspace of element's polyset
+  int _highest_complete_degree;
 
   // Value shape
   std::vector<int> _value_shape;
@@ -982,12 +996,6 @@ private:
 
   // The dual matrix
   xt::xtensor<double, 2> _dual_matrix;
-
-  // Polynomial degree bounds
-  // [0]: highest degree n such that Lagrange order n is a subspace of
-  // this space
-  // [1]: highest polynomial degree
-  std::array<int, 2> _degree_bounds;
 
   // Tensor product representation
   // Entries of tuple are (list of elements on an interval, permutation

--- a/cpp/basix/finite-element.h
+++ b/cpp/basix/finite-element.h
@@ -1018,7 +1018,6 @@ private:
 
 /// Create a custom finite element
 /// @param[in] cell_type The cell type
-/// @param[in] degree The degree of the element
 /// @param[in] value_shape The value shape of the element
 /// @param[in] wcoeffs Matrices for the kth value index containing the
 /// expansion coefficients defining a polynomial basis spanning the
@@ -1034,14 +1033,16 @@ private:
 /// @param[in] highest_complete_degree The highest degree n such that a
 /// Lagrange (or vector Lagrange) element of degree n is a subspace of this
 /// element
+/// @param[in] highest_degree The degree of a polynomial in this element's
+/// polyset
 /// @return A custom finite element
 FiniteElement create_custom_element(
-    cell::type cell_type, int degree,
-    const std::vector<std::size_t>& value_shape,
+    cell::type cell_type, const std::vector<std::size_t>& value_shape,
     const xt::xtensor<double, 2>& wcoeffs,
     const std::array<std::vector<xt::xtensor<double, 2>>, 4>& x,
     const std::array<std::vector<xt::xtensor<double, 3>>, 4>& M,
-    maps::type map_type, bool discontinuous, int highest_complete_degree);
+    maps::type map_type, bool discontinuous, int highest_complete_degree,
+    int highest_degree);
 
 /// Create an element using a given Lagrange variant
 /// @param[in] family The element family

--- a/demo/python/demo_custom_element.py
+++ b/demo/python/demo_custom_element.py
@@ -125,7 +125,6 @@ for _ in range(4):
 # We now create the custom element. The inputs into `basix.create_custom_element` are:
 #
 # - The cell type. In this example, this is a quadrilateral.
-# - The polynomial degree of the element. In this example, this is 2.
 # - The value shape of the element. In this example, this is `[]` as the element is scalar.
 # - The coefficients that define the polynomial set. In this example, this is `wcoeffs`.
 # - The points used to define interpolation into the element. In this example, this is `x`.
@@ -134,9 +133,12 @@ for _ in range(4):
 # - A bool indicating whether the element is discontinuous. In this example, this is `False`.
 # - The highest degree :math:`n` such that all degree :math:`n` polynomials are contained in
 #   this set. In this example, this is 1.
+# - The highest degree of a polynomial in the element. In this example, this is 2. It is
+#   important that this value is correct, as it will be used to determine the number of
+#   polynomials to use when creating and tabulating the element.
 
 element = basix.create_custom_element(
-    CellType.quadrilateral, 2, [], wcoeffs, x, M, MapType.identity, False, 1)
+    CellType.quadrilateral, [], wcoeffs, x, M, MapType.identity, False, 1, 2)
 
 # We can now use this element in the same way we can use a built-in element. For example, we
 # can tabulate the element at a set of points. If the points we use are the same as the points
@@ -224,7 +226,7 @@ M[2].append(np.zeros((0, 2, 0)))
 # --------------------
 
 element = basix.create_custom_element(
-    CellType.triangle, 1, [2], wcoeffs, x, M, MapType.contravariantPiola, False, 0)
+    CellType.triangle, [2], wcoeffs, x, M, MapType.contravariantPiola, False, 0, 1)
 
 # To confirm that we have defined this element correctly, we compare it to the built-in
 # Raviart--Thomas element.

--- a/python/basix/ufl_wrapper.py
+++ b/python/basix/ufl_wrapper.py
@@ -45,7 +45,7 @@ def map_type_to_string(map_type):
 def compute_signature(element):
     """Compute a signature of a custom element."""
     signature = (f"{element.cell_type.name}, {element.value_shape}, {element.map_type.name}, "
-                 f"{element.discontinuous}, {element.highest_complete_degree}, {element.highest_degree}")
+                 f"{element.discontinuous}, {element.highest_complete_degree}, {element.highest_degree}, ")
     data = ",".join([f"{i}" for row in element.wcoeffs for i in row])
     data += "__"
     for entity in element.x:

--- a/python/basix/ufl_wrapper.py
+++ b/python/basix/ufl_wrapper.py
@@ -44,8 +44,8 @@ def map_type_to_string(map_type):
 
 def compute_signature(element):
     """Compute a signature of a custom element."""
-    signature = (f"{element.cell_type.name}, {element.degree}, {element.value_shape}, {element.map_type.name}, "
-                 f"{element.discontinuous}, {element.degree_bounds}, ")
+    signature = (f"{element.cell_type.name}, {element.value_shape}, {element.map_type.name}, "
+                 f"{element.discontinuous}, {element.highest_complete_degree}, {element.highest_degree}")
     data = ",".join([f"{i}" for row in element.wcoeffs for i in row])
     data += "__"
     for entity in element.x:

--- a/python/docs.h
+++ b/python/docs.h
@@ -491,8 +491,6 @@ Parameters
 ==========
 cell_type : basix.CellType
     The cell type
-degree : int
-    The degree of the element
 value_shape : List[int]
     The value shape of the element
 wcoeffs : numpy.ndarray[numpy.float64]
@@ -507,6 +505,8 @@ discontinuous : bool
     Indicates whether or not this is the discontinuous version of the element
 highest_complete_degree : int
     The highest degree n such that a Lagrange (or vector Lagrange) element of degree n is a subspace of this element
+highest_degree : int
+    The degree of a polynomial in this element's polyset
 
 Returns
 =======

--- a/python/docs.h.template
+++ b/python/docs.h.template
@@ -267,23 +267,23 @@ Returns
 )";
 
 {{DOCTYPE}} create_custom_element = R"(
-{{finite-element.h > create_custom_element(cell_type, degree, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_complete_degree) > doc}}
+{{finite-element.h > create_custom_element(cell_type, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_complete_degree, highest_degree) > doc}}
 
 Parameters
 ==========
-{{finite-element.h > create_custom_element(cell_type, degree, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_complete_degree) > param > cell_type : basix.CellType}}
-{{finite-element.h > create_custom_element(cell_type, degree, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_complete_degree) > param > degree : int}}
-{{finite-element.h > create_custom_element(cell_type, degree, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_complete_degree) > param > value_shape : List[int]}}
-{{finite-element.h > create_custom_element(cell_type, degree, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_complete_degree) > param > wcoeffs : numpy.ndarray[numpy.float64]}}
-{{finite-element.h > create_custom_element(cell_type, degree, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_complete_degree) > param > x : List[List[numpy.ndarray[numpy.float64]]]}}
-{{finite-element.h > create_custom_element(cell_type, degree, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_complete_degree) > param > M : List[List[numpy.ndarray[numpy.float64]]]}}
-{{finite-element.h > create_custom_element(cell_type, degree, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_complete_degree) > param > map_type : basix.MapType}}
-{{finite-element.h > create_custom_element(cell_type, degree, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_complete_degree) > param > discontinuous : bool}}
-{{finite-element.h > create_custom_element(cell_type, degree, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_complete_degree) > param > highest_complete_degree : int}}
+{{finite-element.h > create_custom_element(cell_type, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_complete_degree, highest_degree) > param > cell_type : basix.CellType}}
+{{finite-element.h > create_custom_element(cell_type, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_complete_degree, highest_degree) > param > value_shape : List[int]}}
+{{finite-element.h > create_custom_element(cell_type, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_complete_degree, highest_degree) > param > wcoeffs : numpy.ndarray[numpy.float64]}}
+{{finite-element.h > create_custom_element(cell_type, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_complete_degree, highest_degree) > param > x : List[List[numpy.ndarray[numpy.float64]]]}}
+{{finite-element.h > create_custom_element(cell_type, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_complete_degree, highest_degree) > param > M : List[List[numpy.ndarray[numpy.float64]]]}}
+{{finite-element.h > create_custom_element(cell_type, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_complete_degree, highest_degree) > param > map_type : basix.MapType}}
+{{finite-element.h > create_custom_element(cell_type, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_complete_degree, highest_degree) > param > discontinuous : bool}}
+{{finite-element.h > create_custom_element(cell_type, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_complete_degree, highest_degree) > param > highest_complete_degree : int}}
+{{finite-element.h > create_custom_element(cell_type, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_complete_degree, highest_degree) > param > highest_degree : int}}
 
 Returns
 =======
-{{finite-element.h > create_custom_element(cell_type, degree, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_complete_degree) > return : basix.finite_element.FiniteElement}}
+{{finite-element.h > create_custom_element(cell_type, value_shape, wcoeffs, x, M, map_type, discontinuous, highest_complete_degree, highest_degree) > return : basix.finite_element.FiniteElement}}
 )";
 
 {{DOCTYPE}} create_element__family_cell_degree_discontinuous = R"(

--- a/python/generate_docs.py
+++ b/python/generate_docs.py
@@ -73,6 +73,8 @@ def get_docstring(matches):
     if "(" not in function:
         function += "("
 
+    if function not in content:
+        print(function)
     assert function in content
     doc = content.split(function)[0].split(";")[-1]
 

--- a/python/wrapper.cpp
+++ b/python/wrapper.cpp
@@ -455,15 +455,14 @@ Interface to the Basix C++ library.
   // Create FiniteElement
   m.def(
       "create_custom_element",
-      [](cell::type cell_type, int degree, const std::vector<int>& value_shape,
+      [](cell::type cell_type, const std::vector<int>& value_shape,
          const py::array_t<double, py::array::c_style>& wcoeffs,
          const std::vector<
              std::vector<py::array_t<double, py::array::c_style>>>& x,
          const std::vector<
              std::vector<py::array_t<double, py::array::c_style>>>& M,
-         maps::type map_type, bool discontinuous,
-         int highest_complete_degree) -> FiniteElement
-      {
+         maps::type map_type, bool discontinuous, int highest_complete_degree,
+         int highest_degree) -> FiniteElement {
         if (x.size() != 4)
           throw std::runtime_error("x has the wrong size");
         if (M.size() != 4)
@@ -497,9 +496,9 @@ Interface to the Basix C++ library.
         for (std::size_t i = 0; i < value_shape.size(); ++i)
           _vs[i] = static_cast<std::size_t>(value_shape[i]);
 
-        return basix::create_custom_element(cell_type, degree, _vs, _wco, _x,
-                                            _M, map_type, discontinuous,
-                                            highest_complete_degree);
+        return basix::create_custom_element(
+            cell_type, _vs, _wco, _x, _M, map_type, discontinuous,
+            highest_complete_degree, highest_degree);
       },
       basix::docstring::create_custom_element.c_str());
 

--- a/python/wrapper.cpp
+++ b/python/wrapper.cpp
@@ -326,6 +326,9 @@ Interface to the Basix C++ library.
           basix::docstring::FiniteElement__get_tensor_product_representation
               .c_str())
       .def_property_readonly("degree", &FiniteElement::degree)
+      .def_property_readonly("highest_degree", &FiniteElement::highest_degree)
+      .def_property_readonly("highest_complete_degree",
+                             &FiniteElement::highest_complete_degree)
       .def_property_readonly("cell_type", &FiniteElement::cell_type)
       .def_property_readonly("dim", &FiniteElement::dim)
       .def_property_readonly("num_entity_dofs", &FiniteElement::num_entity_dofs)
@@ -355,7 +358,6 @@ Interface to the Basix C++ library.
       .def_property_readonly("interpolation_is_identity",
                              &FiniteElement::interpolation_is_identity)
       .def_property_readonly("map_type", &FiniteElement::map_type)
-      .def_property_readonly("degree_bounds", &FiniteElement::degree_bounds)
       .def_property_readonly("points",
                              [](const FiniteElement& self) {
                                const xt::xtensor<double, 2>& x = self.points();

--- a/test/test_create.py
+++ b/test/test_create.py
@@ -65,6 +65,7 @@ def test_all_elements_included():
 @pytest.mark.parametrize("variant", variants)
 def test_create_element(cell, degree, family, variant):
     """Check that either the element is created or a RuntimeError is thrown."""
+    print(cell, degree, family)
     try:
         element = basix.create_element(family, cell, degree, *variant)
         assert element.degree == degree

--- a/test/test_create.py
+++ b/test/test_create.py
@@ -61,19 +61,21 @@ def test_all_elements_included():
 
 @pytest.mark.parametrize("cell", cells)
 @pytest.mark.parametrize("degree", range(-1, 5))
-@pytest.mark.parametrize("element", elements)
+@pytest.mark.parametrize("family", elements)
 @pytest.mark.parametrize("variant", variants)
-def test_create_element(cell, degree, element, variant):
+def test_create_element(cell, degree, family, variant):
     """Check that either the element is created or a RuntimeError is thrown."""
     try:
-        basix.create_element(element, cell, degree, *variant)
+        element = basix.create_element(family, cell, degree, *variant)
+        assert element.degree == degree
     except RuntimeError as e:
         # Don't allow cryptic "dgesv failed" messages
         if len(e.args) == 0 or "dgesv" in e.args[0]:
             raise e
 
     try:
-        basix.create_element(element, cell, degree, *variant, True)
+        element = basix.create_element(family, cell, degree, *variant, True)
+        assert element.degree == degree
     except RuntimeError as e:
         if len(e.args) == 0 or "dgesv" in e.args[0]:
             raise e

--- a/test/test_create.py
+++ b/test/test_create.py
@@ -65,7 +65,6 @@ def test_all_elements_included():
 @pytest.mark.parametrize("variant", variants)
 def test_create_element(cell, degree, family, variant):
     """Check that either the element is created or a RuntimeError is thrown."""
-    print(cell, degree, family)
     try:
         element = basix.create_element(family, cell, degree, *variant)
         assert element.degree == degree

--- a/test/test_custom_element.py
+++ b/test/test_custom_element.py
@@ -22,8 +22,8 @@ def test_lagrange_custom_triangle_degree1():
         basix.ElementFamily.P, basix.CellType.triangle, 1)
 
     element = basix.create_custom_element(
-        basix.CellType.triangle, 1, [], wcoeffs,
-        x, M, basix.MapType.identity, False, 1)
+        basix.CellType.triangle, [], wcoeffs,
+        x, M, basix.MapType.identity, False, 1, 1)
 
     points = basix.create_lattice(basix.CellType.triangle, 5, basix.LatticeType.equispaced, True)
     assert np.allclose(lagrange.tabulate(1, points), element.tabulate(1, points))
@@ -45,8 +45,8 @@ def test_lagrange_custom_triangle_degree1_l2piola():
         basix.ElementFamily.P, basix.CellType.triangle, 1)
 
     element = basix.create_custom_element(
-        basix.CellType.triangle, 1, [], wcoeffs,
-        x, M, basix.MapType.L2Piola, False, 1)
+        basix.CellType.triangle, [], wcoeffs,
+        x, M, basix.MapType.L2Piola, False, 1, 1)
 
     points = basix.create_lattice(basix.CellType.triangle, 5, basix.LatticeType.equispaced, True)
     assert np.allclose(lagrange.tabulate(1, points), element.tabulate(1, points))
@@ -69,8 +69,8 @@ def test_lagrange_custom_triangle_degree4():
         basix.ElementFamily.P, basix.CellType.triangle, 4, basix.LagrangeVariant.equispaced)
 
     element = basix.create_custom_element(
-        basix.CellType.triangle, 4, [], wcoeffs,
-        x, M, basix.MapType.identity, False, 4)
+        basix.CellType.triangle, [], wcoeffs,
+        x, M, basix.MapType.identity, False, 4, 4)
 
     points = basix.create_lattice(basix.CellType.triangle, 5, basix.LatticeType.equispaced, True)
     assert np.allclose(lagrange.tabulate(1, points), element.tabulate(1, points))
@@ -92,8 +92,8 @@ def test_lagrange_custom_quadrilateral_degree1():
         basix.ElementFamily.P, basix.CellType.quadrilateral, 1)
 
     element = basix.create_custom_element(
-        basix.CellType.quadrilateral, 1, [], wcoeffs,
-        x, M, basix.MapType.identity, False, 1)
+        basix.CellType.quadrilateral, [], wcoeffs,
+        x, M, basix.MapType.identity, False, 1, 1)
 
     points = basix.create_lattice(basix.CellType.quadrilateral, 5, basix.LatticeType.equispaced, True)
     assert np.allclose(lagrange.tabulate(1, points), element.tabulate(1, points))
@@ -131,7 +131,7 @@ def test_raviart_thomas_triangle_degree1():
     M[2].append(np.zeros((0, 2, 0)))
 
     element = basix.create_custom_element(
-        basix.CellType.triangle, 1, [2], wcoeffs, x, M, basix.MapType.contravariantPiola, False, 0)
+        basix.CellType.triangle, [2], wcoeffs, x, M, basix.MapType.contravariantPiola, False, 0, 1)
 
     rt = basix.create_element(
         basix.ElementFamily.RT, basix.CellType.triangle, 1)
@@ -157,7 +157,7 @@ def create_lagrange1_quad(cell_type=basix.CellType.quadrilateral, degree=1, wcoe
     if value_shape is None:
         value_shape = []
     basix.create_custom_element(
-        cell_type, degree, value_shape, wcoeffs, x, M, basix.MapType.identity, discontinuous, 1)
+        cell_type, value_shape, wcoeffs, x, M, basix.MapType.identity, discontinuous, 1, degree)
 
 
 def test_create_lagrange1_quad():

--- a/test/test_interpolation_between_elements.py
+++ b/test/test_interpolation_between_elements.py
@@ -145,15 +145,15 @@ def test_degree_bounds(cell_type, degree, element_type, element_args):
     tab = element.tabulate(0, points)[0]
 
     # Test that this element's basis functions are contained in Lagrange space with
-    # degree element.degree_bounds[1]
+    # degree element.highest_degree
     coeffs = np.random.rand(element.dim)
     values = np.array([tab[:, :, i] @ coeffs
                        for i in range(element.value_size)])
 
-    if element.degree_bounds[1] >= 0:
+    if element.highest_degree >= 0:
         # The element being tested should be a subset of this Lagrange space
         lagrange = basix.create_element(
-            basix.ElementFamily.P, cell_type, element.degree_bounds[1], basix.LagrangeVariant.equispaced, True)
+            basix.ElementFamily.P, cell_type, element.highest_degree, basix.LagrangeVariant.equispaced, True)
         lagrange_coeffs = basix.compute_interpolation_operator(element, lagrange) @ coeffs
         lagrange_tab = lagrange.tabulate(0, points)[0]
         lagrange_values = np.array([lagrange_tab[:, :, 0] @ lagrange_coeffs[i::element.value_size]
@@ -161,10 +161,10 @@ def test_degree_bounds(cell_type, degree, element_type, element_args):
 
         assert np.allclose(values, lagrange_values)
 
-    if element.degree_bounds[1] >= 1:
+    if element.highest_degree >= 1:
         # The element being tested should be NOT a subset of this Lagrange space
         lagrange = basix.create_element(
-            basix.ElementFamily.P, cell_type, element.degree_bounds[1] - 1,
+            basix.ElementFamily.P, cell_type, element.highest_degree - 1,
             basix.LagrangeVariant.equispaced, True)
         lagrange_coeffs = basix.compute_interpolation_operator(element, lagrange) @ coeffs
         lagrange_tab = lagrange.tabulate(0, points)[0]
@@ -173,13 +173,13 @@ def test_degree_bounds(cell_type, degree, element_type, element_args):
 
         assert not np.allclose(values, lagrange_values)
 
-    # Test that the basis functions of Lagrange space with degree element.degree_bounds[0]
+    # Test that the basis functions of Lagrange space with degree element.highest_complete_degree
     # are contained in this space
 
-    if element.degree_bounds[0] >= 0:
+    if element.highest_complete_degree >= 0:
         # This Lagrange space should be a subset to the element being tested
         lagrange = basix.create_element(
-            basix.ElementFamily.P, cell_type, element.degree_bounds[0],
+            basix.ElementFamily.P, cell_type, element.highest_complete_degree,
             basix.LagrangeVariant.equispaced, True)
         lagrange_coeffs = np.random.rand(lagrange.dim * element.value_size)
         lagrange_tab = lagrange.tabulate(0, points)[0]
@@ -192,10 +192,10 @@ def test_degree_bounds(cell_type, degree, element_type, element_args):
 
         assert np.allclose(values, lagrange_values)
 
-    if element.degree_bounds[0] >= -1:
+    if element.highest_complete_degree >= -1:
         # This Lagrange space should NOT be a subset to the element being tested
         lagrange = basix.create_element(
-            basix.ElementFamily.P, cell_type, element.degree_bounds[0] + 1,
+            basix.ElementFamily.P, cell_type, element.highest_complete_degree + 1,
             basix.LagrangeVariant.equispaced, True)
         lagrange_coeffs = np.random.rand(lagrange.dim * element.value_size)
         lagrange_tab = lagrange.tabulate(0, points)[0]


### PR DESCRIPTION
Fixes #455. Added test that checks that the degree input to an element is the same as that that is output. This test (see https://github.com/FEniCS/basix/pull/457/commits/4439f943870d7efd8ceeb50008459314917563bf) fails currently but passed after this PR.

Added a runtime error when trying to check for == of two custom elements (see #456)

This is coupled with https://github.com/FEniCS/ffcx/pull/483 and https://github.com/FEniCS/dolfinx/pull/2159