### PR TITLE
Avoid manipulating `version.h` in source directory

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -50,7 +50,7 @@ else()
   FetchContent_Declare(
     xtl
     GIT_REPOSITORY https://github.com/xtensor-stack/xtl.git
-    GIT_TAG        0.7.3
+    GIT_TAG        0.7.4
   )
   FetchContent_MakeAvailable(xtl)
 
@@ -58,7 +58,7 @@ else()
   FetchContent_Declare(
     xtensor
     GIT_REPOSITORY https://github.com/xtensor-stack/xtensor.git
-    GIT_TAG        0.24.0
+    GIT_TAG        0.24.1
   )
   FetchContent_MakeAvailable(xtensor)
 endif()
@@ -72,7 +72,8 @@ feature_summary(WHAT ALL)
 
 add_library(basix)
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/basix/version.h.in ${CMAKE_CURRENT_SOURCE_DIR}/basix/version.h)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/basix/version.h.in basix/version.h)
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 set(HEADERS_basix
   ${CMAKE_CURRENT_SOURCE_DIR}/basix/cell.h
@@ -100,7 +101,7 @@ set(HEADERS_basix
   ${CMAKE_CURRENT_SOURCE_DIR}/basix/e-crouzeix-raviart.h
   ${CMAKE_CURRENT_SOURCE_DIR}/basix/e-bubble.h
   ${CMAKE_CURRENT_SOURCE_DIR}/basix/e-serendipity.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/basix/version.h)
+  ${CMAKE_CURRENT_BINARY_DIR}/basix/version.h)
 
 target_sources(basix PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/basix/cell.cpp

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -16,7 +16,7 @@
 #include "e-serendipity.h"
 #include "math.h"
 #include "polyset.h"
-#include "version.h"
+#include <basix/version.h>
 #include <numeric>
 #include <xtensor/xbuilder.hpp>
 
@@ -782,7 +782,8 @@ void FiniteElement::tabulate(int nd, const xt::xarray<double>& x,
     throw std::runtime_error("Point dim does not match element dim.");
 
   xt::xtensor<double, 3> basis(
-      {static_cast<std::size_t>(polyset::nderivs(_cell_type, nd)), x_copy.shape(0),
+      {static_cast<std::size_t>(polyset::nderivs(_cell_type, nd)),
+       x_copy.shape(0),
        static_cast<std::size_t>(polyset::dim(_cell_type, _degree))});
   polyset::tabulate(basis, _cell_type, _degree, nd, x_copy);
   const int psize = polyset::dim(_cell_type, _degree);


### PR DESCRIPTION
This is a cleaner approach to CMake builds, with a proper separation between source and build directories.