### PR TITLE
Remove xarray in favor of xt::xtensor<double, 2>

### DIFF
--- a/cpp/basix/e-bubble.cpp
+++ b/cpp/basix/e-bubble.cpp
@@ -80,22 +80,22 @@ FiniteElement basix::element::create_bubble(cell::type celltype, int degree,
   const std::size_t psize = phi.shape(1);
 
   // Create points at nodes on interior
-  const auto points
+  const xt::xtensor<double, 2> points
       = lattice::create(celltype, degree, lattice::type::equispaced, false);
   const std::size_t ndofs = points.shape(0);
   x[tdim].push_back(points);
 
   // Create coefficients for order (degree-1) vector polynomials
   xt::xtensor<double, 2> phi1;
-  xt::xtensor<double, 1> bubble;
+  xt::xtensor<double, 2> bubble({pts.shape(0), (std::size_t)1});
   switch (celltype)
   {
   case cell::type::interval:
   {
     phi1 = xt::view(polyset::tabulate(celltype, degree - 2, 0, pts), 0,
                     xt::all(), xt::all());
-    auto p = pts;
-    bubble = p * (1.0 - p);
+    auto p0 = xt::col(pts, 0);
+    xt::col(bubble, 0) = p0 * (1.0 - p0);
     break;
   }
   case cell::type::triangle:
@@ -104,7 +104,7 @@ FiniteElement basix::element::create_bubble(cell::type celltype, int degree,
                     xt::all(), xt::all());
     auto p0 = xt::col(pts, 0);
     auto p1 = xt::col(pts, 1);
-    bubble = p0 * p1 * (1 - p0 - p1);
+    xt::col(bubble, 0) = p0 * p1 * (1 - p0 - p1);
     break;
   }
   case cell::type::tetrahedron:
@@ -114,7 +114,7 @@ FiniteElement basix::element::create_bubble(cell::type celltype, int degree,
     auto p0 = xt::col(pts, 0);
     auto p1 = xt::col(pts, 1);
     auto p2 = xt::col(pts, 2);
-    bubble = p0 * p1 * p2 * (1 - p0 - p1 - p2);
+    xt::col(bubble, 0) = p0 * p1 * p2 * (1 - p0 - p1 - p2);
     break;
   }
   case cell::type::quadrilateral:
@@ -123,7 +123,7 @@ FiniteElement basix::element::create_bubble(cell::type celltype, int degree,
                     xt::all(), xt::all());
     auto p0 = xt::col(pts, 0);
     auto p1 = xt::col(pts, 1);
-    bubble = p0 * (1 - p0) * p1 * (1 - p1);
+    xt::col(bubble, 0) = p0 * (1 - p0) * p1 * (1 - p1);
     break;
   }
   case cell::type::hexahedron:
@@ -133,7 +133,7 @@ FiniteElement basix::element::create_bubble(cell::type celltype, int degree,
     auto p0 = xt::col(pts, 0);
     auto p1 = xt::col(pts, 1);
     auto p2 = xt::col(pts, 2);
-    bubble = p0 * (1 - p0) * p1 * (1 - p1) * p2 * (1 - p2);
+    xt::col(bubble, 0) = p0 * (1 - p0) * p1 * (1 - p1) * p2 * (1 - p2);
     break;
   }
   default:
@@ -143,7 +143,7 @@ FiniteElement basix::element::create_bubble(cell::type celltype, int degree,
   xt::xtensor<double, 2> wcoeffs = xt::zeros<double>({ndofs, psize});
   for (std::size_t i = 0; i < phi1.shape(1); ++i)
   {
-    auto integrand = xt::col(phi1, i) * bubble;
+    auto integrand = xt::col(phi1, i) * xt::col(bubble, 0);
     for (std::size_t k = 0; k < psize; ++k)
       wcoeffs(i, k) = xt::sum(wts * integrand * xt::col(phi, k))();
   }

--- a/cpp/basix/e-bubble.cpp
+++ b/cpp/basix/e-bubble.cpp
@@ -87,7 +87,7 @@ FiniteElement basix::element::create_bubble(cell::type celltype, int degree,
 
   // Create coefficients for order (degree-1) vector polynomials
   xt::xtensor<double, 2> phi1;
-  xt::xtensor<double, 2> bubble({pts.shape(0), (std::size_t)1});
+  xt::xtensor<double, 1> bubble;
   switch (celltype)
   {
   case cell::type::interval:
@@ -95,7 +95,7 @@ FiniteElement basix::element::create_bubble(cell::type celltype, int degree,
     phi1 = xt::view(polyset::tabulate(celltype, degree - 2, 0, pts), 0,
                     xt::all(), xt::all());
     auto p0 = xt::col(pts, 0);
-    xt::col(bubble, 0) = p0 * (1.0 - p0);
+    bubble = p0 * (1.0 - p0);
     break;
   }
   case cell::type::triangle:
@@ -104,7 +104,7 @@ FiniteElement basix::element::create_bubble(cell::type celltype, int degree,
                     xt::all(), xt::all());
     auto p0 = xt::col(pts, 0);
     auto p1 = xt::col(pts, 1);
-    xt::col(bubble, 0) = p0 * p1 * (1 - p0 - p1);
+    bubble = p0 * p1 * (1 - p0 - p1);
     break;
   }
   case cell::type::tetrahedron:
@@ -114,7 +114,7 @@ FiniteElement basix::element::create_bubble(cell::type celltype, int degree,
     auto p0 = xt::col(pts, 0);
     auto p1 = xt::col(pts, 1);
     auto p2 = xt::col(pts, 2);
-    xt::col(bubble, 0) = p0 * p1 * p2 * (1 - p0 - p1 - p2);
+    bubble = p0 * p1 * p2 * (1 - p0 - p1 - p2);
     break;
   }
   case cell::type::quadrilateral:
@@ -123,7 +123,7 @@ FiniteElement basix::element::create_bubble(cell::type celltype, int degree,
                     xt::all(), xt::all());
     auto p0 = xt::col(pts, 0);
     auto p1 = xt::col(pts, 1);
-    xt::col(bubble, 0) = p0 * (1 - p0) * p1 * (1 - p1);
+    bubble = p0 * (1 - p0) * p1 * (1 - p1);
     break;
   }
   case cell::type::hexahedron:
@@ -133,7 +133,7 @@ FiniteElement basix::element::create_bubble(cell::type celltype, int degree,
     auto p0 = xt::col(pts, 0);
     auto p1 = xt::col(pts, 1);
     auto p2 = xt::col(pts, 2);
-    xt::col(bubble, 0) = p0 * (1 - p0) * p1 * (1 - p1) * p2 * (1 - p2);
+    bubble = p0 * (1 - p0) * p1 * (1 - p1) * p2 * (1 - p2);
     break;
   }
   default:
@@ -143,7 +143,7 @@ FiniteElement basix::element::create_bubble(cell::type celltype, int degree,
   xt::xtensor<double, 2> wcoeffs = xt::zeros<double>({ndofs, psize});
   for (std::size_t i = 0; i < phi1.shape(1); ++i)
   {
-    auto integrand = xt::col(phi1, i) * xt::col(bubble, 0);
+    auto integrand = xt::col(phi1, i) * bubble;
     for (std::size_t k = 0; k < psize; ++k)
       wcoeffs(i, k) = xt::sum(wts * integrand * xt::col(phi, k))();
   }

--- a/cpp/basix/e-hhj.cpp
+++ b/cpp/basix/e-hhj.cpp
@@ -87,12 +87,8 @@ FiniteElement basix::element::create_hhj(cell::type celltype, int degree,
         cell::type ct = cell::sub_entity_type(celltype, d, e);
 
         const std::size_t ndofs = polyset::dim(ct, degree + 1 - d);
-        const auto [_pts, wts]
+        const auto [pts, wts]
             = quadrature::make_quadrature(ct, degree + (degree + 1 - d));
-
-        xt::xarray<double> pts = _pts;
-        if (d == 1)
-          pts.reshape({pts.shape(0), 1});
 
         FiniteElement moment_space = create_lagrange(
             ct, degree + 1 - d, element::lagrange_variant::legendre, true);

--- a/cpp/basix/e-lagrange.cpp
+++ b/cpp/basix/e-lagrange.cpp
@@ -873,7 +873,7 @@ FiniteElement create_legendre(cell::type celltype, int degree,
       }
     }
   }
-  x[tdim][0] = pts.dimension() == 1 ? pts.reshape({pts.shape(0), 1}) : pts;
+  x[tdim][0] = pts;
   M[tdim][0] = xt::xtensor<double, 3>({ndofs, 1, pts.shape(0)});
   for (std::size_t i = 0; i < ndofs; ++i)
     xt::view(M[tdim][0], i, 0, xt::all()) = xt::col(phi, i) * wts;
@@ -963,8 +963,8 @@ FiniteElement basix::element::create_lagrange(cell::type celltype, int degree,
           cell::num_sub_entities(celltype, i),
           xt::xtensor<double, 3>({0, 1, 0}));
     }
-
-    auto pt = lattice::create(celltype, 0, lattice_type, true, simplex_method);
+    const xt::xtensor<double, 2> pt
+        = lattice::create(celltype, 0, lattice_type, true, simplex_method);
     x[tdim].push_back(pt);
     const std::size_t num_dofs = pt.shape(0);
     std::array<std::size_t, 3> s = {num_dofs, 1, num_dofs};

--- a/cpp/basix/e-lagrange.cpp
+++ b/cpp/basix/e-lagrange.cpp
@@ -113,8 +113,8 @@ FiniteElement create_d_lagrange(cell::type celltype, int degree,
             : (celltype == cell::type::tetrahedron ? degree + 4 : degree + 2);
 
   // Create points in interior
-  auto pt = lattice::create(celltype, lattice_degree, lattice_type, false,
-                            simplex_method);
+  const xt::xtensor<double, 2> pt = lattice::create(
+      celltype, lattice_degree, lattice_type, false, simplex_method);
   x[tdim].push_back(pt);
   const std::size_t num_dofs = pt.shape(0);
   std::array<std::size_t, 3> s = {num_dofs, 1, num_dofs};

--- a/cpp/basix/e-regge.cpp
+++ b/cpp/basix/e-regge.cpp
@@ -55,7 +55,8 @@ FiniteElement basix::element::create_regge(cell::type celltype, int degree,
   x[0] = std::vector<xt::xtensor<double, 2>>(
       cell::num_sub_entities(celltype, 0), xt::xtensor<double, 2>({0, tdim}));
   M[0] = std::vector<xt::xtensor<double, 3>>(
-      cell::num_sub_entities(celltype, 0), xt::xtensor<double, 3>({0, tdim * tdim, 0}));
+      cell::num_sub_entities(celltype, 0),
+      xt::xtensor<double, 3>({0, tdim * tdim, 0}));
 
   // Loop over edge and higher dimension entities
   for (std::size_t d = 1; d < topology.size(); ++d)
@@ -85,12 +86,8 @@ FiniteElement basix::element::create_regge(cell::type celltype, int degree,
         cell::type ct = cell::sub_entity_type(celltype, d, e);
 
         const std::size_t ndofs = polyset::dim(ct, degree + 1 - d);
-        const auto [_pts, wts]
+        const auto [pts, wts]
             = quadrature::make_quadrature(ct, degree + (degree + 1 - d));
-
-        xt::xarray<double> pts = _pts;
-        if (d == 1)
-          pts.reshape({pts.shape(0), 1});
 
         FiniteElement moment_space = create_lagrange(
             ct, degree + 1 - d, element::lagrange_variant::legendre, true);

--- a/cpp/basix/e-serendipity.cpp
+++ b/cpp/basix/e-serendipity.cpp
@@ -1034,7 +1034,7 @@ FiniteElement basix::element::create_dpc(cell::type celltype, int degree,
   M[tdim].push_back(xt::xtensor<double, 3>({ndofs, 1, ndofs}));
   xt::view(M[tdim][0], xt::all(), 0, xt::all()) = xt::eye<double>(ndofs);
 
-  const auto pt = make_dpc_points(celltype, degree, variant);
+  const xt::xtensor<double, 2> pt = make_dpc_points(celltype, degree, variant);
   x[tdim].push_back(pt);
 
   return FiniteElement(element::family::DPC, celltype, degree, {}, wcoeffs, x,

--- a/cpp/basix/e-serendipity.cpp
+++ b/cpp/basix/e-serendipity.cpp
@@ -586,7 +586,7 @@ FiniteElement create_legendre_dpc(cell::type celltype, int degree,
       }
     }
   }
-  x[tdim][0] = pts.dimension() == 1 ? pts.reshape({pts.shape(0), 1}) : pts;
+  x[tdim][0] = pts;
   M[tdim][0] = xt::xtensor<double, 3>({ndofs, 1, pts.shape(0)});
 
   xt::xtensor<double, 2> wcoeffs = xt::zeros<double>({ndofs, psize});
@@ -678,7 +678,7 @@ xt::xtensor<double, 2> make_dpc_points(cell::type celltype, int degree,
       std::size_t n = 0;
       for (int j = 0; j <= degree; ++j)
       {
-        const auto interval_pts = lattice::create(
+        const xt::xtensor<double, 2> interval_pts = lattice::create(
             cell::type::interval, degree - j, latticetype, true);
         for (int i = 0; i <= degree - j; ++i)
         {
@@ -702,7 +702,7 @@ xt::xtensor<double, 2> make_dpc_points(cell::type celltype, int degree,
       {
         for (int j = 0; j <= degree - k; ++j)
         {
-          const auto interval_pts = lattice::create(
+          const xt::xtensor<double, 2> interval_pts = lattice::create(
               cell::type::interval, degree - j - k, latticetype, true);
           for (int i = 0; i <= degree - j - k; ++i)
           {
@@ -750,7 +750,7 @@ xt::xtensor<double, 2> make_dpc_points(cell::type celltype, int degree,
       std::size_t n = 0;
       for (int j = 0; j <= degree; ++j)
       {
-        const auto interval_pts
+        const xt::xtensor<double, 2> interval_pts
             = lattice::create(cell::type::interval, j, latticetype, true);
         const double y = gap * (j % 2 == 0 ? j / 2 : degree - (j - 1) / 2);
         const double coord0 = y < 1 ? y : y - 1;
@@ -779,8 +779,8 @@ xt::xtensor<double, 2> make_dpc_points(cell::type celltype, int degree,
       for (int k = 0; k <= degree; ++k)
       {
         const double z = gap * (k % 2 == 0 ? k / 2 : degree - (k - 1) / 2);
-        const auto triangle_pts = lattice::create(cell::type::triangle, k,
-                                                  latticetype, true, latticesm);
+        const xt::xtensor<double, 2> triangle_pts = lattice::create(
+            cell::type::triangle, k, latticetype, true, latticesm);
         if (z < 1)
           for (std::size_t p = 0; p < triangle_pts.shape(0); ++p)
           {
@@ -937,7 +937,6 @@ FiniteElement basix::element::create_serendipity(
   else if (tdim == 3)
     wcoeffs = make_serendipity_space_3d(degree);
 
-
   if (discontinuous)
   {
     std::tie(x, M) = element::make_discontinuous(x, M, tdim, 1);
@@ -987,10 +986,6 @@ FiniteElement basix::element::create_dpc(cell::type celltype, int degree,
 
   const std::size_t ndofs = polyset::dim(simplex_type, degree);
   const std::size_t psize = polyset::dim(celltype, degree);
-
-  auto [pts, _wts] = quadrature::make_quadrature(quadrature::type::Default,
-                                                 celltype, 2 * degree);
-  auto wts = xt::adapt(_wts);
 
   xt::xtensor<double, 2> wcoeffs = xt::zeros<double>({ndofs, psize});
 
@@ -1055,7 +1050,8 @@ FiniteElement basix::element::create_serendipity_div(
   if (degree == 0)
     throw std::runtime_error("Cannot create degree 0 serendipity");
 
-  if (celltype != cell::type::quadrilateral and celltype != cell::type::hexahedron)
+  if (celltype != cell::type::quadrilateral
+      and celltype != cell::type::hexahedron)
   {
     throw std::runtime_error("Invalid celltype");
   }
@@ -1108,7 +1104,6 @@ FiniteElement basix::element::create_serendipity_div(
   else if (tdim == 3)
     wcoeffs = make_serendipity_div_space_3d(degree);
 
-
   if (discontinuous)
   {
     std::tie(x, M) = element::make_discontinuous(x, M, tdim, tdim);
@@ -1126,7 +1121,8 @@ FiniteElement basix::element::create_serendipity_curl(
   if (degree == 0)
     throw std::runtime_error("Cannot create degree 0 serendipity");
 
-  if (celltype != cell::type::quadrilateral and celltype != cell::type::hexahedron)
+  if (celltype != cell::type::quadrilateral
+      and celltype != cell::type::hexahedron)
   {
     throw std::runtime_error("Invalid celltype");
   }

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -104,13 +104,8 @@ compute_dual_matrix(cell::type cell_type, const xt::xtensor<double, 2>& B,
       // Evaluate polynomial basis at x[d]
       const xt::xtensor<double, 2>& x_e = x[d][e];
       xt::xtensor<double, 2> P;
-      if (x_e.shape(1) == 1 and x_e.shape(0) != 0)
-      {
-        auto pts = xt::view(x_e, xt::all(), 0);
-        P = xt::view(polyset::tabulate(cell_type, degree, 0, pts), 0, xt::all(),
-                     xt::all());
-      }
-      else if (x_e.shape(0) != 0)
+
+      if (x_e.shape(0) != 0)
       {
         P = xt::view(polyset::tabulate(cell_type, degree, 0, x_e), 0, xt::all(),
                      xt::all());
@@ -758,33 +753,26 @@ FiniteElement::tabulate_shape(std::size_t nd, std::size_t num_points) const
 }
 //-----------------------------------------------------------------------------
 xt::xtensor<double, 4>
-FiniteElement::tabulate(int nd, const xt::xarray<double>& x) const
+FiniteElement::tabulate(int nd, const xt::xtensor<double, 2>& x) const
 {
-  xt::xarray<double> x_copy = x;
-  if (x_copy.dimension() == 1)
-    x_copy.reshape({x_copy.shape(0), 1});
 
   auto shape = tabulate_shape(nd, x.shape(0));
   xt::xtensor<double, 4> data(shape);
-  tabulate(nd, x_copy, data);
+  tabulate(nd, x, data);
 
   return data;
 }
 //-----------------------------------------------------------------------------
-void FiniteElement::tabulate(int nd, const xt::xarray<double>& x,
+void FiniteElement::tabulate(int nd, const xt::xtensor<double, 2>& x,
                              xt::xtensor<double, 4>& basis_data) const
 {
-  xt::xarray<double> x_copy = x;
-  if (x_copy.dimension() == 2 and x.shape(1) == 1)
-    x_copy.reshape({x.shape(0)});
-
-  if (x_copy.shape(1) != _cell_tdim)
+  if (x.shape(1) != _cell_tdim)
     throw std::runtime_error("Point dim does not match element dim.");
 
   xt::xtensor<double, 3> basis(
-      {static_cast<std::size_t>(polyset::nderivs(_cell_type, nd)), x_copy.shape(0),
+      {static_cast<std::size_t>(polyset::nderivs(_cell_type, nd)), x.shape(0),
        static_cast<std::size_t>(polyset::dim(_cell_type, _degree))});
-  polyset::tabulate(basis, _cell_type, _degree, nd, x_copy);
+  polyset::tabulate(basis, _cell_type, _degree, nd, x);
   const int psize = polyset::dim(_cell_type, _degree);
   const int vs = std::accumulate(_value_shape.begin(), _value_shape.end(), 1,
                                  std::multiplies<int>());

--- a/cpp/basix/finite-element.h
+++ b/cpp/basix/finite-element.h
@@ -283,7 +283,8 @@ public:
   /// - The third index is the basis function index
   /// - The fourth index is the basis function component. Its has size
   /// one for scalar basis functions.
-  xt::xtensor<double, 4> tabulate(int nd, const xt::xarray<double>& x) const;
+  xt::xtensor<double, 4> tabulate(int nd,
+                                  const xt::xtensor<double, 2>& x) const;
 
   /// Compute basis values and derivatives at set of points.
   ///
@@ -310,7 +311,7 @@ public:
   ///
   /// @todo Remove all internal dynamic memory allocation, pass scratch
   /// space as required
-  void tabulate(int nd, const xt::xarray<double>& x,
+  void tabulate(int nd, const xt::xtensor<double, 2>& x,
                 xt::xtensor<double, 4>& basis) const;
 
   /// Get the element cell type
@@ -428,25 +429,20 @@ public:
     case maps::type::identity:
       return [](O& u, const P& U, const Q&, double, const R&) { u.assign(U); };
     case maps::type::L2Piola:
-      return [](O& u, const P& U, const Q& J, double detJ, const R& K) {
-        maps::l2_piola(u, U, J, detJ, K);
-      };
+      return [](O& u, const P& U, const Q& J, double detJ, const R& K)
+      { maps::l2_piola(u, U, J, detJ, K); };
     case maps::type::covariantPiola:
-      return [](O& u, const P& U, const Q& J, double detJ, const R& K) {
-        maps::covariant_piola(u, U, J, detJ, K);
-      };
+      return [](O& u, const P& U, const Q& J, double detJ, const R& K)
+      { maps::covariant_piola(u, U, J, detJ, K); };
     case maps::type::contravariantPiola:
-      return [](O& u, const P& U, const Q& J, double detJ, const R& K) {
-        maps::contravariant_piola(u, U, J, detJ, K);
-      };
+      return [](O& u, const P& U, const Q& J, double detJ, const R& K)
+      { maps::contravariant_piola(u, U, J, detJ, K); };
     case maps::type::doubleCovariantPiola:
-      return [](O& u, const P& U, const Q& J, double detJ, const R& K) {
-        maps::double_covariant_piola(u, U, J, detJ, K);
-      };
+      return [](O& u, const P& U, const Q& J, double detJ, const R& K)
+      { maps::double_covariant_piola(u, U, J, detJ, K); };
     case maps::type::doubleContravariantPiola:
-      return [](O& u, const P& U, const Q& J, double detJ, const R& K) {
-        maps::double_contravariant_piola(u, U, J, detJ, K);
-      };
+      return [](O& u, const P& U, const Q& J, double detJ, const R& K)
+      { maps::double_contravariant_piola(u, U, J, detJ, K); };
     default:
       throw std::runtime_error("Map not implemented");
     }

--- a/cpp/basix/lattice.cpp
+++ b/cpp/basix/lattice.cpp
@@ -18,41 +18,36 @@ using namespace basix;
 namespace
 {
 //-----------------------------------------------------------------------------
-xt::xtensor<double, 1> create_interval_equispaced(int n, bool exterior)
+xt::xtensor<double, 2> create_interval_equispaced(int n, bool exterior)
 {
-  if (exterior)
-    return xt::linspace<double>(0.0, 1.0, n + 1);
-  else
-  {
-    const double h = 1.0 / static_cast<double>(n);
-    return xt::linspace<double>(h, 1.0 - h, n - 1);
-  }
+  const double h = exterior ? 0 : 1.0 / static_cast<double>(n);
+  const std::size_t num_pts = exterior ? n + 1 : n - 1;
+  xt::xtensor<double, 1> pts = xt::linspace<double>(h, 1.0 - h, num_pts);
+  return xt::reshape_view(pts, {num_pts, (std::size_t)1});
 }
 //-----------------------------------------------------------------------------
-xt::xtensor<double, 1> create_interval_gll(int n, bool exterior)
+xt::xtensor<double, 2> create_interval_gll(int n, bool exterior)
 {
   if (n == 0)
-    return {0.5};
+    return {{0.5}};
 
-  auto _pts = quadrature::get_gll_points(n + 1);
+  const xt::xtensor<double, 2> _pts = quadrature::get_gll_points(n + 1);
 
   const std::size_t b = exterior ? 0 : 1;
-  std::array<std::size_t, 1> s = {static_cast<std::size_t>(n + 1 - 2 * b)};
-  xt::xtensor<double, 1> x(s);
-
+  std::array<std::size_t, 2> s
+      = {static_cast<std::size_t>(n + 1 - 2 * b), (std::size_t)1};
+  xt::xtensor<double, 2> x(s);
   if (exterior)
   {
-    x(0) = _pts[0];
-    x(n) = _pts[1];
+    x(0, 0) = _pts(0, 0);
+    x(n, 0) = _pts(1, 0);
   }
-
   for (std::size_t j = 2; j < static_cast<std::size_t>(n + 1); ++j)
-    x(j - 1 - b) = _pts[j];
-
+    x(j - 1 - b, 0) = _pts(j, 0);
   return x;
 }
 //-----------------------------------------------------------------------------
-xt::xtensor<double, 1> create_interval_chebyshev(int n, bool exterior)
+xt::xtensor<double, 2> create_interval_chebyshev(int n, bool exterior)
 {
   if (exterior)
   {
@@ -60,16 +55,17 @@ xt::xtensor<double, 1> create_interval_chebyshev(int n, bool exterior)
         "Chebyshev points including endpoints are not supported.");
   }
 
-  std::array<std::size_t, 1> s = {static_cast<std::size_t>(n - 1)};
-  xt::xtensor<double, 1> x(s);
+  std::array<std::size_t, 2> s
+      = {static_cast<std::size_t>(n - 1), (std::size_t)1};
+  xt::xtensor<double, 2> x(s);
 
   for (int i = 1; i < n; ++i)
-    x(i - 1) = 0.5 - cos((2 * i - 1) * M_PI / (2 * n - 2)) / 2.0;
+    x(i - 1, 0) = 0.5 - cos((2 * i - 1) * M_PI / (2 * n - 2)) / 2.0;
 
   return x;
 }
 //-----------------------------------------------------------------------------
-xt::xtensor<double, 1> create_interval_gl(int n, bool exterior)
+xt::xtensor<double, 2> create_interval_gl(int n, bool exterior)
 {
   if (exterior)
   {
@@ -78,60 +74,62 @@ xt::xtensor<double, 1> create_interval_gl(int n, bool exterior)
   }
 
   if (n == 0)
-    return {0.5};
-  auto _pts = quadrature::get_gl_points(n - 1);
-
-  std::array<std::size_t, 1> s = {static_cast<std::size_t>(n - 1)};
-  xt::xtensor<double, 1> x(s);
+    return {{0.5}};
+  const xt::xtensor<double, 2> pts = quadrature::get_gl_points(n - 1);
+  std::array<std::size_t, 2> s
+      = {static_cast<std::size_t>(n - 1), (std::size_t)1};
+  xt::xtensor<double, 2> x(s);
 
   for (int i = 0; i < n - 1; ++i)
-    x(i) = _pts[i];
+    x(i, 0) = pts(i, 0);
 
   return x;
 }
 //-----------------------------------------------------------------------------
-xt::xtensor<double, 1> create_interval_gl_plus_endpoints(int n, bool exterior)
+xt::xtensor<double, 2> create_interval_gl_plus_endpoints(int n, bool exterior)
 {
-  xt::xtensor<double, 1> x_gl = create_interval_gl(n, false);
+  xt::xtensor<double, 2> x_gl = create_interval_gl(n, false);
 
   if (!exterior)
     return x_gl;
 
-  std::array<std::size_t, 1> s = {static_cast<std::size_t>(n + 1)};
-  xt::xtensor<double, 1> x(s);
+  std::array<std::size_t, 2> s
+      = {static_cast<std::size_t>(n + 1), (std::size_t)1};
+  xt::xtensor<double, 2> x(s);
 
-  x[0] = 0.;
-  x[n] = 1.;
+  x(0, 0) = 0.;
+  x(n, 0) = 1.;
   for (int i = 0; i < n - 1; ++i)
-    x[i + 1] = x_gl[i];
+    x(i + 1, 0) = x_gl(i, 0);
 
   return x;
 }
 //-----------------------------------------------------------------------------
-xt::xtensor<double, 1> create_interval_chebyshev_plus_endpoints(int n,
+xt::xtensor<double, 2> create_interval_chebyshev_plus_endpoints(int n,
                                                                 bool exterior)
 {
-  xt::xtensor<double, 1> x_cheb = create_interval_chebyshev(n, false);
+  xt::xtensor<double, 2> x_cheb = create_interval_chebyshev(n, false);
 
   if (!exterior)
     return x_cheb;
 
-  std::array<std::size_t, 1> s = {static_cast<std::size_t>(n + 1)};
-  xt::xtensor<double, 1> x(s);
+  std::array<std::size_t, 2> s
+      = {static_cast<std::size_t>(n + 1), (std::size_t)1};
+  xt::xtensor<double, 2> x(s);
 
-  x[0] = 0.;
-  x[n] = 1.;
+  x(0, 0) = 0.;
+  x(n, 0) = 1.;
   for (int i = 0; i < n - 1; ++i)
-    x[i + 1] = x_cheb[i];
+    x(i + 1, 0) = x_cheb(i, 0);
 
   return x;
 }
 //-----------------------------------------------------------------------------
-xt::xtensor<double, 1> create_interval(int n, lattice::type lattice_type,
+xt::xtensor<double, 2> create_interval(int n, lattice::type lattice_type,
                                        bool exterior)
 {
   if (n == 0)
-    return {0.5};
+    return {{0.5}};
 
   switch (lattice_type)
   {
@@ -154,13 +152,12 @@ xt::xtensor<double, 1> create_interval(int n, lattice::type lattice_type,
 }
 //-----------------------------------------------------------------------------
 xt::xtensor<double, 2> tabulate_dlagrange(int n,
-                                          const xt::xtensor<double, 1>& x)
+                                          const xt::xtensor<double, 2>& x)
 {
-  std::array<std::size_t, 1> s = {static_cast<std::size_t>(n + 1)};
-  xt::xtensor<double, 1> equi_pts(s);
+  std::array<std::size_t, 2> s = {static_cast<std::size_t>(n + 1), 1};
+  xt::xtensor<double, 2> equi_pts(s);
   for (int i = 0; i <= n; ++i)
-    equi_pts(i) = static_cast<double>(i) / static_cast<double>(n);
-
+    equi_pts(i, 0) = static_cast<double>(i) / static_cast<double>(n);
   xt::xtensor<double, 3> dual_values
       = polyset::tabulate(cell::type::interval, n, 0, equi_pts);
   xt::xtensor<double, 2> dualmat({dual_values.shape(2), dual_values.shape(1)});
@@ -177,18 +174,18 @@ xt::xtensor<double, 2> tabulate_dlagrange(int n,
 }
 //-----------------------------------------------------------------------------
 xt::xtensor<double, 1> warp_function(lattice::type lattice_type, int n,
-                                     const xt::xtensor<double, 1>& x)
+                                     const xt::xtensor<double, 2>& x)
 {
-  xt::xtensor<double, 1> pts = create_interval(n, lattice_type, true);
+  xt::xtensor<double, 2> pts = create_interval(n, lattice_type, true);
   for (int i = 0; i < n + 1; ++i)
-    pts[i] -= static_cast<double>(i) / static_cast<double>(n);
+    pts(i, 0) -= static_cast<double>(i) / static_cast<double>(n);
 
   const xt::xtensor<double, 2> v = tabulate_dlagrange(n, x);
 
   xt::xtensor<double, 1> w = xt::zeros<double>({v.shape(0)});
   for (std::size_t i = 0; i < v.shape(0); ++i)
     for (std::size_t j = 0; j < v.shape(1); ++j)
-      w[i] += v(i, j) * pts[j];
+      w[i] += v(i, j) * pts(j, 0);
 
   return w;
 }
@@ -199,7 +196,7 @@ xt::xtensor<double, 2> create_quad(int n, lattice::type lattice_type,
   if (n == 0)
     return {{0.5, 0.5}};
 
-  xt::xtensor<double, 1> r = create_interval(n, lattice_type, exterior);
+  xt::xtensor<double, 2> r = create_interval(n, lattice_type, exterior);
 
   const std::size_t m = r.shape(0);
   xt::xtensor<double, 2> x({m * m, 2});
@@ -208,8 +205,8 @@ xt::xtensor<double, 2> create_quad(int n, lattice::type lattice_type,
   {
     for (std::size_t i = 0; i < m; ++i)
     {
-      x(c, 0) = r(i);
-      x(c, 1) = r(j);
+      x(c, 0) = r(i, 0);
+      x(c, 1) = r(j, 0);
       c++;
     }
   }
@@ -223,7 +220,7 @@ xt::xtensor<double, 2> create_hex(int n, lattice::type lattice_type,
   if (n == 0)
     return {{0.5, 0.5, 0.5}};
 
-  xt::xtensor<double, 1> r = create_interval(n, lattice_type, exterior);
+  xt::xtensor<double, 2> r = create_interval(n, lattice_type, exterior);
 
   const std::size_t m = r.size();
   xt::xtensor<double, 2> x({m * m * m, 3});
@@ -234,9 +231,9 @@ xt::xtensor<double, 2> create_hex(int n, lattice::type lattice_type,
     {
       for (std::size_t i = 0; i < m; ++i)
       {
-        x(c, 0) = r[i];
-        x(c, 1) = r[j];
-        x(c, 2) = r[k];
+        x(c, 0) = r(i, 0);
+        x(c, 1) = r(j, 0);
+        x(c, 2) = r(k, 0);
         c++;
       }
     }
@@ -268,33 +265,35 @@ xt::xtensor<double, 2> create_tri_equispaced(int n, bool exterior)
   return p;
 }
 //-----------------------------------------------------------------------------
+// Warp points: see Hesthaven and Warburton, Nodal Discontinuous
+// Galerkin Methods, pp. 175-180, https://doi.org/10.1007/978-0-387-72067-8_6
 xt::xtensor<double, 2> create_tri_warped(int n, lattice::type lattice_type,
                                          bool exterior)
 {
-  // Warp points: see Hesthaven and Warburton, Nodal Discontinuous
-  // Galerkin Methods, pp. 175-180
   const std::size_t b = exterior ? 0 : 1;
 
   // Points
   xt::xtensor<double, 2> p({(n - 3 * b + 1) * (n - 3 * b + 2) / 2, 2});
 
   // Displacement from GLL points in 1D, scaled by 1 /(r * (1 - r))
-  xt::xtensor<double, 1> r = xt::linspace<double>(0.0, 1.0, 2 * n + 1);
-  xt::xtensor<double, 1> wbar = warp_function(lattice_type, n, r);
-  auto s = xt::view(r, xt::range(1, 2 * n - 1));
-  xt::view(wbar, xt::range(1, 2 * n - 1)) /= (s * (1 - s));
+  xt::xtensor<double, 1> _r = xt::linspace<double>(0.0, 1.0, 2 * n + 1);
+  xt::xtensor<double, 2> r = xt::reshape_view(
+      _r, {static_cast<std::size_t>(2 * n + 1), (std::size_t)1});
 
+  xt::xtensor<double, 1> wbar = warp_function(lattice_type, n, r);
+  auto s = xt::view(_r, xt::range(1, 2 * n - 1));
+  xt::view(wbar, xt::range(1, 2 * n - 1)) /= (s * (1 - s));
   int c = 0;
   for (std::size_t j = b; j < (n - b + 1); ++j)
   {
     for (std::size_t i = b; i < (n - b + 1 - j); ++i)
     {
-      const double x = r[2 * i];
-      const double y = r[2 * j];
+      const double x = _r[2 * i];
+      const double y = _r[2 * j];
       p(c, 0) = x;
       p(c, 1) = y;
       const std::size_t l = n - j - i;
-      const double a = r[2 * l];
+      const double a = _r[2 * l];
       p(c, 0) += x * (a * wbar(n + i - l) + y * wbar(n + i - j));
       p(c, 1) += y * (a * wbar(n + j - l) + x * wbar(n + j - i));
       ++c;
@@ -313,7 +312,7 @@ xt::xtensor<double, 1> isaac_point(lattice::type lattice_type,
   xt::xtensor<std::size_t, 1> sub_a
       = xt::view(a, xt::range(1, xt::placeholders::_));
   const std::size_t size = xt::sum(a)();
-  xt::xtensor<double, 1> x = create_interval(size, lattice_type, true);
+  xt::xtensor<double, 2> x = create_interval(size, lattice_type, true);
   for (std::size_t i = 0; i < a.shape(0); ++i)
   {
     if (i > 0)
@@ -321,18 +320,19 @@ xt::xtensor<double, 1> isaac_point(lattice::type lattice_type,
     const std::size_t sub_size = size - a(i);
     const xt::xtensor<double, 1> sub_res = isaac_point(lattice_type, sub_a);
     for (std::size_t j = 0; j < sub_res.shape(0); ++j)
-      res[j < i ? j : j + 1] += x[sub_size] * sub_res[j];
-    denominator += x[sub_size];
+      res[j < i ? j : j + 1] += x(sub_size, 0) * sub_res[j];
+    denominator += x(sub_size, 0);
   }
   for (std::size_t i = 0; i < res.shape(0); ++i)
     res[i] /= denominator;
   return res;
 }
 //-----------------------------------------------------------------------------
+// Warp points, See: Isaac, Recursive, Parameter-Free, Explicitly Defined
+// Interpolation Nodes for Simplices, http://dx.doi.org/10.1137/20M1321802
 xt::xtensor<double, 2> create_tri_isaac(int n, lattice::type lattice_type,
                                         bool exterior)
 {
-  // See http://dx.doi.org/10.1137/20M1321802
   const std::size_t b = exterior ? 0 : 1;
 
   // Points
@@ -351,10 +351,11 @@ xt::xtensor<double, 2> create_tri_isaac(int n, lattice::type lattice_type,
   return p;
 }
 //-----------------------------------------------------------------------------
+// See: Blyth, and Pozrikidis, A Lobatto interpolation grid over the triangle,
+// https://dx.doi.org/10.1093/imamat/hxh077
 xt::xtensor<double, 2> create_tri_centroid(int n, lattice::type lattice_type,
                                            bool exterior)
 {
-  // See https://dx.doi.org/10.1093/imamat/hxh077
   if (exterior)
     throw std::runtime_error(
         "Centroid method not implemented to include boundaries");
@@ -362,17 +363,17 @@ xt::xtensor<double, 2> create_tri_centroid(int n, lattice::type lattice_type,
   // Points
   xt::xtensor<double, 2> p(
       {static_cast<std::size_t>((n - 2) * (n - 1) / 2), 2});
-  xt::xtensor<double, 1> x = create_interval(n, lattice_type, false);
+  xt::xtensor<double, 2> x = create_interval(n, lattice_type, false);
 
   int c = 0;
 
   for (std::size_t i = 0; i + 1 < x.shape(0); ++i)
   {
-    const double xi = x(i);
+    const double xi = x(i, 0);
     for (std::size_t j = 0; j + i + 1 < x.shape(0); ++j)
     {
-      const double xj = x(j);
-      const double xk = x(i + j + 1);
+      const double xj = x(j, 0);
+      const double xk = x(i + j + 1, 0);
       p(c, 0) = (2 * xj + xk - xi) / 3;
       p(c, 1) = (2 * xi + xk - xj) / 3;
       ++c;
@@ -437,10 +438,11 @@ xt::xtensor<double, 2> create_tet_equispaced(int n, bool exterior)
   return p;
 }
 //-----------------------------------------------------------------------------
+// See: Isaac, Recursive, Parameter-Free, Explicitly Defined Interpolation Nodes
+// for Simplices http://dx.doi.org/10.1137/20M1321802
 xt::xtensor<double, 2> create_tet_isaac(int n, lattice::type lattice_type,
                                         bool exterior)
 {
-  // See http://dx.doi.org/10.1137/20M1321802
   const std::size_t b = exterior ? 0 : 1;
 
   // Points
@@ -470,9 +472,11 @@ xt::xtensor<double, 2> create_tet_warped(int n, lattice::type lattice_type,
   const std::size_t b = exterior ? 0 : 1;
   xt::xtensor<double, 2> p(
       {(n - 4 * b + 1) * (n - 4 * b + 2) * (n - 4 * b + 3) / 6, 3});
-  auto r = xt::linspace<double>(0.0, 1.0, 2 * n + 1);
+  xt::xtensor<double, 1> _r = xt::linspace<double>(0.0, 1.0, 2 * n + 1);
+  xt::xtensor<double, 2> r = xt::reshape_view(
+      _r, {static_cast<std::size_t>(2 * n + 1), (std::size_t)1});
   auto wbar = warp_function(lattice_type, n, r);
-  auto s = xt::view(r, xt::range(1, 2 * n - 1));
+  auto s = xt::view(r, xt::range(1, 2 * n - 1), 0);
   xt::view(wbar, xt::range(1, 2 * n - 1)) /= s * (1 - s);
 
   std::size_t c = 0;
@@ -483,10 +487,10 @@ xt::xtensor<double, 2> create_tet_warped(int n, lattice::type lattice_type,
       for (std::size_t i = b; i < (n - b + 1 - j - k); ++i)
       {
         const std::size_t l = n - k - j - i;
-        const double x = r[2 * i];
-        const double y = r[2 * j];
-        const double z = r[2 * k];
-        const double a = r[2 * l];
+        const double x = r(2 * i, 0);
+        const double y = r(2 * j, 0);
+        const double z = r(2 * k, 0);
+        const double a = r(2 * l, 0);
         p(c, 0) = x;
         p(c, 1) = y;
         p(c, 2) = z;
@@ -511,10 +515,11 @@ xt::xtensor<double, 2> create_tet_warped(int n, lattice::type lattice_type,
   return p;
 }
 //-----------------------------------------------------------------------------
+// See: Blyth, and Pozrikidis, A Lobatto interpolation grid over the triangle,
+// https://dx.doi.org/10.1093/imamat/hxh077
 xt::xtensor<double, 2> create_tet_centroid(int n, lattice::type lattice_type,
                                            bool exterior)
 {
-  // See https://dx.doi.org/10.1093/imamat/hxh077
   if (exterior)
     throw std::runtime_error(
         "Centroid method not implemented to include boundaries");
@@ -522,20 +527,20 @@ xt::xtensor<double, 2> create_tet_centroid(int n, lattice::type lattice_type,
   // Points
   xt::xtensor<double, 2> p(
       {static_cast<std::size_t>((n - 3) * (n - 2) * (n - 1) / 6), 3});
-  xt::xtensor<double, 1> x = create_interval(n, lattice_type, false);
+  xt::xtensor<double, 2> x = create_interval(n, lattice_type, false);
 
   int c = 0;
 
   for (std::size_t i = 0; i + 2 < x.shape(0); ++i)
   {
-    const double xi = x(i);
+    const double xi = x(i, 0);
     for (std::size_t j = 0; j + i + 2 < x.shape(0); ++j)
     {
-      const double xj = x(j);
+      const double xj = x(j, 0);
       for (std::size_t k = 0; k + j + i + 2 < x.shape(0); ++k)
       {
-        const double xk = x(k);
-        const double xl = x(i + j + k + 2);
+        const double xk = x(k, 0);
+        const double xl = x(i + j + k + 2, 0);
         p(c, 0) = (3 * xk + xl - xi - xj) / 4;
         p(c, 1) = (3 * xj + xl - xi - xk) / 4;
         p(c, 2) = (3 * xi + xl - xj - xk) / 4;
@@ -586,18 +591,17 @@ xt::xtensor<double, 2> create_prism(int n, lattice::type lattice_type,
 
   const xt::xtensor<double, 2> tri_pts
       = create_tri(n, lattice_type, exterior, simplex_method);
-  const xt::xtensor<double, 1> line_pts
+  const xt::xtensor<double, 2> line_pts
       = create_interval(n, lattice_type, exterior);
 
   xt::xtensor<double, 2> x({tri_pts.shape(0) * line_pts.shape(0), 3});
-  std::array<std::size_t, 2> reps = {line_pts.shape(0), 1};
+  std::array<std::size_t, 2> reps = line_pts.shape();
   xt::view(x, xt::all(), xt::range(0, 2)).assign(xt::tile(tri_pts, reps));
   for (std::size_t i = 0; i < line_pts.shape(0); ++i)
   {
     auto rows = xt::range(i * tri_pts.shape(0), (i + 1) * tri_pts.shape(0));
-    xt::view(x, rows, 2) = line_pts(i);
+    xt::view(x, rows, 2) = line_pts(i, 0);
   }
-
   return x;
 }
 //-----------------------------------------------------------------------------
@@ -635,22 +639,21 @@ xt::xtensor<double, 2> create_pyramid_gll_warped(int n, bool exterior)
   const double h = 1.0 / static_cast<double>(n);
 
   // Interpolate warp factor along interval
-  xt::xtensor<double, 1> pts = quadrature::get_gll_points(n + 1);
+  xt::xtensor<double, 2> pts = quadrature::get_gll_points(n + 1);
   pts *= 0.5;
   for (int i = 0; i < n + 1; ++i)
-    pts[i] += (0.5 - static_cast<double>(i) / static_cast<double>(n));
+    pts(i, 0) += (0.5 - static_cast<double>(i) / static_cast<double>(n));
 
   // Get interpolated value at r in range [-1, 1]
   auto w = [&](double r) -> double
   {
-    xt::xtensor<double, 1> rr = {0.5 * (r + 1.0)};
+    xt::xtensor<double, 2> rr = {{0.5 * (r + 1.0)}};
     xt::xtensor<double, 1> v
         = xt::view(tabulate_dlagrange(n, rr), 0, xt::all());
     double d = 0.0;
     for (std::size_t i = 0; i < pts.shape(0); ++i)
-      d += v[i] * pts[i];
+      d += v[i] * pts(i, 0);
     return d;
-    // return v.dot(pts);
   };
 
   const std::size_t b = (exterior == false) ? 1 : 0;
@@ -789,11 +792,7 @@ xt::xtensor<double, 2> lattice::create(cell::type celltype, int n,
   case cell::type::point:
     return {{0.0}};
   case cell::type::interval:
-  {
-    xt::xtensor<double, 1> x = create_interval(n, type, exterior);
-    std::array<std::size_t, 2> s = {x.shape(0), 1};
-    return xt::reshape_view(x, s);
-  }
+    return create_interval(n, type, exterior);
   case cell::type::triangle:
     return create_tri(n, type, exterior, simplex_method);
   case cell::type::tetrahedron:

--- a/cpp/basix/lattice.cpp
+++ b/cpp/basix/lattice.cpp
@@ -34,8 +34,7 @@ xt::xtensor<double, 2> create_interval_gll(int n, bool exterior)
   const xt::xtensor<double, 2> _pts = quadrature::get_gll_points(n + 1);
 
   const std::size_t b = exterior ? 0 : 1;
-  std::array<std::size_t, 2> s
-      = {static_cast<std::size_t>(n + 1 - 2 * b), (std::size_t)1};
+  std::array<std::size_t, 2> s = {static_cast<std::size_t>(n + 1 - 2 * b), 1};
   xt::xtensor<double, 2> x(s);
   if (exterior)
   {
@@ -55,8 +54,7 @@ xt::xtensor<double, 2> create_interval_chebyshev(int n, bool exterior)
         "Chebyshev points including endpoints are not supported.");
   }
 
-  std::array<std::size_t, 2> s
-      = {static_cast<std::size_t>(n - 1), (std::size_t)1};
+  std::array<std::size_t, 2> s = {static_cast<std::size_t>(n - 1), 1};
   xt::xtensor<double, 2> x(s);
 
   for (int i = 1; i < n; ++i)
@@ -76,8 +74,7 @@ xt::xtensor<double, 2> create_interval_gl(int n, bool exterior)
   if (n == 0)
     return {{0.5}};
   const xt::xtensor<double, 2> pts = quadrature::get_gl_points(n - 1);
-  std::array<std::size_t, 2> s
-      = {static_cast<std::size_t>(n - 1), (std::size_t)1};
+  std::array<std::size_t, 2> s = {static_cast<std::size_t>(n - 1), 1};
   xt::xtensor<double, 2> x(s);
 
   for (int i = 0; i < n - 1; ++i)
@@ -93,8 +90,7 @@ xt::xtensor<double, 2> create_interval_gl_plus_endpoints(int n, bool exterior)
   if (!exterior)
     return x_gl;
 
-  std::array<std::size_t, 2> s
-      = {static_cast<std::size_t>(n + 1), (std::size_t)1};
+  std::array<std::size_t, 2> s = {static_cast<std::size_t>(n + 1), 1};
   xt::xtensor<double, 2> x(s);
 
   x(0, 0) = 0.;
@@ -113,8 +109,7 @@ xt::xtensor<double, 2> create_interval_chebyshev_plus_endpoints(int n,
   if (!exterior)
     return x_cheb;
 
-  std::array<std::size_t, 2> s
-      = {static_cast<std::size_t>(n + 1), (std::size_t)1};
+  std::array<std::size_t, 2> s = {static_cast<std::size_t>(n + 1), 1};
   xt::xtensor<double, 2> x(s);
 
   x(0, 0) = 0.;

--- a/cpp/basix/lattice.cpp
+++ b/cpp/basix/lattice.cpp
@@ -34,7 +34,8 @@ xt::xtensor<double, 2> create_interval_gll(int n, bool exterior)
   const xt::xtensor<double, 2> _pts = quadrature::get_gll_points(n + 1);
 
   const std::size_t b = exterior ? 0 : 1;
-  std::array<std::size_t, 2> s = {static_cast<std::size_t>(n + 1 - 2 * b), 1};
+  std::array<std::size_t, 2> s
+      = {static_cast<std::size_t>(n + 1 - 2 * b), (std::size_t)1};
   xt::xtensor<double, 2> x(s);
   if (exterior)
   {
@@ -54,7 +55,8 @@ xt::xtensor<double, 2> create_interval_chebyshev(int n, bool exterior)
         "Chebyshev points including endpoints are not supported.");
   }
 
-  std::array<std::size_t, 2> s = {static_cast<std::size_t>(n - 1), 1};
+  std::array<std::size_t, 2> s
+      = {static_cast<std::size_t>(n - 1), (std::size_t)1};
   xt::xtensor<double, 2> x(s);
 
   for (int i = 1; i < n; ++i)
@@ -74,7 +76,8 @@ xt::xtensor<double, 2> create_interval_gl(int n, bool exterior)
   if (n == 0)
     return {{0.5}};
   const xt::xtensor<double, 2> pts = quadrature::get_gl_points(n - 1);
-  std::array<std::size_t, 2> s = {static_cast<std::size_t>(n - 1), 1};
+  std::array<std::size_t, 2> s
+      = {static_cast<std::size_t>(n - 1), (std::size_t)1};
   xt::xtensor<double, 2> x(s);
 
   for (int i = 0; i < n - 1; ++i)
@@ -90,7 +93,8 @@ xt::xtensor<double, 2> create_interval_gl_plus_endpoints(int n, bool exterior)
   if (!exterior)
     return x_gl;
 
-  std::array<std::size_t, 2> s = {static_cast<std::size_t>(n + 1), 1};
+  std::array<std::size_t, 2> s
+      = {static_cast<std::size_t>(n + 1), (std::size_t)1};
   xt::xtensor<double, 2> x(s);
 
   x(0, 0) = 0.;
@@ -109,7 +113,8 @@ xt::xtensor<double, 2> create_interval_chebyshev_plus_endpoints(int n,
   if (!exterior)
     return x_cheb;
 
-  std::array<std::size_t, 2> s = {static_cast<std::size_t>(n + 1), 1};
+  std::array<std::size_t, 2> s
+      = {static_cast<std::size_t>(n + 1), (std::size_t)1};
   xt::xtensor<double, 2> x(s);
 
   x(0, 0) = 0.;

--- a/cpp/basix/moments.cpp
+++ b/cpp/basix/moments.cpp
@@ -100,9 +100,6 @@ moments::make_integral_moments(const FiniteElement& V, cell::type celltype,
   auto [pts, _wts] = quadrature::make_quadrature(quadrature::type::Default,
                                                  sub_celltype, q_deg);
   auto wts = xt::adapt(_wts);
-  if (pts.dimension() == 1)
-    pts = pts.reshape({pts.shape(0), 1});
-
   // Evaluate moment space at quadrature points
   assert(std::accumulate(V.value_shape().begin(), V.value_shape().end(), 1,
                          std::multiplies<int>())
@@ -267,7 +264,7 @@ moments::make_tangent_integral_moments(const FiniteElement& V,
 
     // Map quadrature points onto triangle edge
     for (std::size_t i = 0; i < pts.shape(0); ++i)
-      xt::view(points[e], i, xt::all()) = X0 + pts[i] * tangent;
+      xt::view(points[e], i, xt::all()) = X0 + pts(i, 0) * tangent;
 
     // Compute edge tangent integral moments
     for (std::size_t i = 0; i < phi.shape(1); ++i)
@@ -333,7 +330,7 @@ moments::make_normal_integral_moments(const FiniteElement& V,
       auto tangent = xt::row(facet_x, 1) - x0;
       normal = {-tangent(1), tangent(0)};
       for (std::size_t p = 0; p < pts.shape(0); ++p)
-        xt::view(points[e], p, xt::all()) = x0 + pts[p] * tangent;
+        xt::view(points[e], p, xt::all()) = x0 + pts(p, 0) * tangent;
     }
     else if (tdim == 3)
     {
@@ -359,7 +356,6 @@ moments::make_normal_integral_moments(const FiniteElement& V,
         xt::view(D[e], i, j, xt::all()) = phi_i * wts * normal[j];
     }
   }
-
   return {points, D};
 }
 //----------------------------------------------------------------------------

--- a/cpp/basix/moments.cpp
+++ b/cpp/basix/moments.cpp
@@ -8,7 +8,6 @@
 #include "math.h"
 #include "quadrature.h"
 #include <xtensor/xadapt.hpp>
-#include <xtensor/xarray.hpp>
 #include <xtensor/xbuilder.hpp>
 #include <xtensor/xpad.hpp>
 #include <xtensor/xview.hpp>

--- a/cpp/basix/polynomials.cpp
+++ b/cpp/basix/polynomials.cpp
@@ -11,7 +11,7 @@ using namespace basix;
 //-----------------------------------------------------------------------------
 xt::xtensor<double, 2> polynomials::tabulate(polynomials::type polytype,
                                              cell::type celltype, int d,
-                                             const xt::xarray<double>& x)
+                                             const xt::xtensor<double, 2>& x)
 {
   switch (polytype)
   {

--- a/cpp/basix/polynomials.h
+++ b/cpp/basix/polynomials.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "cell.h"
-#include <xtensor/xarray.hpp>
 #include <xtensor/xtensor.hpp>
 
 /// Polynomials

--- a/cpp/basix/polynomials.h
+++ b/cpp/basix/polynomials.h
@@ -27,7 +27,7 @@ enum class type
 /// @return Polynomial sets, for each derivative, tabulated at points.
 /// The shape is `(number of points, basis index)`.
 xt::xtensor<double, 2> tabulate(polynomials::type polytype, cell::type celltype,
-                                int d, const xt::xarray<double>& x);
+                                int d, const xt::xtensor<double, 2>& x);
 
 /// Dimension of a polynomial space
 /// @param[in] polytype The polynomial type

--- a/cpp/basix/polyset.h
+++ b/cpp/basix/polyset.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "cell.h"
-#include <xtensor/xarray.hpp>
 #include <xtensor/xtensor.hpp>
 
 /// Polynomial expansion sets

--- a/cpp/basix/polyset.h
+++ b/cpp/basix/polyset.h
@@ -160,7 +160,7 @@ namespace basix::polyset
 /// - The third index is the basis function index.
 /// @todo Does the order for the third index need to be documented?
 xt::xtensor<double, 3> tabulate(cell::type celltype, int d, int n,
-                                const xt::xarray<double>& x);
+                                const xt::xtensor<double, 2>& x);
 
 /// Tabulate the orthonormal polynomial basis, and derivatives, at
 /// points on the reference cell.
@@ -203,7 +203,7 @@ xt::xtensor<double, 3> tabulate(cell::type celltype, int d, int n,
 /// @param[in] x Points at which to evaluate the basis. The shape is
 /// (number of points, geometric dimension).
 void tabulate(xt::xtensor<double, 3>& P, cell::type celltype, int d, int n,
-              const xt::xarray<double>& x);
+              const xt::xtensor<double, 2>& x);
 
 /// Dimension of a polynomial space
 /// @param[in] cell The cell type

--- a/cpp/basix/quadrature.cpp
+++ b/cpp/basix/quadrature.cpp
@@ -240,7 +240,7 @@ std::pair<xt::xtensor<double, 2>, std::vector<double>>
 compute_gauss_jacobi_rule(double a, int m)
 {
   /// @note Computes on [-1, 1]
-  std::vector<double> pts = compute_gauss_jacobi_points(a, m);
+  const std::vector<double> pts = compute_gauss_jacobi_points(a, m);
   const xt::xtensor<double, 1> Jd
       = xt::row(compute_jacobi_deriv(a, m, 1, pts), 1);
 

--- a/cpp/basix/quadrature.cpp
+++ b/cpp/basix/quadrature.cpp
@@ -240,7 +240,7 @@ std::pair<xt::xtensor<double, 2>, std::vector<double>>
 compute_gauss_jacobi_rule(double a, int m)
 {
   /// @note Computes on [-1, 1]
-  std::vector<double> pts = compute_gauss_jacobi_points(a, m);
+  const std::vector<double> pts = compute_gauss_jacobi_points(a, m);
   const xt::xtensor<double, 1> Jd
       = xt::row(compute_jacobi_deriv(a, m, 1, pts), 1);
 
@@ -395,13 +395,13 @@ make_gauss_jacobi_quadrature(cell::type celltype, std::size_t m)
     throw std::runtime_error("Unsupported celltype for make_quadrature");
   }
 }
+
 //-----------------------------------------------------------------------------
+// The Gauss-Lobatto-Legendre quadrature rules on the interval using Greg von
+// Winckel's implementation. This facilitates implementing spectral elements.
+// The quadrature rule uses m points for a degree of precision of 2m-3.
 std::pair<xt::xtensor<double, 2>, std::vector<double>> compute_gll_rule(int m)
 {
-  // Implement the Gauss-Lobatto-Legendre quadrature rules on the interval
-  // using Greg von Winckel's implementation. This facilitates implementing
-  // spectral elements
-  // The quadrature rule uses m points for a degree of precision of 2m-3.
 
   if (m < 2)
   {

--- a/cpp/basix/quadrature.cpp
+++ b/cpp/basix/quadrature.cpp
@@ -240,7 +240,7 @@ std::pair<xt::xtensor<double, 2>, std::vector<double>>
 compute_gauss_jacobi_rule(double a, int m)
 {
   /// @note Computes on [-1, 1]
-  const std::vector<double> pts = compute_gauss_jacobi_points(a, m);
+  std::vector<double> pts = compute_gauss_jacobi_points(a, m);
   const xt::xtensor<double, 1> Jd
       = xt::row(compute_jacobi_deriv(a, m, 1, pts), 1);
 
@@ -395,13 +395,13 @@ make_gauss_jacobi_quadrature(cell::type celltype, std::size_t m)
     throw std::runtime_error("Unsupported celltype for make_quadrature");
   }
 }
-
 //-----------------------------------------------------------------------------
-// The Gauss-Lobatto-Legendre quadrature rules on the interval using Greg von
-// Winckel's implementation. This facilitates implementing spectral elements.
-// The quadrature rule uses m points for a degree of precision of 2m-3.
 std::pair<xt::xtensor<double, 2>, std::vector<double>> compute_gll_rule(int m)
 {
+  // Implement the Gauss-Lobatto-Legendre quadrature rules on the interval
+  // using Greg von Winckel's implementation. This facilitates implementing
+  // spectral elements
+  // The quadrature rule uses m points for a degree of precision of 2m-3.
 
   if (m < 2)
   {

--- a/cpp/basix/quadrature.cpp
+++ b/cpp/basix/quadrature.cpp
@@ -418,7 +418,7 @@ std::pair<xt::xtensor<double, 2>, std::vector<double>> compute_gll_rule(int m)
   // Reorder to match 1d dof  ordering
   std::rotate(xs_ref.rbegin(), xs_ref.rbegin() + 1, xs_ref.rend() - 1);
   std::rotate(ws_ref.rbegin(), ws_ref.rbegin() + 1, ws_ref.rend() - 1);
-  const xt::xtensor<double, 2> points
+  xt::xtensor<double, 2> points
       = xt::adapt(xs_ref, {xs_ref.size(), (std::size_t)1});
   return {points, ws_ref};
 }

--- a/cpp/basix/quadrature.cpp
+++ b/cpp/basix/quadrature.cpp
@@ -240,7 +240,7 @@ std::pair<xt::xtensor<double, 2>, std::vector<double>>
 compute_gauss_jacobi_rule(double a, int m)
 {
   /// @note Computes on [-1, 1]
-  const std::vector<double> pts = compute_gauss_jacobi_points(a, m);
+  std::vector<double> pts = compute_gauss_jacobi_points(a, m);
   const xt::xtensor<double, 1> Jd
       = xt::row(compute_jacobi_deriv(a, m, 1, pts), 1);
 

--- a/cpp/basix/quadrature.cpp
+++ b/cpp/basix/quadrature.cpp
@@ -240,21 +240,21 @@ std::pair<xt::xtensor<double, 2>, std::vector<double>>
 compute_gauss_jacobi_rule(double a, int m)
 {
   /// @note Computes on [-1, 1]
-  std::vector<double> _pts = compute_gauss_jacobi_points(a, m);
+  std::vector<double> pts = compute_gauss_jacobi_points(a, m);
   const xt::xtensor<double, 1> Jd
-      = xt::row(compute_jacobi_deriv(a, m, 1, _pts), 1);
+      = xt::row(compute_jacobi_deriv(a, m, 1, pts), 1);
 
   const double a1 = std::pow(2.0, a + 1.0);
 
   std::vector<double> wts(m);
   for (int i = 0; i < m; ++i)
   {
-    const double x = _pts[i];
+    const double x = pts[i];
     const double f = Jd[i];
     wts[i] = a1 / (1.0 - x * x) / (f * f);
   }
 
-  return {xt::adapt(_pts, {_pts.size(), (std::size_t)1}), wts};
+  return {xt::adapt(pts, {pts.size(), (std::size_t)1}), wts};
 }
 //-----------------------------------------------------------------------------
 std::pair<xt::xtensor<double, 2>, std::vector<double>>

--- a/cpp/basix/quadrature.cpp
+++ b/cpp/basix/quadrature.cpp
@@ -236,30 +236,29 @@ std::vector<double> compute_gauss_jacobi_points(double a, int m)
   return x;
 }
 //-----------------------------------------------------------------------------
-std::pair<xt::xarray<double>, std::vector<double>>
+std::pair<xt::xtensor<double, 2>, std::vector<double>>
 compute_gauss_jacobi_rule(double a, int m)
 {
   /// @note Computes on [-1, 1]
   std::vector<double> _pts = compute_gauss_jacobi_points(a, m);
-  auto pts = xt::adapt(_pts);
-
   const xt::xtensor<double, 1> Jd
-      = xt::row(compute_jacobi_deriv(a, m, 1, pts), 1);
+      = xt::row(compute_jacobi_deriv(a, m, 1, _pts), 1);
 
   const double a1 = std::pow(2.0, a + 1.0);
 
   std::vector<double> wts(m);
   for (int i = 0; i < m; ++i)
   {
-    const double x = pts[i];
+    const double x = _pts[i];
     const double f = Jd[i];
     wts[i] = a1 / (1.0 - x * x) / (f * f);
   }
 
-  return {pts, wts};
+  return {xt::adapt(_pts, {_pts.size(), (std::size_t)1}), wts};
 }
 //-----------------------------------------------------------------------------
-std::pair<xt::xarray<double>, std::vector<double>> make_quadrature_line(int m)
+std::pair<xt::xtensor<double, 2>, std::vector<double>>
+make_quadrature_line(int m)
 {
   auto [ptx, wx] = compute_gauss_jacobi_rule(0.0, m);
   std::transform(wx.begin(), wx.end(), wx.begin(),
@@ -267,7 +266,7 @@ std::pair<xt::xarray<double>, std::vector<double>> make_quadrature_line(int m)
   return {0.5 * (ptx + 1.0), wx};
 }
 //-----------------------------------------------------------------------------
-std::pair<xt::xarray<double>, std::vector<double>>
+std::pair<xt::xtensor<double, 2>, std::vector<double>>
 make_quadrature_triangle_collapsed(std::size_t m)
 {
   auto [ptx, wx] = compute_gauss_jacobi_rule(0.0, m);
@@ -279,8 +278,8 @@ make_quadrature_triangle_collapsed(std::size_t m)
   {
     for (std::size_t j = 0; j < m; ++j)
     {
-      pts(c, 0) = 0.25 * (1.0 + ptx[i]) * (1.0 - pty[j]);
-      pts(c, 1) = 0.5 * (1.0 + pty[j]);
+      pts(c, 0) = 0.25 * (1.0 + ptx(i, 0)) * (1.0 - pty(j, 0));
+      pts(c, 1) = 0.5 * (1.0 + pty(j, 0));
       wts[c] = wx[i] * wy[j] * 0.125;
       ++c;
     }
@@ -289,7 +288,7 @@ make_quadrature_triangle_collapsed(std::size_t m)
   return {pts, wts};
 }
 //-----------------------------------------------------------------------------
-std::pair<xt::xarray<double>, std::vector<double>>
+std::pair<xt::xtensor<double, 2>, std::vector<double>>
 make_quadrature_tetrahedron_collapsed(std::size_t m)
 {
   auto [ptx, wx] = compute_gauss_jacobi_rule(0.0, m);
@@ -305,9 +304,10 @@ make_quadrature_tetrahedron_collapsed(std::size_t m)
     {
       for (std::size_t k = 0; k < m; ++k)
       {
-        pts(c, 0) = 0.125 * (1.0 + ptx[i]) * (1.0 - pty[j]) * (1.0 - ptz[k]);
-        pts(c, 1) = 0.25 * (1. + pty[j]) * (1. - ptz[k]);
-        pts(c, 2) = 0.5 * (1.0 + ptz[k]);
+        pts(c, 0)
+            = 0.125 * (1.0 + ptx(i, 0)) * (1.0 - pty(j, 0)) * (1.0 - ptz(k, 0));
+        pts(c, 1) = 0.25 * (1. + pty(j, 0)) * (1. - ptz(k, 0));
+        pts(c, 2) = 0.5 * (1.0 + ptz(k, 0));
         wts[c] = wx[i] * wy[j] * wz[k] * 0.125 * 0.125;
         ++c;
       }
@@ -317,7 +317,7 @@ make_quadrature_tetrahedron_collapsed(std::size_t m)
   return {pts, wts};
 }
 //-----------------------------------------------------------------------------
-std::pair<xt::xarray<double>, std::vector<double>>
+std::pair<xt::xtensor<double, 2>, std::vector<double>>
 make_gauss_jacobi_quadrature(cell::type celltype, std::size_t m)
 {
   const std::size_t np = (m + 2) / 2;
@@ -335,8 +335,8 @@ make_gauss_jacobi_quadrature(cell::type celltype, std::size_t m)
     {
       for (std::size_t j = 0; j < np; ++j)
       {
-        Qpts(c, 0) = QptsL[i];
-        Qpts(c, 1) = QptsL[j];
+        Qpts(c, 0) = QptsL(i, 0);
+        Qpts(c, 1) = QptsL(j, 0);
         Qwts[c] = QwtsL[i] * QwtsL[j];
         ++c;
       }
@@ -355,9 +355,9 @@ make_gauss_jacobi_quadrature(cell::type celltype, std::size_t m)
       {
         for (std::size_t k = 0; k < np; ++k)
         {
-          Qpts(c, 0) = QptsL[i];
-          Qpts(c, 1) = QptsL[j];
-          Qpts(c, 2) = QptsL[k];
+          Qpts(c, 0) = QptsL(i, 0);
+          Qpts(c, 1) = QptsL(j, 0);
+          Qpts(c, 2) = QptsL(k, 0);
           Qwts[c] = QwtsL[i] * QwtsL[j] * QwtsL[k];
           ++c;
         }
@@ -378,7 +378,7 @@ make_gauss_jacobi_quadrature(cell::type celltype, std::size_t m)
       {
         Qpts(c, 0) = QptsT(i, 0);
         Qpts(c, 1) = QptsT(i, 1);
-        Qpts(c, 2) = QptsL[k];
+        Qpts(c, 2) = QptsL(k, 0);
         Qwts[c] = QwtsT[i] * QwtsL[k];
         ++c;
       }
@@ -396,7 +396,7 @@ make_gauss_jacobi_quadrature(cell::type celltype, std::size_t m)
   }
 }
 //-----------------------------------------------------------------------------
-std::pair<xt::xarray<double>, std::vector<double>> compute_gll_rule(int m)
+std::pair<xt::xtensor<double, 2>, std::vector<double>> compute_gll_rule(int m)
 {
   // Implement the Gauss-Lobatto-Legendre quadrature rules on the interval
   // using Greg von Winckel's implementation. This facilitates implementing
@@ -418,11 +418,12 @@ std::pair<xt::xarray<double>, std::vector<double>> compute_gll_rule(int m)
   // Reorder to match 1d dof  ordering
   std::rotate(xs_ref.rbegin(), xs_ref.rbegin() + 1, xs_ref.rend() - 1);
   std::rotate(ws_ref.rbegin(), ws_ref.rbegin() + 1, ws_ref.rend() - 1);
-
-  return {xt::adapt(xs_ref), ws_ref};
+  xt::xtensor<double, 2> points
+      = xt::adapt(xs_ref, {xs_ref.size(), (std::size_t)1});
+  return {points, ws_ref};
 }
 //-----------------------------------------------------------------------------
-std::pair<xt::xarray<double>, std::vector<double>> make_gll_line(int m)
+std::pair<xt::xtensor<double, 2>, std::vector<double>> make_gll_line(int m)
 {
   auto [ptx, wx] = compute_gll_rule(m);
   std::transform(wx.begin(), wx.end(), wx.begin(),
@@ -430,7 +431,7 @@ std::pair<xt::xarray<double>, std::vector<double>> make_gll_line(int m)
   return {0.5 * (ptx + 1.0), wx};
 }
 //-----------------------------------------------------------------------------
-std::pair<xt::xarray<double>, std::vector<double>>
+std::pair<xt::xtensor<double, 2>, std::vector<double>>
 make_gll_quadrature(cell::type celltype, std::size_t m)
 {
   const std::size_t np = (m + 4) / 2;
@@ -448,12 +449,13 @@ make_gll_quadrature(cell::type celltype, std::size_t m)
     {
       for (std::size_t j = 0; j < np; ++j)
       {
-        Qpts(c, 0) = QptsL[i];
-        Qpts(c, 1) = QptsL[j];
+        Qpts(c, 0) = QptsL(i, 0);
+        Qpts(c, 1) = QptsL(j, 0);
         Qwts[c] = QwtsL[i] * QwtsL[j];
         ++c;
       }
     }
+    assert(Qpts.shape().size() == 2);
     return {Qpts, Qwts};
   }
   case cell::type::hexahedron:
@@ -468,9 +470,9 @@ make_gll_quadrature(cell::type celltype, std::size_t m)
       {
         for (std::size_t k = 0; k < np; ++k)
         {
-          Qpts(c, 0) = QptsL[i];
-          Qpts(c, 1) = QptsL[j];
-          Qpts(c, 2) = QptsL[k];
+          Qpts(c, 0) = QptsL(i, 0);
+          Qpts(c, 1) = QptsL(j, 0);
+          Qpts(c, 2) = QptsL(k, 0);
           Qwts[c] = QwtsL[i] * QwtsL[j] * QwtsL[k];
           ++c;
         }
@@ -493,7 +495,7 @@ make_gll_quadrature(cell::type celltype, std::size_t m)
   }
 }
 //-----------------------------------------------------------------------------
-std::pair<xt::xarray<double>, std::vector<double>>
+std::pair<xt::xtensor<double, 2>, std::vector<double>>
 make_strang_fix_quadrature(cell::type celltype, std::size_t m)
 {
   if (celltype == cell::type::triangle)
@@ -583,7 +585,7 @@ make_strang_fix_quadrature(cell::type celltype, std::size_t m)
   throw std::runtime_error("Strang-Fix not implemented for this cell type.");
 }
 //-------------------------------------------------------------------------------------------------------
-std::pair<xt::xarray<double>, std::vector<double>>
+std::pair<xt::xtensor<double, 2>, std::vector<double>>
 make_zienkiewicz_taylor_quadrature(cell::type celltype, std::size_t m)
 {
   if (celltype == cell::type::triangle)
@@ -634,7 +636,7 @@ make_zienkiewicz_taylor_quadrature(cell::type celltype, std::size_t m)
       "Zienkiewicz-Taylor not implemented for this cell type.");
 }
 //-----------------------------------------------------------------------------
-std::pair<xt::xarray<double>, std::vector<double>>
+std::pair<xt::xtensor<double, 2>, std::vector<double>>
 make_keast_quadrature(cell::type celltype, std::size_t m)
 {
   if (celltype == cell::type::tetrahedron)
@@ -868,7 +870,7 @@ make_keast_quadrature(cell::type celltype, std::size_t m)
   throw std::runtime_error("Keast not implemented for this cell type.");
 }
 //-----------------------------------------------------------------------------
-std::pair<xt::xarray<double>, std::vector<double>>
+std::pair<xt::xtensor<double, 2>, std::vector<double>>
 make_xiao_gimbutas_quadrature(cell::type celltype, int m)
 {
   if (celltype == cell::type::triangle)
@@ -5302,7 +5304,7 @@ quadrature::type quadrature::get_default_rule(cell::type celltype, int m)
     return type::gauss_jacobi;
 }
 //-----------------------------------------------------------------------------
-std::pair<xt::xarray<double>, std::vector<double>>
+std::pair<xt::xtensor<double, 2>, std::vector<double>>
 quadrature::make_quadrature(quadrature::type rule, cell::type celltype, int m)
 {
   switch (rule)
@@ -5326,23 +5328,23 @@ quadrature::make_quadrature(quadrature::type rule, cell::type celltype, int m)
   }
 }
 //-----------------------------------------------------------------------------
-std::pair<xt::xarray<double>, std::vector<double>>
+std::pair<xt::xtensor<double, 2>, std::vector<double>>
 quadrature::make_quadrature(cell::type celltype, int m)
 {
   return make_quadrature(quadrature::type::Default, celltype, m);
 }
 //-----------------------------------------------------------------------------
-xt::xtensor<double, 1> quadrature::get_gl_points(int m)
+xt::xtensor<double, 2> quadrature::get_gl_points(int m)
 {
   std::vector<double> _pts = compute_gauss_jacobi_points(0, m);
-  std::array<std::size_t, 1> shape = {_pts.size()};
-  xt::xtensor<double, 1> pts(shape);
+  std::array<std::size_t, 2> shape = {_pts.size(), (std::size_t)1};
+  xt::xtensor<double, 2> pts(shape);
   for (std::size_t i = 0; i < _pts.size(); ++i)
-    pts(i) = 0.5 + 0.5 * _pts[i];
+    pts(i, 0) = 0.5 + 0.5 * _pts[i];
   return pts;
 }
 //-----------------------------------------------------------------------------
-xt::xtensor<double, 1> quadrature::get_gll_points(int m)
+xt::xtensor<double, 2> quadrature::get_gll_points(int m)
 {
   [[maybe_unused]] auto [pts, wts] = make_gll_line(m);
   return pts;

--- a/cpp/basix/quadrature.cpp
+++ b/cpp/basix/quadrature.cpp
@@ -240,7 +240,7 @@ std::pair<xt::xtensor<double, 2>, std::vector<double>>
 compute_gauss_jacobi_rule(double a, int m)
 {
   /// @note Computes on [-1, 1]
-  std::vector<double> pts = compute_gauss_jacobi_points(a, m);
+  const std::vector<double> pts = compute_gauss_jacobi_points(a, m);
   const xt::xtensor<double, 1> Jd
       = xt::row(compute_jacobi_deriv(a, m, 1, pts), 1);
 
@@ -395,13 +395,13 @@ make_gauss_jacobi_quadrature(cell::type celltype, std::size_t m)
     throw std::runtime_error("Unsupported celltype for make_quadrature");
   }
 }
+
 //-----------------------------------------------------------------------------
+// The Gauss-Lobatto-Legendre quadrature rules on the interval using Greg von
+// Winckel's implementation. This facilitates implementing spectral elements.
+// The quadrature rule uses m points for a degree of precision of 2m-3.
 std::pair<xt::xtensor<double, 2>, std::vector<double>> compute_gll_rule(int m)
 {
-  // Implement the Gauss-Lobatto-Legendre quadrature rules on the interval
-  // using Greg von Winckel's implementation. This facilitates implementing
-  // spectral elements
-  // The quadrature rule uses m points for a degree of precision of 2m-3.
 
   if (m < 2)
   {
@@ -418,7 +418,7 @@ std::pair<xt::xtensor<double, 2>, std::vector<double>> compute_gll_rule(int m)
   // Reorder to match 1d dof  ordering
   std::rotate(xs_ref.rbegin(), xs_ref.rbegin() + 1, xs_ref.rend() - 1);
   std::rotate(ws_ref.rbegin(), ws_ref.rbegin() + 1, ws_ref.rend() - 1);
-  xt::xtensor<double, 2> points
+  const xt::xtensor<double, 2> points
       = xt::adapt(xs_ref, {xs_ref.size(), (std::size_t)1});
   return {points, ws_ref};
 }

--- a/cpp/basix/quadrature.h
+++ b/cpp/basix/quadrature.h
@@ -33,7 +33,7 @@ enum class type
 /// will integrate exactly
 /// @return List of points and list of weights. The number of points
 /// arrays has shape (num points, gdim)
-std::pair<xt::xarray<double>, std::vector<double>>
+std::pair<xt::xtensor<double, 2>, std::vector<double>>
 make_quadrature(const quadrature::type rule, cell::type celltype, int m);
 
 /// Make a default quadrature rule on reference cell
@@ -42,7 +42,7 @@ make_quadrature(const quadrature::type rule, cell::type celltype, int m);
 /// will integrate exactly
 /// @return List of points and list of weights. The number of points
 /// arrays has shape (num points, gdim)
-std::pair<xt::xarray<double>, std::vector<double>>
+std::pair<xt::xtensor<double, 2>, std::vector<double>>
 make_quadrature(cell::type celltype, int m);
 
 /// Get the default quadrature type for the given cell and order
@@ -55,11 +55,11 @@ quadrature::type get_default_rule(cell::type celltype, int m);
 /// Get Gauss-Lobatto-Legendre (GLL) points on the interval [0, 1].
 /// @param[in] m The number of points
 /// @return An array of GLL points
-xt::xtensor<double, 1> get_gll_points(int m);
+xt::xtensor<double, 2> get_gll_points(int m);
 
 /// Get Gauss-Legendre (GL) points on the interval [0, 1].
 /// @param[in] m The number of points
 /// @return An array of GL points
-xt::xtensor<double, 1> get_gl_points(int m);
+xt::xtensor<double, 2> get_gl_points(int m);
 
 } // namespace basix::quadrature

--- a/test/test_tensor_products.py
+++ b/test/test_tensor_products.py
@@ -52,7 +52,7 @@ def test_tensor_product_factorisation(cell_type, degree, element_type, element_a
 
             values2 = np.empty((element.dim, 1))
             for fs, perm in factors:
-                evals = [e.tabulate(d, [p])[d, 0, :, 0] for e, p, d in zip(fs, point, ds)]
+                evals = [e.tabulate(d, p.reshape(1, -1))[d, 0, :, 0] for e, p, d in zip(fs, point, ds)]
                 tab2 = tensor_product(*evals)
                 for a, b in enumerate(perm):
                     if b != -1:


### PR DESCRIPTION
This avoid hidden copying and reshaping when passing functions from xt::xarray -> xt::xtensor<double, 2> -> xt::xarray inside the tabulate code.

Only remaining use of xt::xarray is in basix::math::solve, where it probably also should be avoided. 
I will leave that to a separate PR as it is only called during construction of elements.

Resolves #471