### PR TITLE
Add functions to UFL wrapper

### DIFF
--- a/python/basix/ufl_wrapper.py
+++ b/python/basix/ufl_wrapper.py
@@ -23,7 +23,7 @@ class BasixElement(_FiniteElementBase):
         self.basix_element = element
 
     def mapping(self) -> str:
-        """Return the map type"""
+        """Return the map type."""
         return _map_type_to_string(self.basix_element.map_type)
 
     def __eq__(self, other):

--- a/python/basix/ufl_wrapper.py
+++ b/python/basix/ufl_wrapper.py
@@ -74,8 +74,8 @@ def _compute_signature(element: _basix.finite_element.FiniteElement):
 
 
 def create_element(family: _typing.Union[_basix.ElementFamily, str], cell: _typing.Union[_basix.CellType, str],
-                   degree: int, lagrange_variant: _basix.LagrangeVariant=_basix.LagrangeVariant.unset,
-                   dpc_variant: _basix.DPCVariant=_basix.DPCVariant.unset, discontinuous=False) -> BasixElement:
+                   degree: int, lagrange_variant: _basix.LagrangeVariant = _basix.LagrangeVariant.unset,
+                   dpc_variant: _basix.DPCVariant = _basix.DPCVariant.unset, discontinuous=False) -> BasixElement:
     """Create a UFL element using Basix."""
     if isinstance(cell, str):
         cell = _basix.cell.str_to_type(cell)
@@ -91,21 +91,25 @@ def create_element(family: _typing.Union[_basix.ElementFamily, str], cell: _typi
 
         family = _basix.element.str_to_family(family, cell.name)
 
-    e = _basix.create_element(family, call, degree, lagrange_variant, dpc_variand, discontinuous)
+    e = _basix.create_element(family, cell, degree, lagrange_variant, dpc_variant, discontinuous)
     return BasixElement(e)
 
 
-def create_vector_element(family: _typing.Union[_basix.ElementFamily, str], cell: _typing.Union[_basix.CellType, str],
-                          degree: int, lagrange_variant: _basix.LagrangeVariant=_basix.LagrangeVariant.unset,
-                          dpc_variant: _basix.DPCVariant=_basix.DPCVariant.unset, discontinuous=False) -> _ufl.VectorElement:
+def create_vector_element(
+    family: _typing.Union[_basix.ElementFamily, str], cell: _typing.Union[_basix.CellType, str],
+    degree: int, lagrange_variant: _basix.LagrangeVariant = _basix.LagrangeVariant.unset,
+    dpc_variant: _basix.DPCVariant = _basix.DPCVariant.unset, discontinuous=False
+) -> _ufl.VectorElement:
     """Create a UFL vector element using Basix."""
     e = create_element(family, cell, degree, lagrange_variant, dpc_variant, discontinuous)
     return _ufl.VectorElement(e)
 
 
-def create_tensor_element(family: _typing.Union[_basix.ElementFamily, str], cell: _typing.Union[_basix.CellType, str],
-                          degree: int, lagrange_variant: _basix.LagrangeVariant=_basix.LagrangeVariant.unset,
-                          dpc_variant: _basix.DPCVariant=_basix.DPCVariant.unset, discontinuous=False) -> _ufl.TensorElement:
+def create_tensor_element(
+    family: _typing.Union[_basix.ElementFamily, str], cell: _typing.Union[_basix.CellType, str],
+    degree: int, lagrange_variant: _basix.LagrangeVariant = _basix.LagrangeVariant.unset,
+    dpc_variant: _basix.DPCVariant = _basix.DPCVariant.unset, discontinuous=False
+) -> _ufl.TensorElement:
     """Create a UFL tensor element using Basix."""
     e = create_element(family, cell, degree, lagrange_variant, dpc_variant, discontinuous)
     return _ufl.TensorElement(e)

--- a/python/basix/ufl_wrapper.py
+++ b/python/basix/ufl_wrapper.py
@@ -1,48 +1,54 @@
 """Functions to directly wrap Basix elements in UFL."""
 
-from ufl.finiteelement.finiteelementbase import FiniteElementBase
-import hashlib
-import basix
+from ufl.finiteelement.finiteelementbase import FiniteElementBase as _FiniteElementBase
+import hashlib as _hashlib
+import basix as _basix
 
 
-class BasixElement(FiniteElementBase):
+class BasixElement(_FiniteElementBase):
     """A wrapper allowing Basix elements to be used with UFL."""
 
-    def __init__(self, element):
+    def __init__(self, element: _basix.finite_element.FiniteElement):
         super().__init__(
             element.family.name, element.cell_type.name, element.degree, None, tuple(element.value_shape),
             tuple(element.value_shape))
 
-        if element.family == basix.ElementFamily.custom:
-            self._repr = f"custom Basix element ({compute_signature(element)})"
+        if element.family == _basix.ElementFamily.custom:
+            self._repr = f"custom Basix element ({_compute_signature(element)})"
         else:
             self._repr = (f"Basix element ({element.family.name}, {element.cell_type.name}, {element.degree}, "
                           f"{element.lagrange_variant.name}, {element.dpc_variant.name}, {element.discontinuous})")
         self.basix_element = element
 
-    def mapping(self):
-        """Get the map type for this element."""
-        return map_type_to_string(self.basix_element.map_type)
+    def mapping(self) -> str:
+        """Return the map type"""
+        return _map_type_to_string(self.basix_element.map_type)
+
+    def __eq__(self, other):
+        """Check if two elements are equal."""
+        if isinstance(other, BasixElement):
+            return self.basix_element == other.basix_element
+        return False
 
 
-def map_type_to_string(map_type):
+def _map_type_to_string(map_type: _basix.MapType) -> str:
     """Convert map type to a UFL string."""
-    if map_type == basix.MapType.identity:
+    if map_type == _basix.MapType.identity:
         return "identity"
-    if map_type == basix.MapType.L2Piola:
+    if map_type == _basix.MapType.L2Piola:
         return "L2 Piola"
-    if map_type == basix.MapType.contravariantPiola:
+    if map_type == _basix.MapType.contravariantPiola:
         return "contravariant Piola"
-    if map_type == basix.MapType.covariantPiola:
+    if map_type == _basix.MapType.covariantPiola:
         return "covariant Piola"
-    if map_type == basix.MapType.doubleContravariantPiola:
+    if map_type == _basix.MapType.doubleContravariantPiola:
         return "double contravariant Piola"
-    if map_type == basix.MapType.doubleCovariantPiola:
+    if map_type == _basix.MapType.doubleCovariantPiola:
         return "double covariant Piola"
     raise ValueError(f"Unsupported map type: {map_type}")
 
 
-def compute_signature(element):
+def _compute_signature(element: _basix.finite_element.FiniteElement):
     """Compute a signature of a custom element."""
     signature = (f"{element.cell_type.name}, {element.degree}, {element.value_shape}, {element.map_type.name}, "
                  f"{element.discontinuous}, {element.degree_bounds}, ")
@@ -61,5 +67,5 @@ def compute_signature(element):
     for mat in element.entity_transformations().values():
         data = ",".join([f"{i}" for row in mat for i in row])
         data += "__"
-    signature += hashlib.sha1(data.encode('utf-8')).hexdigest()
+    signature += _hashlib.sha1(data.encode('utf-8')).hexdigest()
     return signature

--- a/python/basix/ufl_wrapper.py
+++ b/python/basix/ufl_wrapper.py
@@ -3,6 +3,7 @@
 from ufl.finiteelement.finiteelementbase import FiniteElementBase as _FiniteElementBase
 import hashlib as _hashlib
 import basix as _basix
+import typing as _typing
 
 
 class BasixElement(_FiniteElementBase):
@@ -69,3 +70,24 @@ def _compute_signature(element: _basix.finite_element.FiniteElement):
         data += "__"
     signature += _hashlib.sha1(data.encode('utf-8')).hexdigest()
     return signature
+
+
+def create_element(family: _typing.Union[_basix.ElementFamily, str], cell: _typing.Union[_basix.CellType, str],
+                   degree: int, lagrange_variant: _basix.LagrangeVariant=_basix.LagrangeVariant.unset,
+                   dpc_variant: _basix.DPCVariant=_basix.DPCVariant.unset, discontinuous=False) -> BasixElement:
+    if isinstance(cell, str):
+        cell = _basix.cell.str_to_type(cell)
+    if isinstance(family, str):
+        if family.startswith("Discontinuous "):
+            family = family[14:]
+            discontinuous = True
+        if family in ["DP", "DG", "DQ"]:
+            family = "P"
+            discontinuous = True
+        if family == "DPC":
+            discontinuous = True
+
+        family = _basix.element.str_to_family(family, cell.name)
+
+    e = _basix.create_element(family, call, degree, lagrange_variant, dpc_variand, discontinuous)
+    return BasixElement(e)

--- a/python/basix/ufl_wrapper.py
+++ b/python/basix/ufl_wrapper.py
@@ -1,5 +1,6 @@
 """Functions to directly wrap Basix elements in UFL."""
 
+import ufl as _ufl
 from ufl.finiteelement.finiteelementbase import FiniteElementBase as _FiniteElementBase
 import hashlib as _hashlib
 import basix as _basix
@@ -75,6 +76,7 @@ def _compute_signature(element: _basix.finite_element.FiniteElement):
 def create_element(family: _typing.Union[_basix.ElementFamily, str], cell: _typing.Union[_basix.CellType, str],
                    degree: int, lagrange_variant: _basix.LagrangeVariant=_basix.LagrangeVariant.unset,
                    dpc_variant: _basix.DPCVariant=_basix.DPCVariant.unset, discontinuous=False) -> BasixElement:
+    """Create a UFL element using Basix."""
     if isinstance(cell, str):
         cell = _basix.cell.str_to_type(cell)
     if isinstance(family, str):
@@ -91,3 +93,19 @@ def create_element(family: _typing.Union[_basix.ElementFamily, str], cell: _typi
 
     e = _basix.create_element(family, call, degree, lagrange_variant, dpc_variand, discontinuous)
     return BasixElement(e)
+
+
+def create_vector_element(family: _typing.Union[_basix.ElementFamily, str], cell: _typing.Union[_basix.CellType, str],
+                          degree: int, lagrange_variant: _basix.LagrangeVariant=_basix.LagrangeVariant.unset,
+                          dpc_variant: _basix.DPCVariant=_basix.DPCVariant.unset, discontinuous=False) -> _ufl.VectorElement:
+    """Create a UFL vector element using Basix."""
+    e = create_element(family, cell, degree, lagrange_variant, dpc_variant, discontinuous)
+    return _ufl.VectorElement(e)
+
+
+def create_tensor_element(family: _typing.Union[_basix.ElementFamily, str], cell: _typing.Union[_basix.CellType, str],
+                          degree: int, lagrange_variant: _basix.LagrangeVariant=_basix.LagrangeVariant.unset,
+                          dpc_variant: _basix.DPCVariant=_basix.DPCVariant.unset, discontinuous=False) -> _ufl.TensorElement:
+    """Create a UFL tensor element using Basix."""
+    e = create_element(family, cell, degree, lagrange_variant, dpc_variant, discontinuous)
+    return _ufl.TensorElement(e)

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(name="fenics-basix",
           "docs": ["markdown", "pylit3", "pyyaml", "sphinx", "sphinx_rtd_theme"],
           "lint": ["flake8", "pydocstyle"],
           "optional": ["numba"],
-          "test": ["pytest", "sympy", "numba", "scipy", "matplotlib"],
+          "test": ["pytest", "sympy", "numba", "scipy", "matplotlib", "fenics-ufl"],
           "ci": ["pytest-xdist", "fenics-basix[docs]", "fenics-basix[lint]", "fenics-basix[optional]",
                  "fenics-basix[test]"]
       },

--- a/test/test_ufl_wrapper.py
+++ b/test/test_ufl_wrapper.py
@@ -1,0 +1,33 @@
+import pytest
+import basix
+import basix.ufl_wrapper
+
+
+@pytest.mark.parametrize("inputs", [
+    ("Lagrange", "triangle", 2),
+    ("Lagrange", basix.CellType.triangle, 2),
+    (basix.ElementFamily.P, basix.CellType.triangle, 2),
+    (basix.ElementFamily.P, "triangle", 2),
+])
+def test_create_element(inputs)
+    basix.ufl_wrapper.create_element(*inputs)
+
+
+@pytest.mark.parametrize("inputs", [
+    ("Lagrange", "triangle", 2),
+    ("Lagrange", basix.CellType.triangle, 2),
+    (basix.ElementFamily.P, basix.CellType.triangle, 2),
+    (basix.ElementFamily.P, "triangle", 2),
+])
+def test_create_vector_element(inputs)
+    basix.ufl_wrapper.create_vector_element(*inputs)
+
+
+@pytest.mark.parametrize("inputs", [
+    ("Lagrange", "triangle", 2),
+    ("Lagrange", basix.CellType.triangle, 2),
+    (basix.ElementFamily.P, basix.CellType.triangle, 2),
+    (basix.ElementFamily.P, "triangle", 2),
+])
+def test_create_tensor_element(inputs)
+    basix.ufl_wrapper.create_tensor_element(*inputs)


### PR DESCRIPTION
Currently, in order to make a Basix element and wrap it as a UFL element, you need to write (eg):

```python
import basix
import basix.ufl_wrapper

e = basix.create_element(basix.ElementFamily.P, basix.CellType.triangle, 2)
ufl_element = basix.ufl_wrapper.BasixElement(e)
```

If you want to create a VectorElement using a strings, this gets even more long and verbose:

```python
import ufl
import basix
import basix.ufl_wrapper

e = basix.create_element(basix.element.string_to_family("Lagrange", "triangle"), basix.cell.string_to_type("triangle"), 2)
sub_ufl_element = basix.ufl_wrapper.BasixElement(e)
ufl_element = ufl.VectorElement(sub_ufl_element)
```

Following this PR, the users in these cases could simply write:

```python
import basix
import basix.ufl_wrapper

ufl_element = basix.ufl_wrapper.create_element(basix.ElementFamily.P, basix.CellType.triangle, 2)
```

```
import basix.ufl_wrapper

ufl_element = basix.create_vector_element("Lagrange", "triangle", 2)
```

As we will at some point be aiming to get users to use this interface for creating elements for use with DOLFINx, I welcome any opinions/suggestions from people who think our public interface should be different.