### PR TITLE
Transpose polysets

### DIFF
--- a/cpp/basix/dof-transformations.cpp
+++ b/cpp/basix/dof-transformations.cpp
@@ -361,8 +361,7 @@ xt::xtensor<double, 2> compute_transformation(
     auto data_view = xt::view(tabulated_data, xt::all(), xt::all(), j);
     xt::xtensor<double, 2> C
         = xt::view(coeffs, xt::all(), xt::range(psize * j, psize * j + psize));
-    xt::xtensor<double, 2> Ct = xt::transpose(C);
-    auto result = math::dot(xt::transpose(polyset_vals), Ct);
+    auto result = xt::transpose(math::dot(C, polyset_vals));
     data_view.assign(result);
   }
 

--- a/cpp/basix/dof-transformations.cpp
+++ b/cpp/basix/dof-transformations.cpp
@@ -361,8 +361,8 @@ xt::xtensor<double, 2> compute_transformation(
     auto data_view = xt::view(tabulated_data, xt::all(), xt::all(), j);
     xt::xtensor<double, 2> C
         = xt::view(coeffs, xt::all(), xt::range(psize * j, psize * j + psize));
-    xt::xtensor<double, 2> Ct = xt::transpose(C);
-    auto result = math::dot(polyset_vals, Ct);
+    //    xt::xtensor<double, 2> Ct = xt::transpose(C);
+    auto result = math::dot(polyset_vals, C);
     data_view.assign(result);
   }
 

--- a/cpp/basix/dof-transformations.cpp
+++ b/cpp/basix/dof-transformations.cpp
@@ -361,8 +361,8 @@ xt::xtensor<double, 2> compute_transformation(
     auto data_view = xt::view(tabulated_data, xt::all(), xt::all(), j);
     xt::xtensor<double, 2> C
         = xt::view(coeffs, xt::all(), xt::range(psize * j, psize * j + psize));
-    //    xt::xtensor<double, 2> Ct = xt::transpose(C);
-    auto result = math::dot(polyset_vals, C);
+    xt::xtensor<double, 2> Ct = xt::transpose(C);
+    auto result = math::dot(xt::transpose(polyset_vals), Ct);
     data_view.assign(result);
   }
 

--- a/cpp/basix/e-bubble.cpp
+++ b/cpp/basix/e-bubble.cpp
@@ -77,7 +77,7 @@ FiniteElement basix::element::create_bubble(cell::type celltype, int degree,
       polyset::tabulate(celltype, degree, 0, pts), 0, xt::all(), xt::all());
 
   // The number of order (degree) polynomials
-  const std::size_t psize = phi.shape(1);
+  const std::size_t psize = phi.shape(0);
 
   // Create points at nodes on interior
   const xt::xtensor<double, 2> points
@@ -141,11 +141,11 @@ FiniteElement basix::element::create_bubble(cell::type celltype, int degree,
   }
 
   xt::xtensor<double, 2> wcoeffs = xt::zeros<double>({ndofs, psize});
-  for (std::size_t i = 0; i < phi1.shape(1); ++i)
+  for (std::size_t i = 0; i < phi1.shape(0); ++i)
   {
-    auto integrand = xt::col(phi1, i) * bubble;
+    auto integrand = xt::row(phi1, i) * bubble;
     for (std::size_t k = 0; k < psize; ++k)
-      wcoeffs(i, k) = xt::sum(wts * integrand * xt::col(phi, k))();
+      wcoeffs(i, k) = xt::sum(wts * integrand * xt::row(phi, k))();
   }
 
   const std::vector<std::vector<std::vector<int>>> topology

--- a/cpp/basix/e-bubble.cpp
+++ b/cpp/basix/e-bubble.cpp
@@ -77,7 +77,7 @@ FiniteElement basix::element::create_bubble(cell::type celltype, int degree,
       polyset::tabulate(celltype, degree, 0, pts), 0, xt::all(), xt::all());
 
   // The number of order (degree) polynomials
-  const std::size_t psize = phi.shape(0);
+  const std::size_t psize = phi.shape(1);
 
   // Create points at nodes on interior
   const xt::xtensor<double, 2> points
@@ -141,11 +141,11 @@ FiniteElement basix::element::create_bubble(cell::type celltype, int degree,
   }
 
   xt::xtensor<double, 2> wcoeffs = xt::zeros<double>({ndofs, psize});
-  for (std::size_t i = 0; i < phi1.shape(0); ++i)
+  for (std::size_t i = 0; i < phi1.shape(1); ++i)
   {
-    auto integrand = xt::row(phi1, i) * bubble;
+    auto integrand = xt::col(phi1, i) * bubble;
     for (std::size_t k = 0; k < psize; ++k)
-      wcoeffs(i, k) = xt::sum(wts * integrand * xt::row(phi, k))();
+      wcoeffs(i, k) = xt::sum(wts * integrand * xt::col(phi, k))();
   }
 
   const std::vector<std::vector<std::vector<int>>> topology

--- a/cpp/basix/e-nce-rtc.cpp
+++ b/cpp/basix/e-nce-rtc.cpp
@@ -191,7 +191,7 @@ FiniteElement basix::element::create_nce(cell::type celltype, int degree,
       polyset::tabulate(celltype, degree, 0, pts), 0, xt::all(), xt::all());
 
   // The number of order (degree) polynomials
-  const int psize = phi.shape(1);
+  const int psize = phi.shape(0);
 
   const int edge_count = tdim == 2 ? 4 : 12;
   const int edge_dofs = polyset::dim(cell::type::interval, degree - 1);
@@ -244,7 +244,7 @@ FiniteElement basix::element::create_nce(cell::type celltype, int degree,
           integrand *= xt::col(pts, d);
         for (int k = 0; k < psize; ++k)
         {
-          const double w_sum = xt::sum(wts * integrand * xt::col(phi, k))();
+          const double w_sum = xt::sum(wts * integrand * xt::row(phi, k))();
           wcoeffs(dof, k + psize * d) = w_sum;
         }
         ++dof;
@@ -278,7 +278,7 @@ FiniteElement basix::element::create_nce(cell::type celltype, int degree,
               for (int k = 0; k < psize; ++k)
               {
                 const double w_sum
-                    = xt::sum(wts * integrand * xt::col(phi, k))();
+                    = xt::sum(wts * integrand * xt::row(phi, k))();
                 wcoeffs(dof, k + psize * d) = w_sum;
               }
               ++dof;

--- a/cpp/basix/e-nce-rtc.cpp
+++ b/cpp/basix/e-nce-rtc.cpp
@@ -51,7 +51,7 @@ FiniteElement basix::element::create_rtc(cell::type celltype, int degree,
       polyset::tabulate(celltype, degree, 0, pts), 0, xt::all(), xt::all());
 
   // The number of order (degree) polynomials
-  const std::size_t psize = phi.shape(1);
+  const std::size_t psize = phi.shape(0);
 
   const int facet_count = tdim == 2 ? 4 : 6;
   const int facet_dofs = polyset::dim(facettype, degree - 1);
@@ -109,7 +109,7 @@ FiniteElement basix::element::create_rtc(cell::type celltype, int degree,
 
       for (std::size_t k = 0; k < psize; ++k)
       {
-        const double w_sum = xt::sum(Qwts * integrand * xt::col(phi, k))();
+        const double w_sum = xt::sum(Qwts * integrand * xt::row(phi, k))();
         wcoeffs(dof, k + psize * d) = w_sum;
       }
       ++dof;

--- a/cpp/basix/e-nedelec.cpp
+++ b/cpp/basix/e-nedelec.cpp
@@ -40,7 +40,7 @@ xt::xtensor<double, 2> create_nedelec_2d_space(int degree)
       = xt::view(polyset::tabulate(cell::type::triangle, degree, 0, pts), 0,
                  xt::all(), xt::all());
 
-  const std::size_t psize = phi.shape(0);
+  const std::size_t psize = phi.shape(1);
 
   // Create coefficients for order (degree-1) vector polynomials
   xt::xtensor<double, 2> wcoeffs = xt::zeros<double>({nv * 2 + ns, psize * 2});
@@ -51,10 +51,10 @@ xt::xtensor<double, 2> create_nedelec_2d_space(int degree)
   // Create coefficients for the additional Nedelec polynomials
   for (std::size_t i = 0; i < ns; ++i)
   {
-    auto p = xt::row(phi, ns0 + i);
+    auto p = xt::col(phi, ns0 + i);
     for (std::size_t k = 0; k < psize; ++k)
     {
-      auto pk = xt::row(phi, k);
+      auto pk = xt::col(phi, k);
       wcoeffs(2 * nv + i, k) = xt::sum(wts * p * xt::col(pts, 1) * pk)();
       wcoeffs(2 * nv + i, k + psize)
           = xt::sum(-wts * p * xt::col(pts, 0) * pk)();
@@ -93,7 +93,7 @@ xt::xtensor<double, 2> create_nedelec_3d_space(int degree)
   xt::xtensor<double, 2> phi
       = xt::view(polyset::tabulate(cell::type::tetrahedron, degree, 0, pts), 0,
                  xt::all(), xt::all());
-  const std::size_t psize = phi.shape(0);
+  const std::size_t psize = phi.shape(1);
 
   // Create coefficients for order (degree-1) polynomials
   xt::xtensor<double, 2> wcoeffs = xt::zeros<double>({ndofs, psize * tdim});
@@ -113,7 +113,7 @@ xt::xtensor<double, 2> create_nedelec_3d_space(int degree)
     auto p = xt::col(phi, ns0 + i);
     for (std::size_t k = 0; k < psize; ++k)
     {
-      const double w = xt::sum(wts * p * p2 * xt::row(phi, k))();
+      const double w = xt::sum(wts * p * p2 * xt::col(phi, k))();
 
       // Don't include polynomials (*, *, 0) that are dependant
       if (i >= ns_remove)
@@ -124,10 +124,10 @@ xt::xtensor<double, 2> create_nedelec_3d_space(int degree)
 
   for (std::size_t i = 0; i < ns; ++i)
   {
-    auto p = xt::row(phi, ns0 + i);
+    auto p = xt::col(phi, ns0 + i);
     for (std::size_t k = 0; k < psize; ++k)
     {
-      const double w = xt::sum(wts * p * p1 * xt::row(phi, k))();
+      const double w = xt::sum(wts * p * p1 * xt::col(phi, k))();
       wcoeffs(tdim * nv + i + ns * 2 - ns_remove, k) = -w;
 
       // Don't include polynomials (*, *, 0) that are dependant
@@ -138,10 +138,10 @@ xt::xtensor<double, 2> create_nedelec_3d_space(int degree)
 
   for (std::size_t i = 0; i < ns; ++i)
   {
-    auto p = xt::row(phi, ns0 + i);
+    auto p = xt::col(phi, ns0 + i);
     for (std::size_t k = 0; k < psize; ++k)
     {
-      const double w = xt::sum(wts * p * p0 * xt::row(phi, k))();
+      const double w = xt::sum(wts * p * p0 * xt::col(phi, k))();
       wcoeffs(tdim * nv + i + ns - ns_remove, psize * 2 + k) = -w;
       wcoeffs(tdim * nv + i + ns * 2 - ns_remove, psize + k) = w;
     }

--- a/cpp/basix/e-nedelec.cpp
+++ b/cpp/basix/e-nedelec.cpp
@@ -40,7 +40,7 @@ xt::xtensor<double, 2> create_nedelec_2d_space(int degree)
       = xt::view(polyset::tabulate(cell::type::triangle, degree, 0, pts), 0,
                  xt::all(), xt::all());
 
-  const std::size_t psize = phi.shape(1);
+  const std::size_t psize = phi.shape(0);
 
   // Create coefficients for order (degree-1) vector polynomials
   xt::xtensor<double, 2> wcoeffs = xt::zeros<double>({nv * 2 + ns, psize * 2});
@@ -51,10 +51,10 @@ xt::xtensor<double, 2> create_nedelec_2d_space(int degree)
   // Create coefficients for the additional Nedelec polynomials
   for (std::size_t i = 0; i < ns; ++i)
   {
-    auto p = xt::col(phi, ns0 + i);
+    auto p = xt::row(phi, ns0 + i);
     for (std::size_t k = 0; k < psize; ++k)
     {
-      auto pk = xt::col(phi, k);
+      auto pk = xt::row(phi, k);
       wcoeffs(2 * nv + i, k) = xt::sum(wts * p * xt::col(pts, 1) * pk)();
       wcoeffs(2 * nv + i, k + psize)
           = xt::sum(-wts * p * xt::col(pts, 0) * pk)();
@@ -93,7 +93,7 @@ xt::xtensor<double, 2> create_nedelec_3d_space(int degree)
   xt::xtensor<double, 2> phi
       = xt::view(polyset::tabulate(cell::type::tetrahedron, degree, 0, pts), 0,
                  xt::all(), xt::all());
-  const std::size_t psize = phi.shape(1);
+  const std::size_t psize = phi.shape(0);
 
   // Create coefficients for order (degree-1) polynomials
   xt::xtensor<double, 2> wcoeffs = xt::zeros<double>({ndofs, psize * tdim});
@@ -113,7 +113,7 @@ xt::xtensor<double, 2> create_nedelec_3d_space(int degree)
     auto p = xt::col(phi, ns0 + i);
     for (std::size_t k = 0; k < psize; ++k)
     {
-      const double w = xt::sum(wts * p * p2 * xt::col(phi, k))();
+      const double w = xt::sum(wts * p * p2 * xt::row(phi, k))();
 
       // Don't include polynomials (*, *, 0) that are dependant
       if (i >= ns_remove)
@@ -124,10 +124,10 @@ xt::xtensor<double, 2> create_nedelec_3d_space(int degree)
 
   for (std::size_t i = 0; i < ns; ++i)
   {
-    auto p = xt::col(phi, ns0 + i);
+    auto p = xt::row(phi, ns0 + i);
     for (std::size_t k = 0; k < psize; ++k)
     {
-      const double w = xt::sum(wts * p * p1 * xt::col(phi, k))();
+      const double w = xt::sum(wts * p * p1 * xt::row(phi, k))();
       wcoeffs(tdim * nv + i + ns * 2 - ns_remove, k) = -w;
 
       // Don't include polynomials (*, *, 0) that are dependant
@@ -138,10 +138,10 @@ xt::xtensor<double, 2> create_nedelec_3d_space(int degree)
 
   for (std::size_t i = 0; i < ns; ++i)
   {
-    auto p = xt::col(phi, ns0 + i);
+    auto p = xt::row(phi, ns0 + i);
     for (std::size_t k = 0; k < psize; ++k)
     {
-      const double w = xt::sum(wts * p * p0 * xt::col(phi, k))();
+      const double w = xt::sum(wts * p * p0 * xt::row(phi, k))();
       wcoeffs(tdim * nv + i + ns - ns_remove, psize * 2 + k) = -w;
       wcoeffs(tdim * nv + i + ns * 2 - ns_remove, psize + k) = w;
     }

--- a/cpp/basix/e-nedelec.cpp
+++ b/cpp/basix/e-nedelec.cpp
@@ -40,7 +40,7 @@ xt::xtensor<double, 2> create_nedelec_2d_space(int degree)
       = xt::view(polyset::tabulate(cell::type::triangle, degree, 0, pts), 0,
                  xt::all(), xt::all());
 
-  const std::size_t psize = phi.shape(1);
+  const std::size_t psize = phi.shape(0);
 
   // Create coefficients for order (degree-1) vector polynomials
   xt::xtensor<double, 2> wcoeffs = xt::zeros<double>({nv * 2 + ns, psize * 2});
@@ -51,10 +51,10 @@ xt::xtensor<double, 2> create_nedelec_2d_space(int degree)
   // Create coefficients for the additional Nedelec polynomials
   for (std::size_t i = 0; i < ns; ++i)
   {
-    auto p = xt::col(phi, ns0 + i);
+    auto p = xt::row(phi, ns0 + i);
     for (std::size_t k = 0; k < psize; ++k)
     {
-      auto pk = xt::col(phi, k);
+      auto pk = xt::row(phi, k);
       wcoeffs(2 * nv + i, k) = xt::sum(wts * p * xt::col(pts, 1) * pk)();
       wcoeffs(2 * nv + i, k + psize)
           = xt::sum(-wts * p * xt::col(pts, 0) * pk)();
@@ -93,7 +93,7 @@ xt::xtensor<double, 2> create_nedelec_3d_space(int degree)
   xt::xtensor<double, 2> phi
       = xt::view(polyset::tabulate(cell::type::tetrahedron, degree, 0, pts), 0,
                  xt::all(), xt::all());
-  const std::size_t psize = phi.shape(1);
+  const std::size_t psize = phi.shape(0);
 
   // Create coefficients for order (degree-1) polynomials
   xt::xtensor<double, 2> wcoeffs = xt::zeros<double>({ndofs, psize * tdim});
@@ -110,10 +110,10 @@ xt::xtensor<double, 2> create_nedelec_3d_space(int degree)
   auto p2 = xt::col(pts, 2);
   for (std::size_t i = 0; i < ns; ++i)
   {
-    auto p = xt::col(phi, ns0 + i);
+    auto p = xt::row(phi, ns0 + i);
     for (std::size_t k = 0; k < psize; ++k)
     {
-      const double w = xt::sum(wts * p * p2 * xt::col(phi, k))();
+      const double w = xt::sum(wts * p * p2 * xt::row(phi, k))();
 
       // Don't include polynomials (*, *, 0) that are dependant
       if (i >= ns_remove)
@@ -124,10 +124,10 @@ xt::xtensor<double, 2> create_nedelec_3d_space(int degree)
 
   for (std::size_t i = 0; i < ns; ++i)
   {
-    auto p = xt::col(phi, ns0 + i);
+    auto p = xt::row(phi, ns0 + i);
     for (std::size_t k = 0; k < psize; ++k)
     {
-      const double w = xt::sum(wts * p * p1 * xt::col(phi, k))();
+      const double w = xt::sum(wts * p * p1 * xt::row(phi, k))();
       wcoeffs(tdim * nv + i + ns * 2 - ns_remove, k) = -w;
 
       // Don't include polynomials (*, *, 0) that are dependant
@@ -138,10 +138,10 @@ xt::xtensor<double, 2> create_nedelec_3d_space(int degree)
 
   for (std::size_t i = 0; i < ns; ++i)
   {
-    auto p = xt::col(phi, ns0 + i);
+    auto p = xt::row(phi, ns0 + i);
     for (std::size_t k = 0; k < psize; ++k)
     {
-      const double w = xt::sum(wts * p * p0 * xt::col(phi, k))();
+      const double w = xt::sum(wts * p * p0 * xt::row(phi, k))();
       wcoeffs(tdim * nv + i + ns - ns_remove, psize * 2 + k) = -w;
       wcoeffs(tdim * nv + i + ns * 2 - ns_remove, psize + k) = w;
     }

--- a/cpp/basix/e-raviart-thomas.cpp
+++ b/cpp/basix/e-raviart-thomas.cpp
@@ -51,7 +51,7 @@ FiniteElement basix::element::create_rt(cell::type celltype, int degree,
                             xt::all(), xt::all());
 
   // The number of order (degree) polynomials
-  const std::size_t psize = phi.shape(1);
+  const std::size_t psize = phi.shape(0);
 
   // Create coefficients for order (degree-1) vector polynomials
   xt::xtensor<double, 2> B = xt::zeros<double>({nv * tdim + ns, psize * tdim});
@@ -66,10 +66,10 @@ FiniteElement basix::element::create_rt(cell::type celltype, int degree,
   // polynomial basis
   for (std::size_t i = 0; i < ns; ++i)
   {
-    auto p = xt::col(phi, ns0 + i);
+    auto p = xt::row(phi, ns0 + i);
     for (std::size_t k = 0; k < psize; ++k)
     {
-      auto pk = xt::col(phi, k);
+      auto pk = xt::row(phi, k);
       for (std::size_t j = 0; j < tdim; ++j)
       {
         B(nv * tdim + i, k + psize * j)

--- a/cpp/basix/e-raviart-thomas.cpp
+++ b/cpp/basix/e-raviart-thomas.cpp
@@ -51,7 +51,7 @@ FiniteElement basix::element::create_rt(cell::type celltype, int degree,
                             xt::all(), xt::all());
 
   // The number of order (degree) polynomials
-  const std::size_t psize = phi.shape(0);
+  const std::size_t psize = phi.shape(1);
 
   // Create coefficients for order (degree-1) vector polynomials
   xt::xtensor<double, 2> B = xt::zeros<double>({nv * tdim + ns, psize * tdim});
@@ -66,10 +66,10 @@ FiniteElement basix::element::create_rt(cell::type celltype, int degree,
   // polynomial basis
   for (std::size_t i = 0; i < ns; ++i)
   {
-    auto p = xt::row(phi, ns0 + i);
+    auto p = xt::col(phi, ns0 + i);
     for (std::size_t k = 0; k < psize; ++k)
     {
-      auto pk = xt::row(phi, k);
+      auto pk = xt::col(phi, k);
       for (std::size_t j = 0; j < tdim; ++j)
       {
         B(nv * tdim + i, k + psize * j)

--- a/cpp/basix/e-serendipity.cpp
+++ b/cpp/basix/e-serendipity.cpp
@@ -34,7 +34,7 @@ xt::xtensor<double, 2> make_serendipity_space_2d(int degree)
       = xt::view(polyset::tabulate(cell::type::quadrilateral, degree, 0, pts),
                  0, xt::all(), xt::all());
 
-  const std::size_t psize = Pq.shape(1);
+  const std::size_t psize = Pq.shape(0);
 
   // Create coefficients for order (degree) polynomials
   xt::xtensor<double, 2> wcoeffs = xt::zeros<double>({ndofs, psize});
@@ -48,7 +48,7 @@ xt::xtensor<double, 2> make_serendipity_space_2d(int degree)
   if (degree == 1)
   {
     for (std::size_t k = 0; k < psize; ++k)
-      wcoeffs(row_n, k) = xt::sum(wts * q0 * q1 * xt::col(Pq, k))();
+      wcoeffs(row_n, k) = xt::sum(wts * q0 * q1 * xt::row(Pq, k))();
     return wcoeffs;
   }
 
@@ -128,7 +128,7 @@ xt::xtensor<double, 2> make_serendipity_space_3d(int degree)
       = xt::view(polyset::tabulate(cell::type::hexahedron, degree, 0, pts), 0,
                  xt::all(), xt::all());
 
-  const std::size_t psize = Ph.shape(1);
+  const std::size_t psize = Ph.shape(0);
 
   // Create coefficients for order (degree) polynomials
   xt::xtensor<double, 2> wcoeffs = xt::zeros<double>({ndofs, psize});
@@ -148,7 +148,7 @@ xt::xtensor<double, 2> make_serendipity_space_3d(int degree)
     {
       for (std::size_t k = 0; k < psize; ++k)
       {
-        integrand = wts * xt::col(Ph, k);
+        integrand = wts * xt::row(Ph, k);
         for (int d = 0; d < 3; ++d)
         {
           auto q_d = xt::col(pts, d);
@@ -178,7 +178,7 @@ xt::xtensor<double, 2> make_serendipity_div_space_2d(int degree)
       polyset::tabulate(cell::type::quadrilateral, degree + 1, 0, pts), 0,
       xt::all(), xt::all());
 
-  const std::size_t psize = Pq.shape(1);
+  const std::size_t psize = Pq.shape(0);
   const std::size_t nv = polyset::dim(cell::type::triangle, degree);
 
   // Create coefficients for order (degree) vector polynomials
@@ -200,7 +200,7 @@ xt::xtensor<double, 2> make_serendipity_div_space_2d(int degree)
   xt::xtensor<double, 1> integrand;
   for (std::size_t k = 0; k < psize; ++k)
   {
-    auto pk = xt::col(Pq, k);
+    auto pk = xt::row(Pq, k);
     for (std::size_t d = 0; d < 2; ++d)
     {
       for (std::size_t a = 0; a < 2; ++a)
@@ -239,7 +239,7 @@ xt::xtensor<double, 2> make_serendipity_div_space_3d(int degree)
       = xt::view(polyset::tabulate(cell::type::hexahedron, degree + 1, 0, pts),
                  0, xt::all(), xt::all());
 
-  const std::size_t psize = polyset_at_Qpts.shape(1);
+  const std::size_t psize = polyset_at_Qpts.shape(0);
   const std::size_t nv = polyset::dim(cell::type::tetrahedron, degree);
 
   // Create coefficients for order (degree) vector polynomials
@@ -267,7 +267,7 @@ xt::xtensor<double, 2> make_serendipity_div_space_3d(int degree)
   xt::xtensor<double, 1> integrand;
   for (std::size_t k = 0; k < psize; ++k)
   {
-    auto pk = xt::col(polyset_at_Qpts, k);
+    auto pk = xt::row(polyset_at_Qpts, k);
     for (std::size_t d = 0; d < 3; ++d)
     {
       for (std::size_t a = 0; a < 3; ++a)
@@ -341,7 +341,7 @@ xt::xtensor<double, 2> make_serendipity_curl_space_2d(int degree)
       polyset::tabulate(cell::type::quadrilateral, degree + 1, 0, pts), 0,
       xt::all(), xt::all());
 
-  const std::size_t psize = polyset_at_Qpts.shape(1);
+  const std::size_t psize = polyset_at_Qpts.shape(0);
   const std::size_t nv = polyset::dim(cell::type::triangle, degree);
 
   // Create coefficients for order (degree) vector polynomials
@@ -363,7 +363,7 @@ xt::xtensor<double, 2> make_serendipity_curl_space_2d(int degree)
   xt::xtensor<double, 1> integrand;
   for (std::size_t k = 0; k < psize; ++k)
   {
-    auto pk = xt::col(polyset_at_Qpts, k);
+    auto pk = xt::row(polyset_at_Qpts, k);
     for (std::size_t d = 0; d < 2; ++d)
     {
       for (std::size_t a = 0; a < 2; ++a)
@@ -405,7 +405,7 @@ xt::xtensor<double, 2> make_serendipity_curl_space_3d(int degree)
       = xt::view(polyset::tabulate(cell::type::hexahedron, degree + 1, 0, pts),
                  0, xt::all(), xt::all());
 
-  const std::size_t psize = polyset_at_Qpts.shape(1);
+  const std::size_t psize = polyset_at_Qpts.shape(0);
   const std::size_t nv = polyset::dim(cell::type::tetrahedron, degree);
 
   // Create coefficients for order (degree) vector polynomials
@@ -433,7 +433,7 @@ xt::xtensor<double, 2> make_serendipity_curl_space_3d(int degree)
   xt::xtensor<double, 1> integrand;
   for (std::size_t k = 0; k < psize; ++k)
   {
-    auto pk = xt::col(polyset_at_Qpts, k);
+    auto pk = xt::row(polyset_at_Qpts, k);
     for (std::size_t d = 0; d < 3; ++d)
     {
       for (std::size_t a = 0; a < (degree > 1 ? 3 : 2); ++a)

--- a/cpp/basix/e-serendipity.cpp
+++ b/cpp/basix/e-serendipity.cpp
@@ -55,7 +55,7 @@ xt::xtensor<double, 2> make_serendipity_space_2d(int degree)
   xt::xtensor<double, 1> integrand;
   for (std::size_t k = 0; k < psize; ++k)
   {
-    auto pk = xt::col(Pq, k);
+    auto pk = xt::row(Pq, k);
     for (std::size_t a = 0; a < 2; ++a)
     {
       auto q_a = xt::col(pts, a);
@@ -502,7 +502,7 @@ xt::xtensor<double, 2> make_serendipity_curl_space_3d(int degree)
       {
         for (int d = 0; d < 3; ++d)
         {
-          integrand = wts * xt::col(polyset_at_Qpts, k);
+          integrand = wts * xt::row(polyset_at_Qpts, k);
           for (int d2 = 0; d2 < 3; ++d2)
           {
             auto q_d2 = xt::col(pts, d2);
@@ -1132,9 +1132,6 @@ FiniteElement basix::element::create_serendipity_curl(
   auto [Qpts, _wts] = quadrature::make_quadrature(quadrature::type::Default,
                                                   celltype, 2 * degree + 1);
   auto wts = xt::adapt(_wts);
-  xt::xtensor<double, 2> polyset_at_Qpts
-      = xt::view(polyset::tabulate(celltype, degree + 1, 0, Qpts), 0, xt::all(),
-                 xt::all());
 
   xt::xtensor<double, 2> wcoeffs;
   if (tdim == 2)

--- a/cpp/basix/e-serendipity.cpp
+++ b/cpp/basix/e-serendipity.cpp
@@ -34,7 +34,7 @@ xt::xtensor<double, 2> make_serendipity_space_2d(int degree)
       = xt::view(polyset::tabulate(cell::type::quadrilateral, degree, 0, pts),
                  0, xt::all(), xt::all());
 
-  const std::size_t psize = Pq.shape(0);
+  const std::size_t psize = Pq.shape(1);
 
   // Create coefficients for order (degree) polynomials
   xt::xtensor<double, 2> wcoeffs = xt::zeros<double>({ndofs, psize});
@@ -48,7 +48,7 @@ xt::xtensor<double, 2> make_serendipity_space_2d(int degree)
   if (degree == 1)
   {
     for (std::size_t k = 0; k < psize; ++k)
-      wcoeffs(row_n, k) = xt::sum(wts * q0 * q1 * xt::row(Pq, k))();
+      wcoeffs(row_n, k) = xt::sum(wts * q0 * q1 * xt::col(Pq, k))();
     return wcoeffs;
   }
 
@@ -128,7 +128,7 @@ xt::xtensor<double, 2> make_serendipity_space_3d(int degree)
       = xt::view(polyset::tabulate(cell::type::hexahedron, degree, 0, pts), 0,
                  xt::all(), xt::all());
 
-  const std::size_t psize = Ph.shape(0);
+  const std::size_t psize = Ph.shape(1);
 
   // Create coefficients for order (degree) polynomials
   xt::xtensor<double, 2> wcoeffs = xt::zeros<double>({ndofs, psize});
@@ -148,7 +148,7 @@ xt::xtensor<double, 2> make_serendipity_space_3d(int degree)
     {
       for (std::size_t k = 0; k < psize; ++k)
       {
-        integrand = wts * xt::row(Ph, k);
+        integrand = wts * xt::col(Ph, k);
         for (int d = 0; d < 3; ++d)
         {
           auto q_d = xt::col(pts, d);
@@ -178,7 +178,7 @@ xt::xtensor<double, 2> make_serendipity_div_space_2d(int degree)
       polyset::tabulate(cell::type::quadrilateral, degree + 1, 0, pts), 0,
       xt::all(), xt::all());
 
-  const std::size_t psize = Pq.shape(0);
+  const std::size_t psize = Pq.shape(1);
   const std::size_t nv = polyset::dim(cell::type::triangle, degree);
 
   // Create coefficients for order (degree) vector polynomials
@@ -200,7 +200,7 @@ xt::xtensor<double, 2> make_serendipity_div_space_2d(int degree)
   xt::xtensor<double, 1> integrand;
   for (std::size_t k = 0; k < psize; ++k)
   {
-    auto pk = xt::row(Pq, k);
+    auto pk = xt::col(Pq, k);
     for (std::size_t d = 0; d < 2; ++d)
     {
       for (std::size_t a = 0; a < 2; ++a)
@@ -239,7 +239,7 @@ xt::xtensor<double, 2> make_serendipity_div_space_3d(int degree)
       = xt::view(polyset::tabulate(cell::type::hexahedron, degree + 1, 0, pts),
                  0, xt::all(), xt::all());
 
-  const std::size_t psize = polyset_at_Qpts.shape(0);
+  const std::size_t psize = polyset_at_Qpts.shape(1);
   const std::size_t nv = polyset::dim(cell::type::tetrahedron, degree);
 
   // Create coefficients for order (degree) vector polynomials
@@ -267,7 +267,7 @@ xt::xtensor<double, 2> make_serendipity_div_space_3d(int degree)
   xt::xtensor<double, 1> integrand;
   for (std::size_t k = 0; k < psize; ++k)
   {
-    auto pk = xt::row(polyset_at_Qpts, k);
+    auto pk = xt::col(polyset_at_Qpts, k);
     for (std::size_t d = 0; d < 3; ++d)
     {
       for (std::size_t a = 0; a < 3; ++a)
@@ -341,7 +341,7 @@ xt::xtensor<double, 2> make_serendipity_curl_space_2d(int degree)
       polyset::tabulate(cell::type::quadrilateral, degree + 1, 0, pts), 0,
       xt::all(), xt::all());
 
-  const std::size_t psize = polyset_at_Qpts.shape(0);
+  const std::size_t psize = polyset_at_Qpts.shape(1);
   const std::size_t nv = polyset::dim(cell::type::triangle, degree);
 
   // Create coefficients for order (degree) vector polynomials
@@ -363,7 +363,7 @@ xt::xtensor<double, 2> make_serendipity_curl_space_2d(int degree)
   xt::xtensor<double, 1> integrand;
   for (std::size_t k = 0; k < psize; ++k)
   {
-    auto pk = xt::row(polyset_at_Qpts, k);
+    auto pk = xt::col(polyset_at_Qpts, k);
     for (std::size_t d = 0; d < 2; ++d)
     {
       for (std::size_t a = 0; a < 2; ++a)
@@ -405,7 +405,7 @@ xt::xtensor<double, 2> make_serendipity_curl_space_3d(int degree)
       = xt::view(polyset::tabulate(cell::type::hexahedron, degree + 1, 0, pts),
                  0, xt::all(), xt::all());
 
-  const std::size_t psize = polyset_at_Qpts.shape(0);
+  const std::size_t psize = polyset_at_Qpts.shape(1);
   const std::size_t nv = polyset::dim(cell::type::tetrahedron, degree);
 
   // Create coefficients for order (degree) vector polynomials
@@ -433,7 +433,7 @@ xt::xtensor<double, 2> make_serendipity_curl_space_3d(int degree)
   xt::xtensor<double, 1> integrand;
   for (std::size_t k = 0; k < psize; ++k)
   {
-    auto pk = xt::row(polyset_at_Qpts, k);
+    auto pk = xt::col(polyset_at_Qpts, k);
     for (std::size_t d = 0; d < 3; ++d)
     {
       for (std::size_t a = 0; a < (degree > 1 ? 3 : 2); ++a)
@@ -502,7 +502,7 @@ xt::xtensor<double, 2> make_serendipity_curl_space_3d(int degree)
       {
         for (int d = 0; d < 3; ++d)
         {
-          integrand = wts * xt::row(polyset_at_Qpts, k);
+          integrand = wts * xt::col(polyset_at_Qpts, k);
           for (int d2 = 0; d2 < 3; ++d2)
           {
             auto q_d2 = xt::col(pts, d2);

--- a/cpp/basix/e-serendipity.cpp
+++ b/cpp/basix/e-serendipity.cpp
@@ -34,7 +34,7 @@ xt::xtensor<double, 2> make_serendipity_space_2d(int degree)
       = xt::view(polyset::tabulate(cell::type::quadrilateral, degree, 0, pts),
                  0, xt::all(), xt::all());
 
-  const std::size_t psize = Pq.shape(1);
+  const std::size_t psize = Pq.shape(0);
 
   // Create coefficients for order (degree) polynomials
   xt::xtensor<double, 2> wcoeffs = xt::zeros<double>({ndofs, psize});
@@ -48,7 +48,7 @@ xt::xtensor<double, 2> make_serendipity_space_2d(int degree)
   if (degree == 1)
   {
     for (std::size_t k = 0; k < psize; ++k)
-      wcoeffs(row_n, k) = xt::sum(wts * q0 * q1 * xt::col(Pq, k))();
+      wcoeffs(row_n, k) = xt::sum(wts * q0 * q1 * xt::row(Pq, k))();
     return wcoeffs;
   }
 
@@ -128,7 +128,7 @@ xt::xtensor<double, 2> make_serendipity_space_3d(int degree)
       = xt::view(polyset::tabulate(cell::type::hexahedron, degree, 0, pts), 0,
                  xt::all(), xt::all());
 
-  const std::size_t psize = Ph.shape(1);
+  const std::size_t psize = Ph.shape(0);
 
   // Create coefficients for order (degree) polynomials
   xt::xtensor<double, 2> wcoeffs = xt::zeros<double>({ndofs, psize});
@@ -148,7 +148,7 @@ xt::xtensor<double, 2> make_serendipity_space_3d(int degree)
     {
       for (std::size_t k = 0; k < psize; ++k)
       {
-        integrand = wts * xt::col(Ph, k);
+        integrand = wts * xt::row(Ph, k);
         for (int d = 0; d < 3; ++d)
         {
           auto q_d = xt::col(pts, d);
@@ -178,7 +178,7 @@ xt::xtensor<double, 2> make_serendipity_div_space_2d(int degree)
       polyset::tabulate(cell::type::quadrilateral, degree + 1, 0, pts), 0,
       xt::all(), xt::all());
 
-  const std::size_t psize = Pq.shape(1);
+  const std::size_t psize = Pq.shape(0);
   const std::size_t nv = polyset::dim(cell::type::triangle, degree);
 
   // Create coefficients for order (degree) vector polynomials
@@ -200,7 +200,7 @@ xt::xtensor<double, 2> make_serendipity_div_space_2d(int degree)
   xt::xtensor<double, 1> integrand;
   for (std::size_t k = 0; k < psize; ++k)
   {
-    auto pk = xt::col(Pq, k);
+    auto pk = xt::row(Pq, k);
     for (std::size_t d = 0; d < 2; ++d)
     {
       for (std::size_t a = 0; a < 2; ++a)
@@ -239,7 +239,7 @@ xt::xtensor<double, 2> make_serendipity_div_space_3d(int degree)
       = xt::view(polyset::tabulate(cell::type::hexahedron, degree + 1, 0, pts),
                  0, xt::all(), xt::all());
 
-  const std::size_t psize = polyset_at_Qpts.shape(1);
+  const std::size_t psize = polyset_at_Qpts.shape(0);
   const std::size_t nv = polyset::dim(cell::type::tetrahedron, degree);
 
   // Create coefficients for order (degree) vector polynomials
@@ -267,7 +267,7 @@ xt::xtensor<double, 2> make_serendipity_div_space_3d(int degree)
   xt::xtensor<double, 1> integrand;
   for (std::size_t k = 0; k < psize; ++k)
   {
-    auto pk = xt::col(polyset_at_Qpts, k);
+    auto pk = xt::row(polyset_at_Qpts, k);
     for (std::size_t d = 0; d < 3; ++d)
     {
       for (std::size_t a = 0; a < 3; ++a)
@@ -341,7 +341,7 @@ xt::xtensor<double, 2> make_serendipity_curl_space_2d(int degree)
       polyset::tabulate(cell::type::quadrilateral, degree + 1, 0, pts), 0,
       xt::all(), xt::all());
 
-  const std::size_t psize = polyset_at_Qpts.shape(1);
+  const std::size_t psize = polyset_at_Qpts.shape(0);
   const std::size_t nv = polyset::dim(cell::type::triangle, degree);
 
   // Create coefficients for order (degree) vector polynomials
@@ -363,7 +363,7 @@ xt::xtensor<double, 2> make_serendipity_curl_space_2d(int degree)
   xt::xtensor<double, 1> integrand;
   for (std::size_t k = 0; k < psize; ++k)
   {
-    auto pk = xt::col(polyset_at_Qpts, k);
+    auto pk = xt::row(polyset_at_Qpts, k);
     for (std::size_t d = 0; d < 2; ++d)
     {
       for (std::size_t a = 0; a < 2; ++a)
@@ -405,7 +405,7 @@ xt::xtensor<double, 2> make_serendipity_curl_space_3d(int degree)
       = xt::view(polyset::tabulate(cell::type::hexahedron, degree + 1, 0, pts),
                  0, xt::all(), xt::all());
 
-  const std::size_t psize = polyset_at_Qpts.shape(1);
+  const std::size_t psize = polyset_at_Qpts.shape(0);
   const std::size_t nv = polyset::dim(cell::type::tetrahedron, degree);
 
   // Create coefficients for order (degree) vector polynomials
@@ -433,7 +433,7 @@ xt::xtensor<double, 2> make_serendipity_curl_space_3d(int degree)
   xt::xtensor<double, 1> integrand;
   for (std::size_t k = 0; k < psize; ++k)
   {
-    auto pk = xt::col(polyset_at_Qpts, k);
+    auto pk = xt::row(polyset_at_Qpts, k);
     for (std::size_t d = 0; d < 3; ++d)
     {
       for (std::size_t a = 0; a < (degree > 1 ? 3 : 2); ++a)
@@ -502,7 +502,7 @@ xt::xtensor<double, 2> make_serendipity_curl_space_3d(int degree)
       {
         for (int d = 0; d < 3; ++d)
         {
-          integrand = wts * xt::col(polyset_at_Qpts, k);
+          integrand = wts * xt::row(polyset_at_Qpts, k);
           for (int d2 = 0; d2 < 3; ++d2)
           {
             auto q_d2 = xt::col(pts, d2);

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -132,9 +132,9 @@ compute_dual_matrix(cell::type cell_type, const xt::xtensor<double, 2>& B,
       // Compute dual matrix contribution
       for (std::size_t i = 0; i < Me.shape(0); ++i)      // Dof index
         for (std::size_t j = 0; j < Me.shape(1); ++j)    // Value index
-          for (std::size_t k = 0; k < Me.shape(2); ++k)  // Point
-            for (std::size_t l = 0; l < P.shape(1); ++l) // Polynomial term
-              D(dof_index + i, j, l) += Me(i, j, k) * P(k, l);
+          for (std::size_t l = 0; l < P.shape(0); ++l) // Polynomial term
+            for (std::size_t k = 0; k < Me.shape(2); ++k)  // Point
+              D(dof_index + i, j, l) += Me(i, j, k) * P(l, k);
 
       dof_index += M[d][e].shape(0);
     }
@@ -855,20 +855,20 @@ void FiniteElement::tabulate(int nd, const xt::xtensor<double, 2>& x,
 
   const int psize = polyset::dim(_cell_type, _highest_degree);
   xt::xtensor<double, 3> basis(
-      {static_cast<std::size_t>(polyset::nderivs(_cell_type, nd)), x.shape(0),
-       static_cast<std::size_t>(psize)});
+      {static_cast<std::size_t>(polyset::nderivs(_cell_type, nd)), 
+       static_cast<std::size_t>(psize), x.shape(0)});
   polyset::tabulate(basis, _cell_type, _highest_degree, nd, x);
   const int vs = std::accumulate(_value_shape.begin(), _value_shape.end(), 1,
                                  std::multiplies<int>());
   xt::xtensor<double, 2> B, C;
-  for (std::size_t p = 0; p < basis.shape(0); ++p)
+  for (std::size_t p = 0; p < basis.shape(2); ++p)
   {
     for (int j = 0; j < vs; ++j)
     {
       auto basis_view = xt::view(basis_data, p, xt::all(), xt::all(), j);
       B = xt::view(basis, p, xt::all(), xt::all());
-      C = xt::transpose(xt::view(_coeffs, xt::all(),
-                                 xt::range(psize * j, psize * j + psize)));
+      C = xt::view(_coeffs, xt::all(),
+                                 xt::range(psize * j, psize * j + psize));
       auto result = math::dot(B, C);
       basis_view.assign(result);
     }

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -19,7 +19,6 @@
 #include <basix/version.h>
 #include <numeric>
 #include <xtensor/xbuilder.hpp>
-#include <xtensor/xio.hpp>
 
 #define str_macro(X) #X
 #define str(X) str_macro(X)

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -867,10 +867,9 @@ void FiniteElement::tabulate(int nd, const xt::xtensor<double, 2>& x,
     for (int j = 0; j < vs; ++j)
     {
       auto basis_view = xt::view(basis_data, p, xt::all(), xt::all(), j);
-      B = xt::transpose(xt::view(basis, p, xt::all(), xt::all()));
-      C = xt::transpose(xt::view(_coeffs, xt::all(),
-                                 xt::range(psize * j, psize * j + psize)));
-      auto result = math::dot(B, C);
+      B = xt::view(basis, p, xt::all(), xt::all());
+      C = xt::view(_coeffs, xt::all(), xt::range(psize * j, psize * j + psize));
+      auto result = xt::transpose(math::dot(C, B));
       basis_view.assign(result);
     }
   }

--- a/cpp/basix/lattice.cpp
+++ b/cpp/basix/lattice.cpp
@@ -155,14 +155,13 @@ xt::xtensor<double, 2> tabulate_dlagrange(int n,
     equi_pts(i, 0) = static_cast<double>(i) / static_cast<double>(n);
   xt::xtensor<double, 3> dual_values
       = polyset::tabulate(cell::type::interval, n, 0, equi_pts);
-  xt::xtensor<double, 2> dualmat({dual_values.shape(2), dual_values.shape(1)});
-  dualmat.assign(xt::view(dual_values, 0, xt::all(), xt::all()));
+  xt::xtensor<double, 2> dualmat
+      = xt::view(dual_values, 0, xt::all(), xt::all());
 
   xt::xtensor<double, 3> tabulated_values
       = polyset::tabulate(cell::type::interval, n, 0, x);
-  xt::xtensor<double, 2> tabulated(
-      {tabulated_values.shape(2), tabulated_values.shape(1)});
-  tabulated.assign(xt::view(tabulated_values, 0, xt::all(), xt::all()));
+  xt::xtensor<double, 2> tabulated
+      = xt::view(tabulated_values, 0, xt::all(), xt::all());
 
   return xt::transpose(math::solve(dualmat, tabulated));
 }

--- a/cpp/basix/lattice.cpp
+++ b/cpp/basix/lattice.cpp
@@ -156,14 +156,13 @@ xt::xtensor<double, 2> tabulate_dlagrange(int n,
   xt::xtensor<double, 3> dual_values
       = polyset::tabulate(cell::type::interval, n, 0, equi_pts);
   xt::xtensor<double, 2> dualmat({dual_values.shape(2), dual_values.shape(1)});
-  dualmat.assign(xt::transpose(xt::view(dual_values, 0, xt::all(), xt::all())));
+  dualmat.assign(xt::view(dual_values, 0, xt::all(), xt::all()));
 
   xt::xtensor<double, 3> tabulated_values
       = polyset::tabulate(cell::type::interval, n, 0, x);
   xt::xtensor<double, 2> tabulated(
       {tabulated_values.shape(2), tabulated_values.shape(1)});
-  tabulated.assign(
-      xt::transpose(xt::view(tabulated_values, 0, xt::all(), xt::all())));
+  tabulated.assign(xt::view(tabulated_values, 0, xt::all(), xt::all()));
 
   return xt::transpose(math::solve(dualmat, tabulated));
 }
@@ -640,8 +639,7 @@ xt::xtensor<double, 2> create_pyramid_gll_warped(int n, bool exterior)
     pts(i, 0) += (0.5 - static_cast<double>(i) / static_cast<double>(n));
 
   // Get interpolated value at r in range [-1, 1]
-  auto w = [&](double r) -> double
-  {
+  auto w = [&](double r) -> double {
     xt::xtensor<double, 2> rr = {{0.5 * (r + 1.0)}};
     xt::xtensor<double, 1> v
         = xt::view(tabulate_dlagrange(n, rr), 0, xt::all());

--- a/cpp/basix/lattice.cpp
+++ b/cpp/basix/lattice.cpp
@@ -163,7 +163,7 @@ xt::xtensor<double, 2> tabulate_dlagrange(int n,
   xt::xtensor<double, 2> tabulated
       = xt::view(tabulated_values, 0, xt::all(), xt::all());
 
-  return xt::transpose(math::solve(dualmat, tabulated));
+  return math::solve(dualmat, tabulated);
 }
 //-----------------------------------------------------------------------------
 xt::xtensor<double, 1> warp_function(lattice::type lattice_type, int n,
@@ -172,13 +172,12 @@ xt::xtensor<double, 1> warp_function(lattice::type lattice_type, int n,
   xt::xtensor<double, 2> pts = create_interval(n, lattice_type, true);
   for (int i = 0; i < n + 1; ++i)
     pts(i, 0) -= static_cast<double>(i) / static_cast<double>(n);
-
   const xt::xtensor<double, 2> v = tabulate_dlagrange(n, x);
 
-  xt::xtensor<double, 1> w = xt::zeros<double>({v.shape(0)});
+  xt::xtensor<double, 1> w = xt::zeros<double>({v.shape(1)});
   for (std::size_t i = 0; i < v.shape(0); ++i)
     for (std::size_t j = 0; j < v.shape(1); ++j)
-      w[i] += v(i, j) * pts(j, 0);
+      w[j] += v(i, j) * pts(i, 0);
 
   return w;
 }
@@ -641,7 +640,7 @@ xt::xtensor<double, 2> create_pyramid_gll_warped(int n, bool exterior)
   auto w = [&](double r) -> double {
     xt::xtensor<double, 2> rr = {{0.5 * (r + 1.0)}};
     xt::xtensor<double, 1> v
-        = xt::view(tabulate_dlagrange(n, rr), 0, xt::all());
+        = xt::view(tabulate_dlagrange(n, rr), xt::all(), 0);
     double d = 0.0;
     for (std::size_t i = 0; i < pts.shape(0); ++i)
       d += v[i] * pts(i, 0);

--- a/cpp/basix/polynomials.cpp
+++ b/cpp/basix/polynomials.cpp
@@ -16,8 +16,8 @@ xt::xtensor<double, 2> polynomials::tabulate(polynomials::type polytype,
   switch (polytype)
   {
   case polynomials::type::legendre:
-    return xt::view(polyset::tabulate(celltype, d, 0, x), 0, xt::all(),
-                    xt::all());
+    return xt::transpose(xt::view(polyset::tabulate(celltype, d, 0, x), 0,
+                                  xt::all(), xt::all()));
   default:
     throw std::runtime_error("not implemented yet");
   }

--- a/cpp/basix/polyset.cpp
+++ b/cpp/basix/polyset.cpp
@@ -55,7 +55,7 @@ void tabulate_polyset_line_derivs(xt::xtensor<double, 3>& P, std::size_t n,
   assert(P.shape(0) == nderiv + 1);
   assert(P.shape(1) == n + 1);
   assert(P.shape(2) == x.shape(0));
-  
+
   std::fill(P.begin(), P.end(), 0.0);
   xt::view(P, 0, 0, xt::all()) = 1.0;
   const auto x0 = xt::col(x, 0);
@@ -64,7 +64,7 @@ void tabulate_polyset_line_derivs(xt::xtensor<double, 3>& P, std::size_t n,
 
   { // scope
     auto result = xt::view(P, 0, xt::all(), xt::all());
-    xt::row(result, 1) = (x0 * 2.0 - 1.0) * xt::col(result, 0);
+    xt::row(result, 1) = (x0 * 2.0 - 1.0) * xt::row(result, 0);
     for (std::size_t p = 2; p <= n; ++p)
     {
       const double a = 1.0 - 1.0 / static_cast<double>(p);
@@ -80,8 +80,8 @@ void tabulate_polyset_line_derivs(xt::xtensor<double, 3>& P, std::size_t n,
     for (std::size_t p = 1; p <= n; ++p)
     {
       const double a = 1.0 - 1.0 / static_cast<double>(p);
-      xt::row(result, p) = (x0 * 2.0 - 1.0) * xt::col(result, p - 1) * (a + 1.0)
-                           + 2 * k * xt::col(result0, p - 1) * (a + 1.0)
+      xt::row(result, p) = (x0 * 2.0 - 1.0) * xt::row(result, p - 1) * (a + 1.0)
+                           + 2 * k * xt::row(result0, p - 1) * (a + 1.0)
                            - xt::row(result, p - 2) * a;
     }
   }
@@ -134,11 +134,11 @@ void tabulate_polyset_triangle_derivs(xt::xtensor<double, 3>& P, std::size_t n,
         const double a
             = static_cast<double>(2 * p - 1) / static_cast<double>(p);
         p0 = ((x0 * 2.0 - 1.0) + 0.5 * (x1 * 2.0 - 1.0) + 0.5)
-          * xt::view(P, idx(kx, ky), idx(0, p - 1), xt::all()) * a;
+             * xt::view(P, idx(kx, ky), idx(0, p - 1), xt::all()) * a;
         if (kx > 0)
         {
           p0 += 2 * kx * a
-            * xt::view(P, idx(kx - 1, ky), idx(0, p - 1), xt::all());
+                * xt::view(P, idx(kx - 1, ky), idx(0, p - 1), xt::all());
         }
 
         if (ky > 0)
@@ -149,19 +149,19 @@ void tabulate_polyset_triangle_derivs(xt::xtensor<double, 3>& P, std::size_t n,
         if (p > 1)
         {
           // y^2 terms
-          p0 -= f3 * xt::view(P, idx(kx, ky),  idx(0, p - 2), xt::all())
+          p0 -= f3 * xt::view(P, idx(kx, ky), idx(0, p - 2), xt::all())
                 * (a - 1.0);
           if (ky > 0)
           {
             p0 -= ky * ((x1 * 2.0 - 1.0) - 1.0)
-              * xt::view(P, idx(kx, ky - 1), idx(0, p - 2), xt::all())
+                  * xt::view(P, idx(kx, ky - 1), idx(0, p - 2), xt::all())
                   * (a - 1.0);
           }
 
           if (ky > 1)
           {
             p0 -= ky * (ky - 1)
-              * xt::view(P, idx(kx, ky - 2), idx(0, p - 2), xt::all())
+                  * xt::view(P, idx(kx, ky - 2), idx(0, p - 2), xt::all())
                   * (a - 1.0);
           }
         }
@@ -169,27 +169,27 @@ void tabulate_polyset_triangle_derivs(xt::xtensor<double, 3>& P, std::size_t n,
 
       for (std::size_t p = 0; p < n; ++p)
       {
-        auto p0 = xt::view(P, idx(kx, ky),idx(0, p), xt::all());
+        auto p0 = xt::view(P, idx(kx, ky), idx(0, p), xt::all());
         auto p1 = xt::view(P, idx(kx, ky), idx(1, p), xt::all());
         p1 = p0 * ((x1 * 2.0 - 1.0) * (1.5 + p) + 0.5 + p);
         if (ky > 0)
         {
           p1 += 2 * ky * (1.5 + p)
-            * xt::view(P, idx(kx, ky - 1), idx(0, p), xt::all());
+                * xt::view(P, idx(kx, ky - 1), idx(0, p), xt::all());
         }
 
         for (std::size_t q = 1; q < n - p; ++q)
         {
           const auto [a1, a2, a3] = jrc(2 * p + 1, q);
           xt::view(P, idx(kx, ky), idx(q + 1, p), xt::all())
-            = xt::view(P, idx(kx, ky), idx(q, p), xt::all())
+              = xt::view(P, idx(kx, ky), idx(q, p), xt::all())
                     * ((x1 * 2.0 - 1.0) * a1 + a2)
-            - xt::view(P, idx(kx, ky), idx(q - 1, p), xt::all()) * a3;
+                - xt::view(P, idx(kx, ky), idx(q - 1, p), xt::all()) * a3;
           if (ky > 0)
           {
             xt::view(P, idx(kx, ky), idx(q + 1, p), xt::all())
                 += 2 * ky * a1
-              * xt::view(P, idx(kx, ky - 1), idx(q, p), xt::all());
+                   * xt::view(P, idx(kx, ky - 1), idx(q, p), xt::all());
           }
         }
       }
@@ -211,7 +211,6 @@ void tabulate_polyset_tetrahedron_derivs(xt::xtensor<double, 3>& P,
   assert(P.shape(0) == (nderiv + 1) * (nderiv + 2) * (nderiv + 3) / 6);
   assert(P.shape(1) == (n + 1) * (n + 2) * (n + 3) / 6);
   assert(P.shape(2) == x.shape(0));
-
 
   const auto x0 = xt::col(x, 0);
   const auto x1 = xt::col(x, 1);
@@ -244,70 +243,70 @@ void tabulate_polyset_tetrahedron_derivs(xt::xtensor<double, 3>& P,
           double a = static_cast<double>(2 * p - 1) / static_cast<double>(p);
           p00 = ((x0 * 2.0 - 1.0) + 0.5 * ((x1 * 2.0 - 1.0) + (x2 * 2.0 - 1.0))
                  + 1.0)
-            * xt::view(P, idx(kx, ky, kz), idx(0, 0, p - 1), xt::all()) * a;
+                * xt::view(P, idx(kx, ky, kz), idx(0, 0, p - 1), xt::all()) * a;
           if (kx > 0)
           {
             p00 += 2 * kx * a
-                   * xt::view(P, idx(kx - 1, ky, kz), 
-                              idx(0, 0, p - 1),xt::all());
+                   * xt::view(P, idx(kx - 1, ky, kz), idx(0, 0, p - 1),
+                              xt::all());
           }
 
           if (ky > 0)
           {
             p00 += ky * a
-                   * xt::view(P, idx(kx, ky - 1, kz), 
-                              idx(0, 0, p - 1), xt::all());
+                   * xt::view(P, idx(kx, ky - 1, kz), idx(0, 0, p - 1),
+                              xt::all());
           }
 
           if (kz > 0)
           {
             p00 += kz * a
-                   * xt::view(P, idx(kx, ky, kz - 1), 
-                              idx(0, 0, p - 1),xt::all());
+                   * xt::view(P, idx(kx, ky, kz - 1), idx(0, 0, p - 1),
+                              xt::all());
           }
 
           if (p > 1)
           {
             p00 -= f2
-              * xt::view(P, idx(kx, ky, kz), idx(0, 0, p - 2), xt::all())
+                   * xt::view(P, idx(kx, ky, kz), idx(0, 0, p - 2), xt::all())
                    * (a - 1.0);
             if (ky > 0)
             {
               p00 -= ky * ((x1 * 2.0 - 1.0) + (x2 * 2.0 - 1.0))
-                     * xt::view(P, idx(kx, ky - 1, kz), 
-                                idx(0, 0, p - 2), xt::all())
+                     * xt::view(P, idx(kx, ky - 1, kz), idx(0, 0, p - 2),
+                                xt::all())
                      * (a - 1.0);
             }
 
             if (ky > 1)
             {
               p00 -= ky * (ky - 1)
-                     * xt::view(P, idx(kx, ky - 2, kz), 
-                                idx(0, 0, p - 2), xt::all())
+                     * xt::view(P, idx(kx, ky - 2, kz), idx(0, 0, p - 2),
+                                xt::all())
                      * (a - 1.0);
             }
 
             if (kz > 0)
             {
               p00 -= kz * ((x1 * 2.0 - 1.0) + (x2 * 2.0 - 1.0))
-                     * xt::view(P, idx(kx, ky, kz - 1), 
-                                idx(0, 0, p - 2), xt::all())
+                     * xt::view(P, idx(kx, ky, kz - 1), idx(0, 0, p - 2),
+                                xt::all())
                      * (a - 1.0);
             }
 
             if (kz > 1)
             {
               p00 -= kz * (kz - 1)
-                     * xt::view(P, idx(kx, ky, kz - 2),
-                                idx(0, 0, p - 2), xt::all())
+                     * xt::view(P, idx(kx, ky, kz - 2), idx(0, 0, p - 2),
+                                xt::all())
                      * (a - 1.0);
             }
 
             if (ky > 0 and kz > 0)
             {
               p00 -= 2.0 * ky * kz
-                     * xt::view(P, idx(kx, ky - 1, kz - 1), 
-                                idx(0, 0, p - 2), xt::all())
+                     * xt::view(P, idx(kx, ky - 1, kz - 1), idx(0, 0, p - 2),
+                                xt::all())
                      * (a - 1.0);
             }
           }
@@ -315,49 +314,49 @@ void tabulate_polyset_tetrahedron_derivs(xt::xtensor<double, 3>& P,
 
         for (std::size_t p = 0; p < n; ++p)
         {
-          auto p10 = xt::view(P, idx(kx, ky, kz), xt::all(), idx(0, 1, p));
+          auto p10 = xt::view(P, idx(kx, ky, kz), idx(0, 1, p), xt::all());
           p10 = xt::view(P, idx(kx, ky, kz), idx(0, 0, p), xt::all())
                 * ((1.0 + (x1 * 2.0 - 1.0)) * p
                    + (2.0 + (x1 * 2.0 - 1.0) * 3.0 + (x2 * 2.0 - 1.0)) * 0.5);
           if (ky > 0)
           {
             p10 += 2 * ky
-              * xt::view(P, idx(kx, ky - 1, kz), idx(0, 0, p), xt::all())
+                   * xt::view(P, idx(kx, ky - 1, kz), idx(0, 0, p), xt::all())
                    * (1.5 + p);
           }
 
           if (kz > 0)
           {
             p10 += kz
-              * xt::view(P, idx(kx, ky, kz - 1), idx(0, 0, p), xt::all());
+                   * xt::view(P, idx(kx, ky, kz - 1), idx(0, 0, p), xt::all());
           }
 
           for (std::size_t q = 1; q < n - p; ++q)
           {
             auto [aq, bq, cq] = jrc(2 * p + 1, q);
             auto pq1
-              = xt::view(P, idx(kx, ky, kz),  idx(0, q + 1, p), xt::all());
+                = xt::view(P, idx(kx, ky, kz), idx(0, q + 1, p), xt::all());
             pq1 = xt::view(P, idx(kx, ky, kz), idx(0, q, p), xt::all())
                       * (f3 * aq + f4 * bq)
-              - xt::view(P, idx(kx, ky, kz), idx(0, q - 1, p), xt::all())
+                  - xt::view(P, idx(kx, ky, kz), idx(0, q - 1, p), xt::all())
                         * f5 * cq;
 
             if (ky > 0)
             {
               pq1 += 2 * ky
-                * xt::view(P, idx(kx, ky - 1, kz), idx(0, q, p), xt::all())
+                     * xt::view(P, idx(kx, ky - 1, kz), idx(0, q, p), xt::all())
                      * aq;
             }
 
             if (kz > 0)
             {
               pq1 += kz
-                         * xt::view(P, idx(kx, ky, kz - 1), 
-                                    idx(0, q, p), xt::all())
+                         * xt::view(P, idx(kx, ky, kz - 1), idx(0, q, p),
+                                    xt::all())
                          * (aq - bq)
                      + kz * (1.0 - (x2 * 2.0 - 1.0))
-                           * xt::view(P, idx(kx, ky, kz - 1), 
-                                      idx(0, q - 1, p), xt::all())
+                           * xt::view(P, idx(kx, ky, kz - 1), idx(0, q - 1, p),
+                                      xt::all())
                            * cq;
             }
 
@@ -365,8 +364,8 @@ void tabulate_polyset_tetrahedron_derivs(xt::xtensor<double, 3>& P,
             {
               // Quadratic term in z
               pq1 -= kz * (kz - 1)
-                     * xt::view(P, idx(kx, ky, kz - 2),
-                                idx(0, q - 1, p), xt::all())
+                     * xt::view(P, idx(kx, ky, kz - 2), idx(0, q - 1, p),
+                                xt::all())
                      * cq;
             }
           }
@@ -377,12 +376,12 @@ void tabulate_polyset_tetrahedron_derivs(xt::xtensor<double, 3>& P,
           for (std::size_t q = 0; q < n - p; ++q)
           {
             auto pq = xt::view(P, idx(kx, ky, kz), idx(1, q, p), xt::all());
-            pq = xt::view(P, idx(kx, ky, kz),  idx(0, q, p), xt::all())
+            pq = xt::view(P, idx(kx, ky, kz), idx(0, q, p), xt::all())
                  * ((1.0 + p + q) + (x2 * 2.0 - 1.0) * (2.0 + p + q));
             if (kz > 0)
             {
               pq += 2 * kz * (2.0 + p + q)
-                * xt::view(P, idx(kx, ky, kz - 1), idx(0, q, p), xt::all());
+                    * xt::view(P, idx(kx, ky, kz - 1), idx(0, q, p), xt::all());
             }
           }
         }
@@ -395,16 +394,16 @@ void tabulate_polyset_tetrahedron_derivs(xt::xtensor<double, 3>& P,
             {
               auto [ar, br, cr] = jrc(2 * p + 2 * q + 2, r);
               xt::view(P, idx(kx, ky, kz), idx(r + 1, q, p), xt::all())
-                = xt::view(P, idx(kx, ky, kz), idx(r, q, p), xt::all())
+                  = xt::view(P, idx(kx, ky, kz), idx(r, q, p), xt::all())
                         * ((x2 * 2.0 - 1.0) * ar + br)
-                - xt::view(P, idx(kx, ky, kz),  idx(r - 1, q, p), xt::all())
+                    - xt::view(P, idx(kx, ky, kz), idx(r - 1, q, p), xt::all())
                           * cr;
               if (kz > 0)
               {
                 xt::view(P, idx(kx, ky, kz), idx(r + 1, q, p), xt::all())
                     += 2 * kz * ar
-                       * xt::view(P, idx(kx, ky, kz - 1), 
-                                  idx(r, q, p), xt::all());
+                       * xt::view(P, idx(kx, ky, kz - 1), idx(r, q, p),
+                                  xt::all());
               }
             }
           }
@@ -437,8 +436,8 @@ void tabulate_polyset_pyramid_derivs(xt::xtensor<double, 3>& P, std::size_t n,
   assert(P.shape(2) == x.shape(0));
 
   // Indexing for pyramidal basis functions
-  auto pyr_idx = [n](std::size_t p, std::size_t q, std::size_t r) -> std::size_t
-  {
+  auto pyr_idx
+      = [n](std::size_t p, std::size_t q, std::size_t r) -> std::size_t {
     const std::size_t rv = n - r + 1;
     const std::size_t r0
         = r * (n + 1) * (n - r + 2) + (2 * r - 1) * (r - 1) * r / 6;
@@ -478,40 +477,40 @@ void tabulate_polyset_pyramid_derivs(xt::xtensor<double, 3>& P, std::size_t n,
             const double a
                 = static_cast<double>(p - 1) / static_cast<double>(p);
             auto p00
-              = xt::view(P, idx(kx, ky, kz),  pyr_idx(p, 0, 0), xt::all());
+                = xt::view(P, idx(kx, ky, kz), pyr_idx(p, 0, 0), xt::all());
             p00 = (0.5 + (x0 * 2.0 - 1.0) + (x2 * 2.0 - 1.0) * 0.5)
-                  * xt::view(P, idx(kx, ky, kz),
-                             pyr_idx(p - 1, 0, 0), xt::all())
+                  * xt::view(P, idx(kx, ky, kz), pyr_idx(p - 1, 0, 0),
+                             xt::all())
                   * (a + 1.0);
 
             if (kx > 0)
             {
               p00 += 2.0 * kx
-                     * xt::view(P, idx(kx - 1, ky, kz),
-                                pyr_idx(p - 1, 0, 0), xt::all())
+                     * xt::view(P, idx(kx - 1, ky, kz), pyr_idx(p - 1, 0, 0),
+                                xt::all())
                      * (a + 1.0);
             }
 
             if (kz > 0)
             {
               p00 += kz
-                     * xt::view(P, idx(kx, ky, kz - 1),
-                                pyr_idx(p - 1, 0, 0), xt::all())
+                     * xt::view(P, idx(kx, ky, kz - 1), pyr_idx(p - 1, 0, 0),
+                                xt::all())
                      * (a + 1.0);
             }
 
             if (p > 1)
             {
               p00 -= f2
-                     * xt::view(P, idx(kx, ky, kz),
-                                pyr_idx(p - 2, 0, 0), xt::all())
+                     * xt::view(P, idx(kx, ky, kz), pyr_idx(p - 2, 0, 0),
+                                xt::all())
                      * a;
 
               if (kz > 0)
               {
                 p00 += kz * (1.0 - (x2 * 2.0 - 1.0))
-                       * xt::view(P, idx(kx, ky, kz - 1),
-                                  pyr_idx(p - 2, 0, 0), xt::all())
+                       * xt::view(P, idx(kx, ky, kz - 1), pyr_idx(p - 2, 0, 0),
+                                  xt::all())
                        * a;
               }
 
@@ -519,8 +518,8 @@ void tabulate_polyset_pyramid_derivs(xt::xtensor<double, 3>& P, std::size_t n,
               {
                 // quadratic term in z
                 p00 -= kz * (kz - 1)
-                       * xt::view(P, idx(kx, ky, kz - 2),
-                                  pyr_idx(p - 2, 0, 0), xt::all())
+                       * xt::view(P, idx(kx, ky, kz - 2), pyr_idx(p - 2, 0, 0),
+                                  xt::all())
                        * a;
               }
             }
@@ -531,47 +530,47 @@ void tabulate_polyset_pyramid_derivs(xt::xtensor<double, 3>& P, std::size_t n,
             const double a
                 = static_cast<double>(q - 1) / static_cast<double>(q);
             auto r_pq
-              = xt::view(P, idx(kx, ky, kz),  pyr_idx(p, q, 0), xt::all());
+                = xt::view(P, idx(kx, ky, kz), pyr_idx(p, q, 0), xt::all());
             r_pq = (0.5 + (x1 * 2.0 - 1.0) + (x2 * 2.0 - 1.0) * 0.5)
-                   * xt::view(P, idx(kx, ky, kz), 
-                              pyr_idx(p, q - 1, 0), xt::all())
+                   * xt::view(P, idx(kx, ky, kz), pyr_idx(p, q - 1, 0),
+                              xt::all())
                    * (a + 1.0);
             if (ky > 0)
             {
               r_pq += 2.0 * ky
-                      * xt::view(P, idx(kx, ky - 1, kz),
-                                 pyr_idx(p, q - 1, 0), xt::all())
+                      * xt::view(P, idx(kx, ky - 1, kz), pyr_idx(p, q - 1, 0),
+                                 xt::all())
                       * (a + 1.0);
             }
 
             if (kz > 0)
             {
               r_pq += kz
-                      * xt::view(P, idx(kx, ky, kz - 1),
-                                 pyr_idx(p, q - 1, 0), xt::all())
+                      * xt::view(P, idx(kx, ky, kz - 1), pyr_idx(p, q - 1, 0),
+                                 xt::all())
                       * (a + 1.0);
             }
 
             if (q > 1)
             {
               r_pq -= f2
-                      * xt::view(P, idx(kx, ky, kz),
-                                 pyr_idx(p, q - 2, 0), xt::all())
+                      * xt::view(P, idx(kx, ky, kz), pyr_idx(p, q - 2, 0),
+                                 xt::all())
                       * a;
 
               if (kz > 0)
               {
                 r_pq += kz * (1.0 - (x2 * 2.0 - 1.0))
-                        * xt::view(P, idx(kx, ky, kz - 1),
-                                   pyr_idx(p, q - 2, 0), xt::all())
+                        * xt::view(P, idx(kx, ky, kz - 1), pyr_idx(p, q - 2, 0),
+                                   xt::all())
                         * a;
               }
 
               if (kz > 1)
               {
                 r_pq -= kz * (kz - 1)
-                        * xt::view(P, idx(kx, ky, kz - 2), 
-                                   pyr_idx(p, q - 2, 0), xt::all())
+                        * xt::view(P, idx(kx, ky, kz - 2), pyr_idx(p, q - 2, 0),
+                                   xt::all())
                         * a;
               }
             }
@@ -584,14 +583,14 @@ void tabulate_polyset_pyramid_derivs(xt::xtensor<double, 3>& P, std::size_t n,
           for (std::size_t q = 0; q < n; ++q)
           {
             auto r_pq1
-              = xt::view(P, idx(kx, ky, kz), pyr_idx(p, q, 1), xt::all());
+                = xt::view(P, idx(kx, ky, kz), pyr_idx(p, q, 1), xt::all());
             r_pq1 = xt::view(P, idx(kx, ky, kz), pyr_idx(p, q, 0), xt::all())
                     * ((1.0 + p + q) + (x2 * 2.0 - 1.0) * (2.0 + p + q));
             if (kz > 0)
             {
               r_pq1 += 2 * kz
-                       * xt::view(P, idx(kx, ky, kz - 1),
-                                  pyr_idx(p, q, 0), xt::all())
+                       * xt::view(P, idx(kx, ky, kz - 1), pyr_idx(p, q, 0),
+                                  xt::all())
                        * (2.0 + p + q);
             }
           }
@@ -604,18 +603,18 @@ void tabulate_polyset_pyramid_derivs(xt::xtensor<double, 3>& P, std::size_t n,
             for (std::size_t q = 0; q < n - r; ++q)
             {
               auto [ar, br, cr] = jrc(2 * p + 2 * q + 2, r);
-              auto r_pqr = xt::view(P, idx(kx, ky, kz),
-                                    pyr_idx(p, q, r + 1), xt::all());
+              auto r_pqr = xt::view(P, idx(kx, ky, kz), pyr_idx(p, q, r + 1),
+                                    xt::all());
               r_pqr = xt::view(P, idx(kx, ky, kz), pyr_idx(p, q, r), xt::all())
                           * ((x2 * 2.0 - 1.0) * ar + br)
-                      - xt::view(P, idx(kx, ky, kz),
-                                 pyr_idx(p, q, r - 1), xt::all())
+                      - xt::view(P, idx(kx, ky, kz), pyr_idx(p, q, r - 1),
+                                 xt::all())
                             * cr;
               if (kz > 0)
               {
                 r_pqr += ar * 2 * kz
-                         * xt::view(P, idx(kx, ky, kz - 1),
-                                    pyr_idx(p, q, r), xt::all());
+                         * xt::view(P, idx(kx, ky, kz - 1), pyr_idx(p, q, r),
+                                    xt::all());
               }
             }
           }
@@ -645,10 +644,11 @@ void tabulate_polyset_quad_derivs(xt::xtensor<double, 3>& P, std::size_t n,
   assert(P.shape(0) == (nderiv + 1) * (nderiv + 2) / 2);
   assert(P.shape(1) == (n + 1) * (n + 1));
   assert(P.shape(2) == x.shape(0));
-  
+
   // Indexing for quadrilateral basis functions
-  auto quad_idx = [n](std::size_t px, std::size_t py) -> std::size_t
-  { return (n + 1) * px + py; };
+  auto quad_idx = [n](std::size_t px, std::size_t py) -> std::size_t {
+    return (n + 1) * px + py;
+  };
 
   // Compute 1D basis
   const auto x0 = xt::col(x, 0);
@@ -673,7 +673,7 @@ void tabulate_polyset_quad_derivs(xt::xtensor<double, 3>& P, std::size_t n,
       const double a = 1.0 - 1.0 / static_cast<double>(py);
       xt::row(result, quad_idx(0, py))
           = (x1 * 2.0 - 1.0) * xt::row(result, quad_idx(0, py - 1)) * (a + 1.0)
-        - xt::row(result, quad_idx(0, py - 2)) * a;
+            - xt::row(result, quad_idx(0, py - 2)) * a;
     }
   }
   for (std::size_t ky = 1; ky <= nderiv; ++ky)
@@ -773,8 +773,9 @@ void tabulate_polyset_hex_derivs(xt::xtensor<double, 3>& P, std::size_t n,
 
   // Indexing for hexahedral basis functions
   auto hex_idx
-      = [n](std::size_t px, std::size_t py, std::size_t pz) -> std::size_t
-  { return (n + 1) * (n + 1) * px + (n + 1) * py + pz; };
+      = [n](std::size_t px, std::size_t py, std::size_t pz) -> std::size_t {
+    return (n + 1) * (n + 1) * px + (n + 1) * py + pz;
+  };
 
   // Compute 1D basis
   const auto x0 = xt::col(x, 0);
@@ -947,7 +948,7 @@ void tabulate_polyset_hex_derivs(xt::xtensor<double, 3>& P, std::size_t n,
             for (std::size_t pz = 0; pz <= n; ++pz)
             {
               xt::row(result, hex_idx(1, py, pz))
-                = (x0 * 2.0 - 1.0) * xt::row(result, hex_idx(0, py, pz))
+                  = (x0 * 2.0 - 1.0) * xt::row(result, hex_idx(0, py, pz))
                     + 2 * kx * xt::row(result0, hex_idx(0, py, pz));
             }
           }
@@ -1010,8 +1011,9 @@ void tabulate_polyset_prism_derivs(xt::xtensor<double, 3>& P, std::size_t n,
 
   // Indexing for hexahedral basis functions
   auto prism_idx
-      = [n](std::size_t px, std::size_t py, std::size_t pz) -> std::size_t
-  { return (n + 1) * idx(py, px) + pz; };
+      = [n](std::size_t px, std::size_t py, std::size_t pz) -> std::size_t {
+    return (n + 1) * idx(py, px) + pz;
+  };
 
   // f3 = ((1 - y) / 2)^2
   const auto f3 = xt::square(1.0 - (x1 * 2.0 - 1.0)) * 0.25;
@@ -1037,19 +1039,19 @@ void tabulate_polyset_prism_derivs(xt::xtensor<double, 3>& P, std::size_t n,
         const double a
             = static_cast<double>(2 * p - 1) / static_cast<double>(p);
         p0 = ((x0 * 2.0 - 1.0) + 0.5 * (x1 * 2.0 - 1.0) + 0.5)
-          * xt::view(P, idx(kx, ky, 0),  prism_idx(p - 1, 0, 0), xt::all())
+             * xt::view(P, idx(kx, ky, 0), prism_idx(p - 1, 0, 0), xt::all())
              * a;
         if (kx > 0)
         {
-          auto result0 = xt::view(P, idx(kx - 1, ky, 0),
-                                  prism_idx(p - 1, 0, 0), xt::all());
+          auto result0 = xt::view(P, idx(kx - 1, ky, 0), prism_idx(p - 1, 0, 0),
+                                  xt::all());
           p0 += 2 * kx * a * result0;
         }
 
         if (ky > 0)
         {
-          auto result0 = xt::view(P, idx(kx, ky - 1, 0),
-                                  prism_idx(p - 1, 0, 0), xt::all());
+          auto result0 = xt::view(P, idx(kx, ky - 1, 0), prism_idx(p - 1, 0, 0),
+                                  xt::all());
           p0 += ky * a * result0;
         }
 
@@ -1057,18 +1059,18 @@ void tabulate_polyset_prism_derivs(xt::xtensor<double, 3>& P, std::size_t n,
         {
           // y^2 terms
           p0 -= f3
-            * xt::view(P, idx(kx, ky, 0),  prism_idx(p - 2, 0, 0), xt::all())
+                * xt::view(P, idx(kx, ky, 0), prism_idx(p - 2, 0, 0), xt::all())
                 * (a - 1.0);
           if (ky > 0)
           {
-            auto result0 = xt::view(P, idx(kx, ky - 1, 0), 
+            auto result0 = xt::view(P, idx(kx, ky - 1, 0),
                                     prism_idx(p - 2, 0, 0), xt::all());
             p0 -= ky * ((x1 * 2.0 - 1.0) - 1.0) * result0 * (a - 1.0);
           }
 
           if (ky > 1)
           {
-            auto result0 = xt::view(P, idx(kx, ky - 2, 0), 
+            auto result0 = xt::view(P, idx(kx, ky - 2, 0),
                                     prism_idx(p - 2, 0, 0), xt::all());
             p0 -= ky * (ky - 1) * result0 * (a - 1.0);
           }
@@ -1078,12 +1080,12 @@ void tabulate_polyset_prism_derivs(xt::xtensor<double, 3>& P, std::size_t n,
       for (std::size_t p = 0; p < n; ++p)
       {
         auto p0 = xt::view(P, idx(kx, ky, 0), prism_idx(p, 0, 0), xt::all());
-        auto p1 = xt::view(P, idx(kx, ky, 0),  prism_idx(p, 1, 0), xt::all());
+        auto p1 = xt::view(P, idx(kx, ky, 0), prism_idx(p, 1, 0), xt::all());
         p1 = p0 * ((x1 * 2.0 - 1.0) * (1.5 + p) + 0.5 + p);
         if (ky > 0)
         {
           auto result0
-            = xt::view(P, idx(kx, ky - 1, 0), prism_idx(p, 0, 0), xt::all());
+              = xt::view(P, idx(kx, ky - 1, 0), prism_idx(p, 0, 0), xt::all());
           p1 += 2 * ky * (1.5 + p) * result0;
         }
 
@@ -1091,14 +1093,14 @@ void tabulate_polyset_prism_derivs(xt::xtensor<double, 3>& P, std::size_t n,
         {
           const auto [a1, a2, a3] = jrc(2 * p + 1, q);
           xt::view(P, idx(kx, ky, 0), prism_idx(p, q + 1, 0), xt::all())
-            = xt::view(P, idx(kx, ky, 0),  prism_idx(p, q, 0), xt::all())
+              = xt::view(P, idx(kx, ky, 0), prism_idx(p, q, 0), xt::all())
                     * ((x1 * 2.0 - 1.0) * a1 + a2)
-            - xt::view(P, idx(kx, ky, 0),  prism_idx(p, q - 1, 0), xt::all())
+                - xt::view(P, idx(kx, ky, 0), prism_idx(p, q - 1, 0), xt::all())
                       * a3;
           if (ky > 0)
           {
-            auto result0 = xt::view(P, idx(kx, ky - 1, 0),
-                                    prism_idx(p, q, 0), xt::all());
+            auto result0 = xt::view(P, idx(kx, ky - 1, 0), prism_idx(p, q, 0),
+                                    xt::all());
             xt::view(P, idx(kx, ky, 0), prism_idx(p, q + 1, 0), xt::all())
                 += 2 * ky * a1 * result0;
           }
@@ -1179,7 +1181,7 @@ xt::xtensor<double, 3> polyset::tabulate(cell::type celltype, int d, int n,
                                          const xt::xtensor<double, 2>& x)
 {
   xt::xtensor<double, 3> out(
-      {static_cast<std::size_t>(polyset::nderivs(celltype, n)), 
+      {static_cast<std::size_t>(polyset::nderivs(celltype, n)),
        static_cast<std::size_t>(polyset::dim(celltype, d)), x.shape(0)});
   polyset::tabulate(out, celltype, d, n, x);
   return out;

--- a/cpp/basix/polyset.cpp
+++ b/cpp/basix/polyset.cpp
@@ -35,11 +35,11 @@ void tabulate_polyset_point_derivs(xt::xtensor<double, 3>& P, std::size_t,
 {
   assert(x.shape(0) > 0);
   assert(P.shape(0) == nderiv + 1);
-  assert(P.shape(1) == x.shape(0));
-  assert(P.shape(2) == 1);
+  assert(P.shape(1) == 1);
+  assert(P.shape(2) == x.shape(0));
 
   std::fill(P.begin(), P.end(), 0.0);
-  xt::view(P, 0, xt::all(), 0) = 1.0;
+  xt::view(P, 0, 0, xt::all()) = 1.0;
 }
 //-----------------------------------------------------------------------------
 // Compute the complete set of derivatives from 0 to nderiv, for all the
@@ -53,23 +53,23 @@ void tabulate_polyset_line_derivs(xt::xtensor<double, 3>& P, std::size_t n,
 {
   assert(x.shape(0) > 0);
   assert(P.shape(0) == nderiv + 1);
-  assert(P.shape(1) == x.shape(0));
-  assert(P.shape(2) == n + 1);
-
+  assert(P.shape(1) == n + 1);
+  assert(P.shape(2) == x.shape(0));
+  
   std::fill(P.begin(), P.end(), 0.0);
-  xt::view(P, 0, xt::all(), 0) = 1.0;
+  xt::view(P, 0, 0, xt::all()) = 1.0;
   const auto x0 = xt::col(x, 0);
   if (n == 0)
     return;
 
   { // scope
     auto result = xt::view(P, 0, xt::all(), xt::all());
-    xt::col(result, 1) = (x0 * 2.0 - 1.0) * xt::col(result, 0);
+    xt::row(result, 1) = (x0 * 2.0 - 1.0) * xt::col(result, 0);
     for (std::size_t p = 2; p <= n; ++p)
     {
       const double a = 1.0 - 1.0 / static_cast<double>(p);
-      xt::col(result, p) = (x0 * 2.0 - 1.0) * xt::col(result, p - 1) * (a + 1.0)
-                           - xt::col(result, p - 2) * a;
+      xt::row(result, p) = (x0 * 2.0 - 1.0) * xt::row(result, p - 1) * (a + 1.0)
+                           - xt::row(result, p - 2) * a;
     }
   }
   for (std::size_t k = 1; k <= nderiv; ++k)
@@ -80,15 +80,15 @@ void tabulate_polyset_line_derivs(xt::xtensor<double, 3>& P, std::size_t n,
     for (std::size_t p = 1; p <= n; ++p)
     {
       const double a = 1.0 - 1.0 / static_cast<double>(p);
-      xt::col(result, p) = (x0 * 2.0 - 1.0) * xt::col(result, p - 1) * (a + 1.0)
+      xt::row(result, p) = (x0 * 2.0 - 1.0) * xt::col(result, p - 1) * (a + 1.0)
                            + 2 * k * xt::col(result0, p - 1) * (a + 1.0)
-                           - xt::col(result, p - 2) * a;
+                           - xt::row(result, p - 2) * a;
     }
   }
 
   // Normalise
   for (std::size_t p = 0; p <= n; ++p)
-    xt::view(P, xt::all(), xt::all(), p) *= std::sqrt(2 * p + 1);
+    xt::view(P, xt::all(), p, xt::all()) *= std::sqrt(2 * p + 1);
 }
 //-----------------------------------------------------------------------------
 // Compute the complete set of derivatives from 0 to nderiv, for all the
@@ -108,14 +108,14 @@ void tabulate_polyset_triangle_derivs(xt::xtensor<double, 3>& P, std::size_t n,
   auto x1 = xt::col(x, 1);
 
   assert(P.shape(0) == (nderiv + 1) * (nderiv + 2) / 2);
-  assert(P.shape(1) == x.shape(0));
-  assert(P.shape(2) == (n + 1) * (n + 2) / 2);
+  assert(P.shape(1) == (n + 1) * (n + 2) / 2);
+  assert(P.shape(2) == x.shape(0));
 
   // f3 = ((1 - y) / 2)^2
   const auto f3 = xt::square(1.0 - (x1 * 2.0 - 1.0)) * 0.25;
 
   std::fill(P.begin(), P.end(), 0.0);
-  xt::view(P, idx(0, 0), xt::all(), 0) = 1.0;
+  xt::view(P, idx(0, 0), 0, xt::all()) = 1.0;
 
   if (n == 0)
   {
@@ -130,38 +130,38 @@ void tabulate_polyset_triangle_derivs(xt::xtensor<double, 3>& P, std::size_t n,
     {
       for (std::size_t p = 1; p <= n; ++p)
       {
-        auto p0 = xt::view(P, idx(kx, ky), xt::all(), idx(0, p));
+        auto p0 = xt::view(P, idx(kx, ky), idx(0, p), xt::all());
         const double a
             = static_cast<double>(2 * p - 1) / static_cast<double>(p);
         p0 = ((x0 * 2.0 - 1.0) + 0.5 * (x1 * 2.0 - 1.0) + 0.5)
-             * xt::view(P, idx(kx, ky), xt::all(), idx(0, p - 1)) * a;
+          * xt::view(P, idx(kx, ky), idx(0, p - 1), xt::all()) * a;
         if (kx > 0)
         {
           p0 += 2 * kx * a
-                * xt::view(P, idx(kx - 1, ky), xt::all(), idx(0, p - 1));
+            * xt::view(P, idx(kx - 1, ky), idx(0, p - 1), xt::all());
         }
 
         if (ky > 0)
         {
-          p0 += ky * a * xt::view(P, idx(kx, ky - 1), xt::all(), idx(0, p - 1));
+          p0 += ky * a * xt::view(P, idx(kx, ky - 1), idx(0, p - 1), xt::all());
         }
 
         if (p > 1)
         {
           // y^2 terms
-          p0 -= f3 * xt::view(P, idx(kx, ky), xt::all(), idx(0, p - 2))
+          p0 -= f3 * xt::view(P, idx(kx, ky),  idx(0, p - 2), xt::all())
                 * (a - 1.0);
           if (ky > 0)
           {
             p0 -= ky * ((x1 * 2.0 - 1.0) - 1.0)
-                  * xt::view(P, idx(kx, ky - 1), xt::all(), idx(0, p - 2))
+              * xt::view(P, idx(kx, ky - 1), idx(0, p - 2), xt::all())
                   * (a - 1.0);
           }
 
           if (ky > 1)
           {
             p0 -= ky * (ky - 1)
-                  * xt::view(P, idx(kx, ky - 2), xt::all(), idx(0, p - 2))
+              * xt::view(P, idx(kx, ky - 2), idx(0, p - 2), xt::all())
                   * (a - 1.0);
           }
         }
@@ -169,27 +169,27 @@ void tabulate_polyset_triangle_derivs(xt::xtensor<double, 3>& P, std::size_t n,
 
       for (std::size_t p = 0; p < n; ++p)
       {
-        auto p0 = xt::view(P, idx(kx, ky), xt::all(), idx(0, p));
-        auto p1 = xt::view(P, idx(kx, ky), xt::all(), idx(1, p));
+        auto p0 = xt::view(P, idx(kx, ky),idx(0, p), xt::all());
+        auto p1 = xt::view(P, idx(kx, ky), idx(1, p), xt::all());
         p1 = p0 * ((x1 * 2.0 - 1.0) * (1.5 + p) + 0.5 + p);
         if (ky > 0)
         {
           p1 += 2 * ky * (1.5 + p)
-                * xt::view(P, idx(kx, ky - 1), xt::all(), idx(0, p));
+            * xt::view(P, idx(kx, ky - 1), idx(0, p), xt::all());
         }
 
         for (std::size_t q = 1; q < n - p; ++q)
         {
           const auto [a1, a2, a3] = jrc(2 * p + 1, q);
-          xt::view(P, idx(kx, ky), xt::all(), idx(q + 1, p))
-              = xt::view(P, idx(kx, ky), xt::all(), idx(q, p))
+          xt::view(P, idx(kx, ky), idx(q + 1, p), xt::all())
+            = xt::view(P, idx(kx, ky), idx(q, p), xt::all())
                     * ((x1 * 2.0 - 1.0) * a1 + a2)
-                - xt::view(P, idx(kx, ky), xt::all(), idx(q - 1, p)) * a3;
+            - xt::view(P, idx(kx, ky), idx(q - 1, p), xt::all()) * a3;
           if (ky > 0)
           {
-            xt::view(P, idx(kx, ky), xt::all(), idx(q + 1, p))
+            xt::view(P, idx(kx, ky), idx(q + 1, p), xt::all())
                 += 2 * ky * a1
-                   * xt::view(P, idx(kx, ky - 1), xt::all(), idx(q, p));
+              * xt::view(P, idx(kx, ky - 1), idx(q, p), xt::all());
           }
         }
       }
@@ -199,7 +199,7 @@ void tabulate_polyset_triangle_derivs(xt::xtensor<double, 3>& P, std::size_t n,
   // Normalisation
   for (std::size_t p = 0; p <= n; ++p)
     for (std::size_t q = 0; q <= n - p; ++q)
-      xt::view(P, xt::all(), xt::all(), idx(q, p))
+      xt::view(P, xt::all(), idx(q, p), xt::all())
           *= std::sqrt((p + 0.5) * (p + q + 1)) * 2;
 }
 //-----------------------------------------------------------------------------
@@ -209,8 +209,9 @@ void tabulate_polyset_tetrahedron_derivs(xt::xtensor<double, 3>& P,
 {
   assert(x.shape(1) == 3);
   assert(P.shape(0) == (nderiv + 1) * (nderiv + 2) * (nderiv + 3) / 6);
-  assert(P.shape(1) == x.shape(0));
-  assert(P.shape(2) == (n + 1) * (n + 2) * (n + 3) / 6);
+  assert(P.shape(1) == (n + 1) * (n + 2) * (n + 3) / 6);
+  assert(P.shape(2) == x.shape(0));
+
 
   const auto x0 = xt::col(x, 0);
   const auto x1 = xt::col(x, 1);
@@ -223,7 +224,7 @@ void tabulate_polyset_tetrahedron_derivs(xt::xtensor<double, 3>& P,
 
   // Traverse derivatives in increasing order
   std::fill(P.begin(), P.end(), 0.0);
-  xt::view(P, idx(0, 0, 0), xt::all(), 0) = 1.0;
+  xt::view(P, idx(0, 0, 0), 0, xt::all()) = 1.0;
 
   if (n == 0)
   {
@@ -239,74 +240,74 @@ void tabulate_polyset_tetrahedron_derivs(xt::xtensor<double, 3>& P,
       {
         for (std::size_t p = 1; p <= n; ++p)
         {
-          auto p00 = xt::view(P, idx(kx, ky, kz), xt::all(), idx(0, 0, p));
+          auto p00 = xt::view(P, idx(kx, ky, kz), idx(0, 0, p), xt::all());
           double a = static_cast<double>(2 * p - 1) / static_cast<double>(p);
           p00 = ((x0 * 2.0 - 1.0) + 0.5 * ((x1 * 2.0 - 1.0) + (x2 * 2.0 - 1.0))
                  + 1.0)
-                * xt::view(P, idx(kx, ky, kz), xt::all(), idx(0, 0, p - 1)) * a;
+            * xt::view(P, idx(kx, ky, kz), idx(0, 0, p - 1), xt::all()) * a;
           if (kx > 0)
           {
             p00 += 2 * kx * a
-                   * xt::view(P, idx(kx - 1, ky, kz), xt::all(),
-                              idx(0, 0, p - 1));
+                   * xt::view(P, idx(kx - 1, ky, kz), 
+                              idx(0, 0, p - 1),xt::all());
           }
 
           if (ky > 0)
           {
             p00 += ky * a
-                   * xt::view(P, idx(kx, ky - 1, kz), xt::all(),
-                              idx(0, 0, p - 1));
+                   * xt::view(P, idx(kx, ky - 1, kz), 
+                              idx(0, 0, p - 1), xt::all());
           }
 
           if (kz > 0)
           {
             p00 += kz * a
-                   * xt::view(P, idx(kx, ky, kz - 1), xt::all(),
-                              idx(0, 0, p - 1));
+                   * xt::view(P, idx(kx, ky, kz - 1), 
+                              idx(0, 0, p - 1),xt::all());
           }
 
           if (p > 1)
           {
             p00 -= f2
-                   * xt::view(P, idx(kx, ky, kz), xt::all(), idx(0, 0, p - 2))
+              * xt::view(P, idx(kx, ky, kz), idx(0, 0, p - 2), xt::all())
                    * (a - 1.0);
             if (ky > 0)
             {
               p00 -= ky * ((x1 * 2.0 - 1.0) + (x2 * 2.0 - 1.0))
-                     * xt::view(P, idx(kx, ky - 1, kz), xt::all(),
-                                idx(0, 0, p - 2))
+                     * xt::view(P, idx(kx, ky - 1, kz), 
+                                idx(0, 0, p - 2), xt::all())
                      * (a - 1.0);
             }
 
             if (ky > 1)
             {
               p00 -= ky * (ky - 1)
-                     * xt::view(P, idx(kx, ky - 2, kz), xt::all(),
-                                idx(0, 0, p - 2))
+                     * xt::view(P, idx(kx, ky - 2, kz), 
+                                idx(0, 0, p - 2), xt::all())
                      * (a - 1.0);
             }
 
             if (kz > 0)
             {
               p00 -= kz * ((x1 * 2.0 - 1.0) + (x2 * 2.0 - 1.0))
-                     * xt::view(P, idx(kx, ky, kz - 1), xt::all(),
-                                idx(0, 0, p - 2))
+                     * xt::view(P, idx(kx, ky, kz - 1), 
+                                idx(0, 0, p - 2), xt::all())
                      * (a - 1.0);
             }
 
             if (kz > 1)
             {
               p00 -= kz * (kz - 1)
-                     * xt::view(P, idx(kx, ky, kz - 2), xt::all(),
-                                idx(0, 0, p - 2))
+                     * xt::view(P, idx(kx, ky, kz - 2),
+                                idx(0, 0, p - 2), xt::all())
                      * (a - 1.0);
             }
 
             if (ky > 0 and kz > 0)
             {
               p00 -= 2.0 * ky * kz
-                     * xt::view(P, idx(kx, ky - 1, kz - 1), xt::all(),
-                                idx(0, 0, p - 2))
+                     * xt::view(P, idx(kx, ky - 1, kz - 1), 
+                                idx(0, 0, p - 2), xt::all())
                      * (a - 1.0);
             }
           }
@@ -315,48 +316,48 @@ void tabulate_polyset_tetrahedron_derivs(xt::xtensor<double, 3>& P,
         for (std::size_t p = 0; p < n; ++p)
         {
           auto p10 = xt::view(P, idx(kx, ky, kz), xt::all(), idx(0, 1, p));
-          p10 = xt::view(P, idx(kx, ky, kz), xt::all(), idx(0, 0, p))
+          p10 = xt::view(P, idx(kx, ky, kz), idx(0, 0, p), xt::all())
                 * ((1.0 + (x1 * 2.0 - 1.0)) * p
                    + (2.0 + (x1 * 2.0 - 1.0) * 3.0 + (x2 * 2.0 - 1.0)) * 0.5);
           if (ky > 0)
           {
             p10 += 2 * ky
-                   * xt::view(P, idx(kx, ky - 1, kz), xt::all(), idx(0, 0, p))
+              * xt::view(P, idx(kx, ky - 1, kz), idx(0, 0, p), xt::all())
                    * (1.5 + p);
           }
 
           if (kz > 0)
           {
             p10 += kz
-                   * xt::view(P, idx(kx, ky, kz - 1), xt::all(), idx(0, 0, p));
+              * xt::view(P, idx(kx, ky, kz - 1), idx(0, 0, p), xt::all());
           }
 
           for (std::size_t q = 1; q < n - p; ++q)
           {
             auto [aq, bq, cq] = jrc(2 * p + 1, q);
             auto pq1
-                = xt::view(P, idx(kx, ky, kz), xt::all(), idx(0, q + 1, p));
-            pq1 = xt::view(P, idx(kx, ky, kz), xt::all(), idx(0, q, p))
+              = xt::view(P, idx(kx, ky, kz),  idx(0, q + 1, p), xt::all());
+            pq1 = xt::view(P, idx(kx, ky, kz), idx(0, q, p), xt::all())
                       * (f3 * aq + f4 * bq)
-                  - xt::view(P, idx(kx, ky, kz), xt::all(), idx(0, q - 1, p))
+              - xt::view(P, idx(kx, ky, kz), idx(0, q - 1, p), xt::all())
                         * f5 * cq;
 
             if (ky > 0)
             {
               pq1 += 2 * ky
-                     * xt::view(P, idx(kx, ky - 1, kz), xt::all(), idx(0, q, p))
+                * xt::view(P, idx(kx, ky - 1, kz), idx(0, q, p), xt::all())
                      * aq;
             }
 
             if (kz > 0)
             {
               pq1 += kz
-                         * xt::view(P, idx(kx, ky, kz - 1), xt::all(),
-                                    idx(0, q, p))
+                         * xt::view(P, idx(kx, ky, kz - 1), 
+                                    idx(0, q, p), xt::all())
                          * (aq - bq)
                      + kz * (1.0 - (x2 * 2.0 - 1.0))
-                           * xt::view(P, idx(kx, ky, kz - 1), xt::all(),
-                                      idx(0, q - 1, p))
+                           * xt::view(P, idx(kx, ky, kz - 1), 
+                                      idx(0, q - 1, p), xt::all())
                            * cq;
             }
 
@@ -364,8 +365,8 @@ void tabulate_polyset_tetrahedron_derivs(xt::xtensor<double, 3>& P,
             {
               // Quadratic term in z
               pq1 -= kz * (kz - 1)
-                     * xt::view(P, idx(kx, ky, kz - 2), xt::all(),
-                                idx(0, q - 1, p))
+                     * xt::view(P, idx(kx, ky, kz - 2),
+                                idx(0, q - 1, p), xt::all())
                      * cq;
             }
           }
@@ -375,13 +376,13 @@ void tabulate_polyset_tetrahedron_derivs(xt::xtensor<double, 3>& P,
         {
           for (std::size_t q = 0; q < n - p; ++q)
           {
-            auto pq = xt::view(P, idx(kx, ky, kz), xt::all(), idx(1, q, p));
-            pq = xt::view(P, idx(kx, ky, kz), xt::all(), idx(0, q, p))
+            auto pq = xt::view(P, idx(kx, ky, kz), idx(1, q, p), xt::all());
+            pq = xt::view(P, idx(kx, ky, kz),  idx(0, q, p), xt::all())
                  * ((1.0 + p + q) + (x2 * 2.0 - 1.0) * (2.0 + p + q));
             if (kz > 0)
             {
               pq += 2 * kz * (2.0 + p + q)
-                    * xt::view(P, idx(kx, ky, kz - 1), xt::all(), idx(0, q, p));
+                * xt::view(P, idx(kx, ky, kz - 1), idx(0, q, p), xt::all());
             }
           }
         }
@@ -393,17 +394,17 @@ void tabulate_polyset_tetrahedron_derivs(xt::xtensor<double, 3>& P,
             for (std::size_t r = 1; r < n - p - q; ++r)
             {
               auto [ar, br, cr] = jrc(2 * p + 2 * q + 2, r);
-              xt::view(P, idx(kx, ky, kz), xt::all(), idx(r + 1, q, p))
-                  = xt::view(P, idx(kx, ky, kz), xt::all(), idx(r, q, p))
+              xt::view(P, idx(kx, ky, kz), idx(r + 1, q, p), xt::all())
+                = xt::view(P, idx(kx, ky, kz), idx(r, q, p), xt::all())
                         * ((x2 * 2.0 - 1.0) * ar + br)
-                    - xt::view(P, idx(kx, ky, kz), xt::all(), idx(r - 1, q, p))
+                - xt::view(P, idx(kx, ky, kz),  idx(r - 1, q, p), xt::all())
                           * cr;
               if (kz > 0)
               {
-                xt::view(P, idx(kx, ky, kz), xt::all(), idx(r + 1, q, p))
+                xt::view(P, idx(kx, ky, kz), idx(r + 1, q, p), xt::all())
                     += 2 * kz * ar
-                       * xt::view(P, idx(kx, ky, kz - 1), xt::all(),
-                                  idx(r, q, p));
+                       * xt::view(P, idx(kx, ky, kz - 1), 
+                                  idx(r, q, p), xt::all());
               }
             }
           }
@@ -419,7 +420,7 @@ void tabulate_polyset_tetrahedron_derivs(xt::xtensor<double, 3>& P,
     {
       for (std::size_t r = 0; r <= n - p - q; ++r)
       {
-        xt::view(P, xt::all(), xt::all(), idx(r, q, p))
+        xt::view(P, xt::all(), idx(r, q, p), xt::all())
             *= std::sqrt(2 * (p + 0.5) * (p + q + 1.0) * (p + q + r + 1.5)) * 2;
       }
     }
@@ -432,8 +433,8 @@ void tabulate_polyset_pyramid_derivs(xt::xtensor<double, 3>& P, std::size_t n,
 {
   assert(x.shape(1) == 3);
   assert(P.shape(0) == (nderiv + 1) * (nderiv + 2) * (nderiv + 3) / 6);
-  assert(P.shape(1) == x.shape(0));
-  assert(P.shape(2) == (n + 1) * (n + 2) * (2 * n + 3) / 6);
+  assert(P.shape(1) == (n + 1) * (n + 2) * (2 * n + 3) / 6);
+  assert(P.shape(2) == x.shape(0));
 
   // Indexing for pyramidal basis functions
   auto pyr_idx = [n](std::size_t p, std::size_t q, std::size_t r) -> std::size_t
@@ -452,7 +453,7 @@ void tabulate_polyset_pyramid_derivs(xt::xtensor<double, 3>& P, std::size_t n,
 
   // Traverse derivatives in increasing order
   std::fill(P.begin(), P.end(), 0.0);
-  xt::view(P, idx(0, 0, 0), xt::all(), pyr_idx(0, 0, 0)) = 1.0;
+  xt::view(P, idx(0, 0, 0), pyr_idx(0, 0, 0), xt::all()) = 1.0;
 
   if (n == 0)
   {
@@ -477,40 +478,40 @@ void tabulate_polyset_pyramid_derivs(xt::xtensor<double, 3>& P, std::size_t n,
             const double a
                 = static_cast<double>(p - 1) / static_cast<double>(p);
             auto p00
-                = xt::view(P, idx(kx, ky, kz), xt::all(), pyr_idx(p, 0, 0));
+              = xt::view(P, idx(kx, ky, kz),  pyr_idx(p, 0, 0), xt::all());
             p00 = (0.5 + (x0 * 2.0 - 1.0) + (x2 * 2.0 - 1.0) * 0.5)
-                  * xt::view(P, idx(kx, ky, kz), xt::all(),
-                             pyr_idx(p - 1, 0, 0))
+                  * xt::view(P, idx(kx, ky, kz),
+                             pyr_idx(p - 1, 0, 0), xt::all())
                   * (a + 1.0);
 
             if (kx > 0)
             {
               p00 += 2.0 * kx
-                     * xt::view(P, idx(kx - 1, ky, kz), xt::all(),
-                                pyr_idx(p - 1, 0, 0))
+                     * xt::view(P, idx(kx - 1, ky, kz),
+                                pyr_idx(p - 1, 0, 0), xt::all())
                      * (a + 1.0);
             }
 
             if (kz > 0)
             {
               p00 += kz
-                     * xt::view(P, idx(kx, ky, kz - 1), xt::all(),
-                                pyr_idx(p - 1, 0, 0))
+                     * xt::view(P, idx(kx, ky, kz - 1),
+                                pyr_idx(p - 1, 0, 0), xt::all())
                      * (a + 1.0);
             }
 
             if (p > 1)
             {
               p00 -= f2
-                     * xt::view(P, idx(kx, ky, kz), xt::all(),
-                                pyr_idx(p - 2, 0, 0))
+                     * xt::view(P, idx(kx, ky, kz),
+                                pyr_idx(p - 2, 0, 0), xt::all())
                      * a;
 
               if (kz > 0)
               {
                 p00 += kz * (1.0 - (x2 * 2.0 - 1.0))
-                       * xt::view(P, idx(kx, ky, kz - 1), xt::all(),
-                                  pyr_idx(p - 2, 0, 0))
+                       * xt::view(P, idx(kx, ky, kz - 1),
+                                  pyr_idx(p - 2, 0, 0), xt::all())
                        * a;
               }
 
@@ -518,8 +519,8 @@ void tabulate_polyset_pyramid_derivs(xt::xtensor<double, 3>& P, std::size_t n,
               {
                 // quadratic term in z
                 p00 -= kz * (kz - 1)
-                       * xt::view(P, idx(kx, ky, kz - 2), xt::all(),
-                                  pyr_idx(p - 2, 0, 0))
+                       * xt::view(P, idx(kx, ky, kz - 2),
+                                  pyr_idx(p - 2, 0, 0), xt::all())
                        * a;
               }
             }
@@ -530,47 +531,47 @@ void tabulate_polyset_pyramid_derivs(xt::xtensor<double, 3>& P, std::size_t n,
             const double a
                 = static_cast<double>(q - 1) / static_cast<double>(q);
             auto r_pq
-                = xt::view(P, idx(kx, ky, kz), xt::all(), pyr_idx(p, q, 0));
+              = xt::view(P, idx(kx, ky, kz),  pyr_idx(p, q, 0), xt::all());
             r_pq = (0.5 + (x1 * 2.0 - 1.0) + (x2 * 2.0 - 1.0) * 0.5)
-                   * xt::view(P, idx(kx, ky, kz), xt::all(),
-                              pyr_idx(p, q - 1, 0))
+                   * xt::view(P, idx(kx, ky, kz), 
+                              pyr_idx(p, q - 1, 0), xt::all())
                    * (a + 1.0);
             if (ky > 0)
             {
               r_pq += 2.0 * ky
-                      * xt::view(P, idx(kx, ky - 1, kz), xt::all(),
-                                 pyr_idx(p, q - 1, 0))
+                      * xt::view(P, idx(kx, ky - 1, kz),
+                                 pyr_idx(p, q - 1, 0), xt::all())
                       * (a + 1.0);
             }
 
             if (kz > 0)
             {
               r_pq += kz
-                      * xt::view(P, idx(kx, ky, kz - 1), xt::all(),
-                                 pyr_idx(p, q - 1, 0))
+                      * xt::view(P, idx(kx, ky, kz - 1),
+                                 pyr_idx(p, q - 1, 0), xt::all())
                       * (a + 1.0);
             }
 
             if (q > 1)
             {
               r_pq -= f2
-                      * xt::view(P, idx(kx, ky, kz), xt::all(),
-                                 pyr_idx(p, q - 2, 0))
+                      * xt::view(P, idx(kx, ky, kz),
+                                 pyr_idx(p, q - 2, 0), xt::all())
                       * a;
 
               if (kz > 0)
               {
                 r_pq += kz * (1.0 - (x2 * 2.0 - 1.0))
-                        * xt::view(P, idx(kx, ky, kz - 1), xt::all(),
-                                   pyr_idx(p, q - 2, 0))
+                        * xt::view(P, idx(kx, ky, kz - 1),
+                                   pyr_idx(p, q - 2, 0), xt::all())
                         * a;
               }
 
               if (kz > 1)
               {
                 r_pq -= kz * (kz - 1)
-                        * xt::view(P, idx(kx, ky, kz - 2), xt::all(),
-                                   pyr_idx(p, q - 2, 0))
+                        * xt::view(P, idx(kx, ky, kz - 2), 
+                                   pyr_idx(p, q - 2, 0), xt::all())
                         * a;
               }
             }
@@ -583,14 +584,14 @@ void tabulate_polyset_pyramid_derivs(xt::xtensor<double, 3>& P, std::size_t n,
           for (std::size_t q = 0; q < n; ++q)
           {
             auto r_pq1
-                = xt::view(P, idx(kx, ky, kz), xt::all(), pyr_idx(p, q, 1));
-            r_pq1 = xt::view(P, idx(kx, ky, kz), xt::all(), pyr_idx(p, q, 0))
+              = xt::view(P, idx(kx, ky, kz), pyr_idx(p, q, 1), xt::all());
+            r_pq1 = xt::view(P, idx(kx, ky, kz), pyr_idx(p, q, 0), xt::all())
                     * ((1.0 + p + q) + (x2 * 2.0 - 1.0) * (2.0 + p + q));
             if (kz > 0)
             {
               r_pq1 += 2 * kz
-                       * xt::view(P, idx(kx, ky, kz - 1), xt::all(),
-                                  pyr_idx(p, q, 0))
+                       * xt::view(P, idx(kx, ky, kz - 1),
+                                  pyr_idx(p, q, 0), xt::all())
                        * (2.0 + p + q);
             }
           }
@@ -603,18 +604,18 @@ void tabulate_polyset_pyramid_derivs(xt::xtensor<double, 3>& P, std::size_t n,
             for (std::size_t q = 0; q < n - r; ++q)
             {
               auto [ar, br, cr] = jrc(2 * p + 2 * q + 2, r);
-              auto r_pqr = xt::view(P, idx(kx, ky, kz), xt::all(),
-                                    pyr_idx(p, q, r + 1));
-              r_pqr = xt::view(P, idx(kx, ky, kz), xt::all(), pyr_idx(p, q, r))
+              auto r_pqr = xt::view(P, idx(kx, ky, kz),
+                                    pyr_idx(p, q, r + 1), xt::all());
+              r_pqr = xt::view(P, idx(kx, ky, kz), pyr_idx(p, q, r), xt::all())
                           * ((x2 * 2.0 - 1.0) * ar + br)
-                      - xt::view(P, idx(kx, ky, kz), xt::all(),
-                                 pyr_idx(p, q, r - 1))
+                      - xt::view(P, idx(kx, ky, kz),
+                                 pyr_idx(p, q, r - 1), xt::all())
                             * cr;
               if (kz > 0)
               {
                 r_pqr += ar * 2 * kz
-                         * xt::view(P, idx(kx, ky, kz - 1), xt::all(),
-                                    pyr_idx(p, q, r));
+                         * xt::view(P, idx(kx, ky, kz - 1),
+                                    pyr_idx(p, q, r), xt::all());
               }
             }
           }
@@ -629,7 +630,7 @@ void tabulate_polyset_pyramid_derivs(xt::xtensor<double, 3>& P, std::size_t n,
     {
       for (std::size_t q = 0; q <= n - r; ++q)
       {
-        xt::view(P, xt::all(), xt::all(), pyr_idx(p, q, r))
+        xt::view(P, xt::all(), pyr_idx(p, q, r), xt::all())
             *= std::sqrt(2 * (q + 0.5) * (p + 0.5) * (p + q + r + 1.5)) * 2;
       }
     }
@@ -642,9 +643,9 @@ void tabulate_polyset_quad_derivs(xt::xtensor<double, 3>& P, std::size_t n,
 {
   assert(x.shape(1) == 2);
   assert(P.shape(0) == (nderiv + 1) * (nderiv + 2) / 2);
-  assert(P.shape(1) == x.shape(0));
-  assert(P.shape(2) == (n + 1) * (n + 1));
-
+  assert(P.shape(1) == (n + 1) * (n + 1));
+  assert(P.shape(2) == x.shape(0));
+  
   // Indexing for quadrilateral basis functions
   auto quad_idx = [n](std::size_t px, std::size_t py) -> std::size_t
   { return (n + 1) * px + py; };
@@ -658,21 +659,21 @@ void tabulate_polyset_quad_derivs(xt::xtensor<double, 3>& P, std::size_t n,
 
   // Compute tabulation of interval for px = 0
   std::fill(P.begin(), P.end(), 0.0);
-  xt::view(P, idx(0, 0), xt::all(), quad_idx(0, 0)) = 1.0;
+  xt::view(P, idx(0, 0), quad_idx(0, 0), xt::all()) = 1.0;
 
   if (n == 0)
     return;
 
   { // scope
     auto result = xt::view(P, idx(0, 0), xt::all(), xt::all());
-    xt::col(result, quad_idx(0, 1))
-        = (x1 * 2.0 - 1.0) * xt::col(result, quad_idx(0, 0));
+    xt::row(result, quad_idx(0, 1))
+        = (x1 * 2.0 - 1.0) * xt::row(result, quad_idx(0, 0));
     for (std::size_t py = 2; py <= n; ++py)
     {
       const double a = 1.0 - 1.0 / static_cast<double>(py);
-      xt::col(result, quad_idx(0, py))
-          = (x1 * 2.0 - 1.0) * xt::col(result, quad_idx(0, py - 1)) * (a + 1.0)
-            - xt::col(result, quad_idx(0, py - 2)) * a;
+      xt::row(result, quad_idx(0, py))
+          = (x1 * 2.0 - 1.0) * xt::row(result, quad_idx(0, py - 1)) * (a + 1.0)
+        - xt::row(result, quad_idx(0, py - 2)) * a;
     }
   }
   for (std::size_t ky = 1; ky <= nderiv; ++ky)
@@ -680,16 +681,16 @@ void tabulate_polyset_quad_derivs(xt::xtensor<double, 3>& P, std::size_t n,
     // Get reference to this derivative
     auto result = xt::view(P, idx(0, ky), xt::all(), xt::all());
     auto result0 = xt::view(P, idx(0, ky - 1), xt::all(), xt::all());
-    xt::col(result, quad_idx(0, 1))
-        = (x1 * 2.0 - 1.0) * xt::col(result, quad_idx(0, 0))
-          + 2 * ky * xt::col(result0, quad_idx(0, 0));
+    xt::row(result, quad_idx(0, 1))
+        = (x1 * 2.0 - 1.0) * xt::row(result, quad_idx(0, 0))
+          + 2 * ky * xt::row(result0, quad_idx(0, 0));
     for (std::size_t py = 2; py <= n; ++py)
     {
       const double a = 1.0 - 1.0 / static_cast<double>(py);
-      xt::col(result, quad_idx(0, py))
-          = (x1 * 2.0 - 1.0) * xt::col(result, quad_idx(0, py - 1)) * (a + 1.0)
-            + 2 * ky * xt::col(result0, quad_idx(0, py - 1)) * (a + 1.0)
-            - xt::col(result, quad_idx(0, py - 2)) * a;
+      xt::row(result, quad_idx(0, py))
+          = (x1 * 2.0 - 1.0) * xt::row(result, quad_idx(0, py - 1)) * (a + 1.0)
+            + 2 * ky * xt::row(result0, quad_idx(0, py - 1)) * (a + 1.0)
+            - xt::row(result, quad_idx(0, py - 2)) * a;
     }
   }
 
@@ -699,8 +700,8 @@ void tabulate_polyset_quad_derivs(xt::xtensor<double, 3>& P, std::size_t n,
     auto result = xt::view(P, idx(0, ky), xt::all(), xt::all());
     for (std::size_t py = 0; py <= n; ++py)
     {
-      xt::col(result, quad_idx(1, py))
-          = (x0 * 2.0 - 1.0) * xt::col(result, quad_idx(0, py));
+      xt::row(result, quad_idx(1, py))
+          = (x0 * 2.0 - 1.0) * xt::row(result, quad_idx(0, py));
     }
   }
   for (std::size_t px = 2; px <= n; ++px)
@@ -711,10 +712,10 @@ void tabulate_polyset_quad_derivs(xt::xtensor<double, 3>& P, std::size_t n,
       auto result = xt::view(P, idx(0, ky), xt::all(), xt::all());
       for (std::size_t py = 0; py <= n; ++py)
       {
-        xt::col(result, quad_idx(px, py))
-            = (x0 * 2.0 - 1.0) * xt::col(result, quad_idx(px - 1, py))
+        xt::row(result, quad_idx(px, py))
+            = (x0 * 2.0 - 1.0) * xt::row(result, quad_idx(px - 1, py))
                   * (a + 1.0)
-              - xt::col(result, quad_idx(px - 2, py)) * a;
+              - xt::row(result, quad_idx(px - 2, py)) * a;
       }
     }
   }
@@ -726,9 +727,9 @@ void tabulate_polyset_quad_derivs(xt::xtensor<double, 3>& P, std::size_t n,
       auto result0 = xt::view(P, idx(kx - 1, ky), xt::all(), xt::all());
       for (std::size_t py = 0; py <= n; ++py)
       {
-        xt::col(result, quad_idx(1, py))
-            = (x0 * 2.0 - 1.0) * xt::col(result, quad_idx(0, py))
-              + 2 * kx * xt::col(result0, quad_idx(0, py));
+        xt::row(result, quad_idx(1, py))
+            = (x0 * 2.0 - 1.0) * xt::row(result, quad_idx(0, py))
+              + 2 * kx * xt::row(result0, quad_idx(0, py));
       }
     }
     for (std::size_t px = 2; px <= n; ++px)
@@ -740,11 +741,11 @@ void tabulate_polyset_quad_derivs(xt::xtensor<double, 3>& P, std::size_t n,
         auto result0 = xt::view(P, idx(kx - 1, ky), xt::all(), xt::all());
         for (std::size_t py = 0; py <= n; ++py)
         {
-          xt::col(result, quad_idx(px, py))
-              = (x0 * 2.0 - 1.0) * xt::col(result, quad_idx(px - 1, py))
+          xt::row(result, quad_idx(px, py))
+              = (x0 * 2.0 - 1.0) * xt::row(result, quad_idx(px - 1, py))
                     * (a + 1.0)
-                + 2 * kx * xt::col(result0, quad_idx(px - 1, py)) * (a + 1.0)
-                - xt::col(result, quad_idx(px - 2, py)) * a;
+                + 2 * kx * xt::row(result0, quad_idx(px - 1, py)) * (a + 1.0)
+                - xt::row(result, quad_idx(px - 2, py)) * a;
         }
       }
     }
@@ -755,7 +756,7 @@ void tabulate_polyset_quad_derivs(xt::xtensor<double, 3>& P, std::size_t n,
   {
     for (std::size_t py = 0; py <= n; ++py)
     {
-      xt::view(P, xt::all(), xt::all(), quad_idx(px, py))
+      xt::view(P, xt::all(), quad_idx(px, py), xt::all())
           *= std::sqrt((2 * px + 1) * (2 * py + 1));
     }
   }
@@ -767,8 +768,8 @@ void tabulate_polyset_hex_derivs(xt::xtensor<double, 3>& P, std::size_t n,
 {
   assert(x.shape(1) == 3);
   assert(P.shape(0) == (nderiv + 1) * (nderiv + 2) * (nderiv + 3) / 6);
-  assert(P.shape(1) == x.shape(0));
-  assert(P.shape(2) == (n + 1) * (n + 1) * (n + 1));
+  assert(P.shape(1) == (n + 1) * (n + 1) * (n + 1));
+  assert(P.shape(2) == x.shape(0));
 
   // Indexing for hexahedral basis functions
   auto hex_idx
@@ -785,7 +786,7 @@ void tabulate_polyset_hex_derivs(xt::xtensor<double, 3>& P, std::size_t n,
   assert(x2.shape(0) > 0);
 
   std::fill(P.begin(), P.end(), 0.0);
-  xt::view(P, idx(0, 0, 0), xt::all(), hex_idx(0, 0, 0)) = 1.0;
+  xt::view(P, idx(0, 0, 0), hex_idx(0, 0, 0), xt::all()) = 1.0;
 
   if (n == 0)
     return;
@@ -795,16 +796,16 @@ void tabulate_polyset_hex_derivs(xt::xtensor<double, 3>& P, std::size_t n,
   { // scope
     auto result = xt::view(P, idx(0, 0, 0), xt::all(), xt::all());
     // for pz = 1
-    xt::col(result, hex_idx(0, 0, 1))
-        = (x2 * 2.0 - 1.0) * xt::col(result, hex_idx(0, 0, 0));
+    xt::row(result, hex_idx(0, 0, 1))
+        = (x2 * 2.0 - 1.0) * xt::row(result, hex_idx(0, 0, 0));
     // for larger values of pz
     for (std::size_t pz = 2; pz <= n; ++pz)
     {
       const double a = 1.0 - 1.0 / static_cast<double>(pz);
-      xt::col(result, hex_idx(0, 0, pz))
-          = (x2 * 2.0 - 1.0) * xt::col(result, hex_idx(0, 0, pz - 1))
+      xt::row(result, hex_idx(0, 0, pz))
+          = (x2 * 2.0 - 1.0) * xt::row(result, hex_idx(0, 0, pz - 1))
                 * (a + 1.0)
-            - xt::col(result, hex_idx(0, 0, pz - 2)) * a;
+            - xt::row(result, hex_idx(0, 0, pz - 2)) * a;
     }
   }
   // for larger values of kz
@@ -814,18 +815,18 @@ void tabulate_polyset_hex_derivs(xt::xtensor<double, 3>& P, std::size_t n,
     auto result = xt::view(P, idx(0, 0, kz), xt::all(), xt::all());
     auto result0 = xt::view(P, idx(0, 0, kz - 1), xt::all(), xt::all());
     // for pz = 1
-    xt::col(result, hex_idx(0, 0, 1))
-        = (x2 * 2.0 - 1.0) * xt::col(result, hex_idx(0, 0, 0))
-          + 2 * kz * xt::col(result0, hex_idx(0, 0, 0));
+    xt::row(result, hex_idx(0, 0, 1))
+        = (x2 * 2.0 - 1.0) * xt::row(result, hex_idx(0, 0, 0))
+          + 2 * kz * xt::row(result0, hex_idx(0, 0, 0));
     // for larger values of pz
     for (std::size_t pz = 2; pz <= n; ++pz)
     {
       const double a = 1.0 - 1.0 / static_cast<double>(pz);
-      xt::col(result, hex_idx(0, 0, pz))
-          = (x2 * 2.0 - 1.0) * xt::col(result, hex_idx(0, 0, pz - 1))
+      xt::row(result, hex_idx(0, 0, pz))
+          = (x2 * 2.0 - 1.0) * xt::row(result, hex_idx(0, 0, pz - 1))
                 * (a + 1.0)
-            + 2 * kz * xt::col(result0, hex_idx(0, 0, pz - 1)) * (a + 1.0)
-            - xt::col(result, hex_idx(0, 0, pz - 2)) * a;
+            + 2 * kz * xt::row(result0, hex_idx(0, 0, pz - 1)) * (a + 1.0)
+            - xt::row(result, hex_idx(0, 0, pz - 2)) * a;
     }
   }
 
@@ -837,8 +838,8 @@ void tabulate_polyset_hex_derivs(xt::xtensor<double, 3>& P, std::size_t n,
     auto result = xt::view(P, idx(0, 0, kz), xt::all(), xt::all());
     for (std::size_t pz = 0; pz <= n; ++pz)
     {
-      xt::col(result, hex_idx(0, 1, pz))
-          = (x1 * 2.0 - 1.0) * xt::col(result, hex_idx(0, 0, pz));
+      xt::row(result, hex_idx(0, 1, pz))
+          = (x1 * 2.0 - 1.0) * xt::row(result, hex_idx(0, 0, pz));
     }
   }
   for (std::size_t py = 2; py <= n; ++py)
@@ -849,10 +850,10 @@ void tabulate_polyset_hex_derivs(xt::xtensor<double, 3>& P, std::size_t n,
       auto result = xt::view(P, idx(0, 0, kz), xt::all(), xt::all());
       for (std::size_t pz = 0; pz <= n; ++pz)
       {
-        xt::col(result, hex_idx(0, py, pz))
-            = (x1 * 2.0 - 1.0) * xt::col(result, hex_idx(0, py - 1, pz))
+        xt::row(result, hex_idx(0, py, pz))
+            = (x1 * 2.0 - 1.0) * xt::row(result, hex_idx(0, py - 1, pz))
                   * (a + 1.0)
-              - xt::col(result, hex_idx(0, py - 2, pz)) * a;
+              - xt::row(result, hex_idx(0, py - 2, pz)) * a;
       }
     }
   }
@@ -866,9 +867,9 @@ void tabulate_polyset_hex_derivs(xt::xtensor<double, 3>& P, std::size_t n,
       auto result0 = xt::view(P, idx(0, ky - 1, kz), xt::all(), xt::all());
       for (std::size_t pz = 0; pz <= n; ++pz)
       {
-        xt::col(result, hex_idx(0, 1, pz))
-            = (x1 * 2.0 - 1.0) * xt::col(result, hex_idx(0, 0, pz))
-              + 2 * ky * xt::col(result0, hex_idx(0, 0, pz));
+        xt::row(result, hex_idx(0, 1, pz))
+            = (x1 * 2.0 - 1.0) * xt::row(result, hex_idx(0, 0, pz))
+              + 2 * ky * xt::row(result0, hex_idx(0, 0, pz));
       }
     }
     for (std::size_t py = 2; py <= n; ++py)
@@ -880,11 +881,11 @@ void tabulate_polyset_hex_derivs(xt::xtensor<double, 3>& P, std::size_t n,
         auto result0 = xt::view(P, idx(0, ky - 1, kz), xt::all(), xt::all());
         for (std::size_t pz = 0; pz <= n; ++pz)
         {
-          xt::col(result, hex_idx(0, py, pz))
-              = (x1 * 2.0 - 1.0) * xt::col(result, hex_idx(0, py - 1, pz))
+          xt::row(result, hex_idx(0, py, pz))
+              = (x1 * 2.0 - 1.0) * xt::row(result, hex_idx(0, py - 1, pz))
                     * (a + 1.0)
-                + 2 * ky * xt::col(result0, hex_idx(0, py - 1, pz)) * (a + 1.0)
-                - xt::col(result, hex_idx(0, py - 2, pz)) * a;
+                + 2 * ky * xt::row(result0, hex_idx(0, py - 1, pz)) * (a + 1.0)
+                - xt::row(result, hex_idx(0, py - 2, pz)) * a;
         }
       }
     }
@@ -902,8 +903,8 @@ void tabulate_polyset_hex_derivs(xt::xtensor<double, 3>& P, std::size_t n,
       {
         for (std::size_t pz = 0; pz <= n; ++pz)
         {
-          xt::col(result, hex_idx(1, py, pz))
-              = (x0 * 2.0 - 1.0) * xt::col(result, hex_idx(0, py, pz));
+          xt::row(result, hex_idx(1, py, pz))
+              = (x0 * 2.0 - 1.0) * xt::row(result, hex_idx(0, py, pz));
         }
       }
     }
@@ -921,10 +922,10 @@ void tabulate_polyset_hex_derivs(xt::xtensor<double, 3>& P, std::size_t n,
         {
           for (std::size_t pz = 0; pz <= n; ++pz)
           {
-            xt::col(result, hex_idx(px, py, pz))
-                = (x0 * 2.0 - 1.0) * xt::col(result, hex_idx(px - 1, py, pz))
+            xt::row(result, hex_idx(px, py, pz))
+                = (x0 * 2.0 - 1.0) * xt::row(result, hex_idx(px - 1, py, pz))
                       * (a + 1.0)
-                  - xt::col(result, hex_idx(px - 2, py, pz)) * a;
+                  - xt::row(result, hex_idx(px - 2, py, pz)) * a;
           }
         }
       }
@@ -945,9 +946,9 @@ void tabulate_polyset_hex_derivs(xt::xtensor<double, 3>& P, std::size_t n,
           {
             for (std::size_t pz = 0; pz <= n; ++pz)
             {
-              xt::col(result, hex_idx(1, py, pz))
-                  = (x0 * 2.0 - 1.0) * xt::col(result, hex_idx(0, py, pz))
-                    + 2 * kx * xt::col(result0, hex_idx(0, py, pz));
+              xt::row(result, hex_idx(1, py, pz))
+                = (x0 * 2.0 - 1.0) * xt::row(result, hex_idx(0, py, pz))
+                    + 2 * kx * xt::row(result0, hex_idx(0, py, pz));
             }
           }
         }
@@ -967,12 +968,12 @@ void tabulate_polyset_hex_derivs(xt::xtensor<double, 3>& P, std::size_t n,
           {
             for (std::size_t pz = 0; pz <= n; ++pz)
             {
-              xt::col(result, hex_idx(px, py, pz))
-                  = (x0 * 2.0 - 1.0) * xt::col(result, hex_idx(px - 1, py, pz))
+              xt::row(result, hex_idx(px, py, pz))
+                  = (x0 * 2.0 - 1.0) * xt::row(result, hex_idx(px - 1, py, pz))
                         * (a + 1.0)
-                    + 2 * kx * xt::col(result0, hex_idx(px - 1, py, pz))
+                    + 2 * kx * xt::row(result0, hex_idx(px - 1, py, pz))
                           * (a + 1.0)
-                    - xt::col(result, hex_idx(px - 2, py, pz)) * a;
+                    - xt::row(result, hex_idx(px - 2, py, pz)) * a;
             }
           }
         }
@@ -985,7 +986,7 @@ void tabulate_polyset_hex_derivs(xt::xtensor<double, 3>& P, std::size_t n,
     for (std::size_t py = 0; py <= n; ++py)
       for (std::size_t pz = 0; pz <= n; ++pz)
       {
-        xt::view(P, xt::all(), xt::all(), hex_idx(px, py, pz))
+        xt::view(P, xt::all(), hex_idx(px, py, pz), xt::all())
             *= std::sqrt((2 * px + 1) * (2 * py + 1) * (2 * pz + 1));
       }
 }
@@ -996,8 +997,8 @@ void tabulate_polyset_prism_derivs(xt::xtensor<double, 3>& P, std::size_t n,
 {
   assert(x.shape(1) == 3);
   assert(P.shape(0) == (nderiv + 1) * (nderiv + 2) * (nderiv + 3) / 6);
-  assert(P.shape(1) == x.shape(0));
-  assert(P.shape(2) == (n + 1) * (n + 1) * (n + 2) / 2);
+  assert(P.shape(1) == (n + 1) * (n + 1) * (n + 2) / 2);
+  assert(P.shape(2) == x.shape(0));
 
   const auto x0 = xt::col(x, 0);
   const auto x1 = xt::col(x, 1);
@@ -1017,7 +1018,7 @@ void tabulate_polyset_prism_derivs(xt::xtensor<double, 3>& P, std::size_t n,
 
   // Tabulate triangle for px=0
   std::fill(P.begin(), P.end(), 0.0);
-  xt::view(P, idx(0, 0, 0), xt::all(), prism_idx(0, 0, 0)) = 1.0;
+  xt::view(P, idx(0, 0, 0), prism_idx(0, 0, 0), xt::all()) = 1.0;
 
   if (n == 0)
   {
@@ -1031,24 +1032,24 @@ void tabulate_polyset_prism_derivs(xt::xtensor<double, 3>& P, std::size_t n,
     {
       for (std::size_t p = 1; p <= n; ++p)
       {
-        auto p0 = xt::view(P, idx(kx, ky, 0), xt::all(), prism_idx(p, 0, 0));
+        auto p0 = xt::view(P, idx(kx, ky, 0), prism_idx(p, 0, 0), xt::all());
 
         const double a
             = static_cast<double>(2 * p - 1) / static_cast<double>(p);
         p0 = ((x0 * 2.0 - 1.0) + 0.5 * (x1 * 2.0 - 1.0) + 0.5)
-             * xt::view(P, idx(kx, ky, 0), xt::all(), prism_idx(p - 1, 0, 0))
+          * xt::view(P, idx(kx, ky, 0),  prism_idx(p - 1, 0, 0), xt::all())
              * a;
         if (kx > 0)
         {
-          auto result0 = xt::view(P, idx(kx - 1, ky, 0), xt::all(),
-                                  prism_idx(p - 1, 0, 0));
+          auto result0 = xt::view(P, idx(kx - 1, ky, 0),
+                                  prism_idx(p - 1, 0, 0), xt::all());
           p0 += 2 * kx * a * result0;
         }
 
         if (ky > 0)
         {
-          auto result0 = xt::view(P, idx(kx, ky - 1, 0), xt::all(),
-                                  prism_idx(p - 1, 0, 0));
+          auto result0 = xt::view(P, idx(kx, ky - 1, 0),
+                                  prism_idx(p - 1, 0, 0), xt::all());
           p0 += ky * a * result0;
         }
 
@@ -1056,19 +1057,19 @@ void tabulate_polyset_prism_derivs(xt::xtensor<double, 3>& P, std::size_t n,
         {
           // y^2 terms
           p0 -= f3
-                * xt::view(P, idx(kx, ky, 0), xt::all(), prism_idx(p - 2, 0, 0))
+            * xt::view(P, idx(kx, ky, 0),  prism_idx(p - 2, 0, 0), xt::all())
                 * (a - 1.0);
           if (ky > 0)
           {
-            auto result0 = xt::view(P, idx(kx, ky - 1, 0), xt::all(),
-                                    prism_idx(p - 2, 0, 0));
+            auto result0 = xt::view(P, idx(kx, ky - 1, 0), 
+                                    prism_idx(p - 2, 0, 0), xt::all());
             p0 -= ky * ((x1 * 2.0 - 1.0) - 1.0) * result0 * (a - 1.0);
           }
 
           if (ky > 1)
           {
-            auto result0 = xt::view(P, idx(kx, ky - 2, 0), xt::all(),
-                                    prism_idx(p - 2, 0, 0));
+            auto result0 = xt::view(P, idx(kx, ky - 2, 0), 
+                                    prism_idx(p - 2, 0, 0), xt::all());
             p0 -= ky * (ky - 1) * result0 * (a - 1.0);
           }
         }
@@ -1076,29 +1077,29 @@ void tabulate_polyset_prism_derivs(xt::xtensor<double, 3>& P, std::size_t n,
 
       for (std::size_t p = 0; p < n; ++p)
       {
-        auto p0 = xt::view(P, idx(kx, ky, 0), xt::all(), prism_idx(p, 0, 0));
-        auto p1 = xt::view(P, idx(kx, ky, 0), xt::all(), prism_idx(p, 1, 0));
+        auto p0 = xt::view(P, idx(kx, ky, 0), prism_idx(p, 0, 0), xt::all());
+        auto p1 = xt::view(P, idx(kx, ky, 0),  prism_idx(p, 1, 0), xt::all());
         p1 = p0 * ((x1 * 2.0 - 1.0) * (1.5 + p) + 0.5 + p);
         if (ky > 0)
         {
           auto result0
-              = xt::view(P, idx(kx, ky - 1, 0), xt::all(), prism_idx(p, 0, 0));
+            = xt::view(P, idx(kx, ky - 1, 0), prism_idx(p, 0, 0), xt::all());
           p1 += 2 * ky * (1.5 + p) * result0;
         }
 
         for (std::size_t q = 1; q < n - p; ++q)
         {
           const auto [a1, a2, a3] = jrc(2 * p + 1, q);
-          xt::view(P, idx(kx, ky, 0), xt::all(), prism_idx(p, q + 1, 0))
-              = xt::view(P, idx(kx, ky, 0), xt::all(), prism_idx(p, q, 0))
+          xt::view(P, idx(kx, ky, 0), prism_idx(p, q + 1, 0), xt::all())
+            = xt::view(P, idx(kx, ky, 0),  prism_idx(p, q, 0), xt::all())
                     * ((x1 * 2.0 - 1.0) * a1 + a2)
-                - xt::view(P, idx(kx, ky, 0), xt::all(), prism_idx(p, q - 1, 0))
+            - xt::view(P, idx(kx, ky, 0),  prism_idx(p, q - 1, 0), xt::all())
                       * a3;
           if (ky > 0)
           {
-            auto result0 = xt::view(P, idx(kx, ky - 1, 0), xt::all(),
-                                    prism_idx(p, q, 0));
-            xt::view(P, idx(kx, ky, 0), xt::all(), prism_idx(p, q + 1, 0))
+            auto result0 = xt::view(P, idx(kx, ky - 1, 0),
+                                    prism_idx(p, q, 0), xt::all());
+            xt::view(P, idx(kx, ky, 0), prism_idx(p, q + 1, 0), xt::all())
                 += 2 * ky * a1 * result0;
           }
         }
@@ -1122,16 +1123,16 @@ void tabulate_polyset_prism_derivs(xt::xtensor<double, 3>& P, std::size_t n,
           {
             for (std::size_t q = 0; q <= n - p; ++q)
             {
-              xt::col(result, prism_idx(p, q, r))
-                  = (x2 * 2.0 - 1.0) * xt::col(result, prism_idx(p, q, r - 1))
+              xt::row(result, prism_idx(p, q, r))
+                  = (x2 * 2.0 - 1.0) * xt::row(result, prism_idx(p, q, r - 1))
                     * (a + 1.0);
               if (kz > 0)
-                xt::col(result, prism_idx(p, q, r))
-                    += 2 * kz * xt::col(result0, prism_idx(p, q, r - 1))
+                xt::row(result, prism_idx(p, q, r))
+                    += 2 * kz * xt::row(result0, prism_idx(p, q, r - 1))
                        * (a + 1.0);
               if (r > 1)
-                xt::col(result, prism_idx(p, q, r))
-                    -= xt::col(result, prism_idx(p, q, r - 2)) * a;
+                xt::row(result, prism_idx(p, q, r))
+                    -= xt::row(result, prism_idx(p, q, r - 2)) * a;
             }
           }
         }
@@ -1143,7 +1144,7 @@ void tabulate_polyset_prism_derivs(xt::xtensor<double, 3>& P, std::size_t n,
   for (std::size_t p = 0; p <= n; ++p)
     for (std::size_t q = 0; q <= n - p; ++q)
       for (std::size_t r = 0; r <= n; ++r)
-        xt::view(P, xt::all(), xt::all(), prism_idx(p, q, r))
+        xt::view(P, xt::all(), prism_idx(p, q, r), xt::all())
             *= std::sqrt((p + 0.5) * (p + q + 1) * (2 * r + 1)) * 2;
 }
 } // namespace
@@ -1178,8 +1179,8 @@ xt::xtensor<double, 3> polyset::tabulate(cell::type celltype, int d, int n,
                                          const xt::xtensor<double, 2>& x)
 {
   xt::xtensor<double, 3> out(
-      {static_cast<std::size_t>(polyset::nderivs(celltype, n)), x.shape(0),
-       static_cast<std::size_t>(polyset::dim(celltype, d))});
+      {static_cast<std::size_t>(polyset::nderivs(celltype, n)), 
+       static_cast<std::size_t>(polyset::dim(celltype, d)), x.shape(0)});
   polyset::tabulate(out, celltype, d, n, x);
   return out;
 }

--- a/test/test_dof_transformations.py
+++ b/test/test_dof_transformations.py
@@ -113,7 +113,7 @@ def test_hexahedron_transformation_degrees(element_type, degree, element_args):
     assert len(bt) == 24
     identity = np.identity(e.dim)
     for i, degree in enumerate([2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-                               4, 2, 4, 2, 4, 2, 4, 2, 4, 2, 4, 2]):
+                                4, 2, 4, 2, 4, 2, 4, 2, 4, 2, 4, 2]):
         # TODO: remove the atol here once non-equispaced variants are implemented
         assert np.allclose(
             np.linalg.matrix_power(bt[i], degree),
@@ -127,7 +127,7 @@ def test_prism_transformation_degrees(element_type, degree, element_args):
     assert len(bt) == 19
     identity = np.identity(e.dim)
     for i, degree in enumerate([2, 2, 2, 2, 2, 2, 2, 2, 2,
-                               3, 2, 4, 2, 4, 2, 4, 2, 3, 2]):
+                                3, 2, 4, 2, 4, 2, 4, 2, 3, 2]):
         assert np.allclose(
             np.linalg.matrix_power(bt[i], degree),
             identity)
@@ -140,7 +140,7 @@ def test_pyramid_transformation_degrees(element_type, degree, element_args):
     assert len(bt) == 18
     identity = np.identity(e.dim)
     for i, degree in enumerate([2, 2, 2, 2, 2, 2, 2, 2,
-                               4, 2, 3, 2, 3, 2, 3, 2, 3, 2]):
+                                4, 2, 3, 2, 3, 2, 3, 2, 3, 2]):
         assert np.allclose(
             np.linalg.matrix_power(bt[i], degree),
             identity)

--- a/test/test_orthonormal_basis.py
+++ b/test/test_orthonormal_basis.py
@@ -18,12 +18,12 @@ def test_quad(order):
             Qwts.append(u * v)
     basis = basix._basixcpp.tabulate_polynomial_set(basix.CellType.quadrilateral,
                                                     order, 0, Qpts)[0]
-    ndofs = basis.shape[1]
+    ndofs = basis.shape[0]
 
     mat = np.zeros((ndofs, ndofs))
     for i in range(ndofs):
         for j in range(ndofs):
-            mat[i, j] = sum(basis[:, i] * basis[:, j] * Qwts)
+            mat[i, j] = sum(basis[i, :] * basis[j, :] * Qwts)
 
     assert np.allclose(mat, np.eye(ndofs))
 
@@ -41,12 +41,12 @@ def test_pyramid(order):
                 Qwts.append(u * v * sc * sc * w)
     basis = basix._basixcpp.tabulate_polynomial_set(basix.CellType.pyramid,
                                                     order, 0, Qpts)[0]
-    ndofs = basis.shape[1]
+    ndofs = basis.shape[0]
 
     mat = np.zeros((ndofs, ndofs))
     for i in range(ndofs):
         for j in range(ndofs):
-            mat[i, j] = sum(basis[:, i] * basis[:, j] * Qwts)
+            mat[i, j] = sum(basis[i, :] * basis[j, :] * Qwts)
 
     assert np.allclose(mat, np.eye(ndofs))
 
@@ -63,12 +63,12 @@ def test_hex(order):
                 Qwts.append(u * v * w)
     basis = basix._basixcpp.tabulate_polynomial_set(basix.CellType.hexahedron,
                                                     order, 0, Qpts)[0]
-    ndofs = basis.shape[1]
+    ndofs = basis.shape[0]
 
     mat = np.zeros((ndofs, ndofs))
     for i in range(ndofs):
         for j in range(ndofs):
-            mat[i, j] = sum(basis[:, i] * basis[:, j] * Qwts)
+            mat[i, j] = sum(basis[i, :] * basis[j, :] * Qwts)
 
     assert np.allclose(mat, np.eye(ndofs))
 
@@ -85,12 +85,12 @@ def test_prism(order):
             Qwts.append(u * v)
     basis = basix._basixcpp.tabulate_polynomial_set(basix.CellType.prism,
                                                     order, 0, Qpts)[0]
-    ndofs = basis.shape[1]
+    ndofs = basis.shape[0]
 
     mat = np.zeros((ndofs, ndofs))
     for i in range(ndofs):
         for j in range(ndofs):
-            mat[i, j] = sum(basis[:, i] * basis[:, j] * Qwts)
+            mat[i, j] = sum(basis[i, :] * basis[j, :] * Qwts)
 
     assert np.allclose(mat, np.eye(ndofs))
 
@@ -108,10 +108,10 @@ def test_cell(cell_type, order):
     Qpts, Qwts = basix.make_quadrature(cell_type, 2*order + 1)
     basis = basix._basixcpp.tabulate_polynomial_set(cell_type, order, 0, Qpts)[0]
 
-    ndofs = basis.shape[1]
+    ndofs = basis.shape[0]
     mat = np.zeros((ndofs, ndofs))
     for i in range(ndofs):
         for j in range(ndofs):
-            mat[i, j] = sum(basis[:, i] * basis[:, j] * Qwts)
+            mat[i, j] = sum(basis[i, :] * basis[j, :] * Qwts)
 
     assert np.allclose(mat, np.eye(ndofs))

--- a/test/test_orthonormal_basis_symbolic.py
+++ b/test/test_orthonormal_basis_symbolic.py
@@ -33,7 +33,7 @@ def test_symbolic_interval():
         wsym = np.zeros_like(wtab[k])
         for i in range(n + 1):
             for j, p in enumerate(pts0):
-                wsym[j, i] = wd[i].subs(x, p[0])
+                wsym[i, j] = wd[i].subs(x, p[0])
             wd[i] = sympy.diff(wd[i], x)
         assert np.allclose(wtab[k], wsym)
 
@@ -60,5 +60,5 @@ def test_symbolic_quad():
             for i in range(m):
                 wd = sympy.diff(w[i], x, kx, y, ky)
                 for j, p in enumerate(pts0):
-                    wsym[j, i] = wd.subs([(x, p[0]), (y, p[1])])
+                    wsym[i, j] = wd.subs([(x, p[0]), (y, p[1])])
             assert np.allclose(wtab[idx(kx, ky)], wsym)


### PR DESCRIPTION
Transpose the last two indices of polysets, so that `xt::row` is now used instead of `xt::col`

Fixes #395.