### PR TITLE
Orthogonalise polynomial sets

### DIFF
--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -28,6 +28,7 @@ using namespace basix;
 namespace
 {
 //-----------------------------------------------------------------------------
+/// This function orthogonalises and normalises the rows of a matrix in place
 void orthogonalise(xt::xtensor<double, 2>& wcoeffs)
 {
   for (std::size_t i = 0; i < wcoeffs.shape(0); ++i)


### PR DESCRIPTION
Orthogonalise the polynomial basis during element construction.

This reduces the condition number of the dual matrices. eg for serendipity elements (built-in = current elements on main, orthogonalised = after this PR):

![image](https://user-images.githubusercontent.com/9850599/168251683-b52880b5-f2f8-4273-bd37-028e53c79422.png)

This has a knock on effect of reducing the error when solving problems, eg:

![image](https://user-images.githubusercontent.com/9850599/168251875-d4fb3045-a251-4017-ac68-c42f0a5c84fc.png)
