### PR TITLE
Do not include `cblas.h`

### DIFF
--- a/.github/workflows/redhat.yml
+++ b/.github/workflows/redhat.yml
@@ -21,8 +21,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install Basix
-        run: |
-          CPATH=/usr/include/openblas python3 -m pip install .[test]
+        run: python3 -m pip install .[test]
 
       - name: Run units tests
         run: |

--- a/cpp/basix/math.cpp
+++ b/cpp/basix/math.cpp
@@ -121,26 +121,26 @@ void basix::math::dot(const xt::xtensor<double, 2>& A,
   assert(C.shape(0) == C.shape(0));
   assert(C.shape(1) == B.shape(1));
 
-  int m = A.shape(0);
-  int n = B.shape(1);
-  int k = A.shape(1);
+  int M = A.shape(0);
+  int N = B.shape(1);
+  int K = A.shape(1);
 
-  // if (m * n * k < 4096)
-  // {
-  //   for (std::size_t i = 0; i < A.shape(0); i++)
-  //     for (std::size_t j = 0; j < B.shape(1); j++)
-  //       for (std::size_t k = 0; k < A.shape(1); k++)
-  //         C(i, j) += A(i, k) * B(k, j);
-  // }
-  // else
+  if (M * N * K < 4096)
+  {
+    for (std::size_t i = 0; i < A.shape(0); i++)
+      for (std::size_t j = 0; j < B.shape(1); j++)
+        for (std::size_t k = 0; k < A.shape(1); k++)
+          C(i, j) += A(i, k) * B(k, j);
+  }
+  else
   {
     double alpha = 1;
     double beta = 0;
-    int lda = k;
-    int ldb = n;
-    int ldc = n;
+    int lda = K;
+    int ldb = N;
+    int ldc = N;
     char trans = 'N';
-    dgemm_(&trans, &trans, &n, &m, &k, &alpha, const_cast<double*>(B.data()),
+    dgemm_(&trans, &trans, &N, &M, &K, &alpha, const_cast<double*>(B.data()),
            &ldb, const_cast<double*>(A.data()), &lda, &beta,
            const_cast<double*>(C.data()), &ldc);
   }
@@ -154,4 +154,3 @@ xt::xtensor<double, 2> basix::math::dot(const xt::xtensor<double, 2>& A,
   return C;
 }
 //------------------------------------------------------------------
-

--- a/cpp/basix/math.cpp
+++ b/cpp/basix/math.cpp
@@ -7,10 +7,6 @@
 #include "math.h"
 #include <vector>
 
-#ifdef __APPLE__
-#include <Accelerate/Accelerate.h>
-#else
-#include <cblas.h>
 extern "C"
 {
   void dsyevd_(char* jobz, char* uplo, int* n, double* a, int* lda, double* w,
@@ -18,8 +14,11 @@ extern "C"
 
   void dgesv_(int* N, int* NRHS, double* A, int* LDA, int* IPIV, double* B,
               int* LDB, int* INFO);
+
+  // void dgemm_(char* TRANSA, char* TRANSB, int M, int N, int K, double alpha,
+  //             double* A, int LDA, double* B, int LDB, double BETA, double* C,
+  //             int LDC);
 }
-#endif
 
 //------------------------------------------------------------------
 std::pair<xt::xtensor<double, 1>,
@@ -124,20 +123,20 @@ void basix::math::dot(const xt::xtensor<double, 2>& A,
   assert(C.shape(0) == C.shape(0));
   assert(C.shape(1) == B.shape(1));
 
-  if (m * n * k < 4096)
-    for (std::size_t i = 0; i < A.shape(0); i++)
-      for (std::size_t j = 0; j < B.shape(1); j++)
-        for (std::size_t k = 0; k < A.shape(1); k++)
-          C(i, j) += A(i, k) * B(k, j);
-  else
-  {
-    double alpha = 1;
-    double beta = 0;
-    cblas_dgemm(CBLAS_ORDER::CblasRowMajor, CBLAS_TRANSPOSE::CblasNoTrans,
-                CBLAS_TRANSPOSE::CblasNoTrans, m, n, k, alpha,
-                const_cast<double*>(A.data()), k, const_cast<double*>(B.data()),
-                n, beta, const_cast<double*>(C.data()), n);
-  }
+  // if (m * n * k < 4096)
+  for (std::size_t i = 0; i < A.shape(0); i++)
+    for (std::size_t j = 0; j < B.shape(1); j++)
+      for (std::size_t k = 0; k < A.shape(1); k++)
+        C(i, j) += A(i, k) * B(k, j);
+  // else
+  // {
+  //   double alpha = 1;
+  //   double beta = 0;
+  //   char transpose = 'T';
+  //   dgemm_(&transpose, &transpose, m, n, k, alpha,
+  //          const_cast<double*>(A.data()), m, const_cast<double*>(B.data()),
+  //          k, beta, const_cast<double*>(C.data()), m);
+  // }
 }
 
 xt::xtensor<double, 2> basix::math::dot(const xt::xtensor<double, 2>& A,

--- a/cpp/basix/math.cpp
+++ b/cpp/basix/math.cpp
@@ -127,9 +127,9 @@ void basix::math::dot(const xt::xtensor<double, 2>& A,
 
   if (M * N * K < 4096)
   {
-    for (std::size_t i = 0; i < M; ++i)
-      for (std::size_t j = 0; j < N; ++j)
-        for (std::size_t k = 0; k < K; ++k)
+    for (int i = 0; i < M; ++i)
+      for (int j = 0; j < N; ++j)
+        for (int k = 0; k < K; ++k)
           C(i, j) += A(i, k) * B(k, j);
   }
   else

--- a/cpp/basix/math.cpp
+++ b/cpp/basix/math.cpp
@@ -125,14 +125,14 @@ void basix::math::dot(const xt::xtensor<double, 2>& A,
   int N = B.shape(1);
   int K = A.shape(1);
 
-  if (M * N * K < 4096)
-  {
-    for (int i = 0; i < M; ++i)
-      for (int j = 0; j < N; ++j)
-        for (int k = 0; k < K; ++k)
-          C(i, j) += A(i, k) * B(k, j);
-  }
-  else
+  // if (M * N * K < 4096)
+  // {
+  //   for (int i = 0; i < M; ++i)
+  //     for (int j = 0; j < N; ++j)
+  //       for (int k = 0; k < K; ++k)
+  //         C(i, j) += A(i, k) * B(k, j);
+  // }
+  // else
   {
     double alpha = 1;
     double beta = 0;

--- a/cpp/basix/math.cpp
+++ b/cpp/basix/math.cpp
@@ -127,9 +127,9 @@ void basix::math::dot(const xt::xtensor<double, 2>& A,
 
   if (M * N * K < 4096)
   {
-    for (std::size_t i = 0; i < A.shape(0); i++)
-      for (std::size_t j = 0; j < B.shape(1); j++)
-        for (std::size_t k = 0; k < A.shape(1); k++)
+    for (std::size_t i = 0; i < M; ++i)
+      for (std::size_t j = 0; j < N; ++j)
+        for (std::size_t k = 0; k < K; ++k)
           C(i, j) += A(i, k) * B(k, j);
   }
   else

--- a/cpp/basix/math.cpp
+++ b/cpp/basix/math.cpp
@@ -125,14 +125,14 @@ void basix::math::dot(const xt::xtensor<double, 2>& A,
   int N = B.shape(1);
   int K = A.shape(1);
 
-  // if (M * N * K < 4096)
-  // {
-  //   for (int i = 0; i < M; ++i)
-  //     for (int j = 0; j < N; ++j)
-  //       for (int k = 0; k < K; ++k)
-  //         C(i, j) += A(i, k) * B(k, j);
-  // }
-  // else
+  if (M * N * K < 4096)
+  {
+    for (int i = 0; i < M; ++i)
+      for (int j = 0; j < N; ++j)
+        for (int k = 0; k < K; ++k)
+          C(i, j) += A(i, k) * B(k, j);
+  }
+  else
   {
     double alpha = 1;
     double beta = 0;


### PR DESCRIPTION
`cblas.h` is not included with MKL. With MKL it has a different name, and CMake does't report which BLAS library has been found.

This change declares the BLAS prototype directly. Only one BLAS functions is used.