### PR TITLE
Fix various typos

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -42,7 +42,7 @@ pip install .
 
 ## Running the unit tests
 
-To install Basix and the extra depedencies required to run the Python unit tests:
+To install Basix and the extra dependencies required to run the Python unit tests:
 
 ```console
 pip install .[test]

--- a/cpp/basix/e-nedelec.cpp
+++ b/cpp/basix/e-nedelec.cpp
@@ -114,7 +114,7 @@ impl::mdarray2_t create_nedelec_3d_space(int degree)
       for (std::size_t k = 0; k < wts.size(); ++k)
         w += wts[k] * phi(0, ns0 + i, k) * pts(k, 2) * phi(0, j, k);
 
-      // Don't include polynomials (*, *, 0) that are dependant
+      // Don't include polynomials (*, *, 0) that are dependent
       if (i >= ns_remove)
         wcoeffs(tdim * nv + i - ns_remove, psize + j) = -w;
       wcoeffs(tdim * nv + i + ns - ns_remove, j) = w;
@@ -130,7 +130,7 @@ impl::mdarray2_t create_nedelec_3d_space(int degree)
         w += wts[k] * phi(0, ns0 + i, k) * pts(k, 1) * phi(0, j, k);
       wcoeffs(tdim * nv + i + ns * 2 - ns_remove, j) = -w;
 
-      // Don't include polynomials (*, *, 0) that are dependant
+      // Don't include polynomials (*, *, 0) that are dependent
       if (i >= ns_remove)
         wcoeffs(tdim * nv + i - ns_remove, psize * 2 + j) = w;
     }

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -705,7 +705,7 @@ FiniteElement::FiniteElement(
     }
   }
 
-  // Check that nunber of dofs is equal to number of coefficients
+  // Check that number of dofs is equal to number of coefficients
   if (num_dofs != _coeffs.second[0])
   {
     throw std::runtime_error(

--- a/cpp/basix/finite-element.h
+++ b/cpp/basix/finite-element.h
@@ -1008,7 +1008,7 @@ public:
   /// point_index, derivative).
   ///
   /// These matrices define how to evaluate the DOF functionals
-  /// accociated with each sub-entity of the cell. Given a function f,
+  /// associated with each sub-entity of the cell. Given a function f,
   /// the functionals associated with the `e`-th entity of dimension `d`
   /// can be computed as follows:
   ///

--- a/cpp/basix/mdspan.hpp
+++ b/cpp/basix/mdspan.hpp
@@ -4349,7 +4349,7 @@ class layout_right::mapping {
     }
 #endif
 
-    // Not really public, but currently needed to implement fully constexpr useable submdspan:
+    // Not really public, but currently needed to implement fully constexpr usable submdspan:
     template<size_t N, class SizeType, size_t ... E, size_t ... Idx>
     constexpr index_type __get_stride(std::experimental::extents<SizeType, E...>,integer_sequence<size_t, Idx...>) const {
       return _MDSPAN_FOLD_TIMES_RIGHT((Idx>N? __extents.template __extent<Idx>():1),1);
@@ -4964,7 +4964,7 @@ class layout_left::mapping {
     }
 #endif
 
-    // Not really public, but currently needed to implement fully constexpr useable submdspan:
+    // Not really public, but currently needed to implement fully constexpr usable submdspan:
     template<size_t N, class SizeType, size_t ... E, size_t ... Idx>
     constexpr index_type __get_stride(std::experimental::extents<SizeType, E...>,integer_sequence<size_t, Idx...>) const {
       return _MDSPAN_FOLD_TIMES_RIGHT((Idx<N? __extents.template __extent<Idx>():1),1);

--- a/cpp/basix/polyset.h
+++ b/cpp/basix/polyset.h
@@ -89,7 +89,7 @@
 /// ### Prism
 /// The polynomial set for a prism can be computed by using using the recurrence
 /// relation for the triangle to get the polynomials that are constant with
-/// repect to \f$z\f$, then applying the recurrence relation for the interval to
+/// respect to \f$z\f$, then applying the recurrence relation for the interval to
 /// compute further polynomials with \f$z\f$s.
 ///
 /// ### Pyramid

--- a/cpp/basix/precompute.h
+++ b/cpp/basix/precompute.h
@@ -196,7 +196,7 @@ prepare_matrix(std::pair<std::vector<double>, std::array<std::size_t, 2>>& A);
 /// @note This function is designed to be called at runtime, so its
 /// performance is critical.
 ///
-/// @param[in] v_size_t A permutaion, as computed by
+/// @param[in] v_size_t A permutation, as computed by
 /// precompute::prepare_matrix
 /// @param[in] M The vector created by precompute::prepare_matrix
 /// @param[in,out] data The data to apply the permutation to

--- a/demo/python/demo_custom_element.py
+++ b/demo/python/demo_custom_element.py
@@ -130,7 +130,7 @@ for _ in range(4):
 # - The coefficients that define the polynomial set. In this example, this is `wcoeffs`.
 # - The points used to define interpolation into the element. In this example, this is `x`.
 # - The matrix used to define interpolation into the element. In this example, this is `M`.
-# - The number of derivates used in the evalutation of the functionals. In this example, this
+# - The number of derivates used in the evaluation of the functionals. In this example, this
 #   is 0.
 # - The map type. In this example, this is the identity map.
 # - A bool indicating whether the element is discontinuous. In this example, this is `False`.

--- a/demo/python/demo_facet_integral.py
+++ b/demo/python/demo_facet_integral.py
@@ -58,7 +58,7 @@ mapped_points = np.array([
 # entry as the value size is 1).
 #
 # We then multiply the three derivatives of the basis function by
-# the three componenets of the normal.
+# the three components of the normal.
 
 normal = basix.cell.facet_outward_normals(CellType.tetrahedron)[0]
 tab = lagrange.tabulate(1, mapped_points)[1:, :, 5, 0]

--- a/demo/python/demo_quadrature.py
+++ b/demo/python/demo_quadrature.py
@@ -82,6 +82,6 @@ values = lagrange.tabulate(0, points)
 # function in this space. We can obtain the values of this basis function from
 # `values` by using the indices `[0, :, 3, 0]`. The integral can therefore
 # computed as follows. As this basis function will be degree three, the result
-# will again be exact (withing machine precision).
+# will again be exact (within machine precision).
 
 print(np.sum(weights * values[0, :, 3, 0]))

--- a/doc/web/polyset-order.md
+++ b/doc/web/polyset-order.md
@@ -103,7 +103,7 @@ polynomials times \\(x^2\\), and so on; ie
 
 ### Hexahedron
 On a hexahedron, we take a tensor product of the polynomials on an interval
-with \\(z\\) as the varibles and the polynomials on a quadrilateral with
+with \\(z\\) as the variables and the polynomials on a quadrilateral with
 \\((x,y)\\) as the variables. The resulting ordering has polynomials containing
 only \\(z\\) first (low-to-high degree) then these polynomials times \\(y\\),
 then the same polynomials times \\(y^2\\), then \\(y^3\\) and so on (following
@@ -176,7 +176,7 @@ the order on a quadrilateral); ie
 
 ### Prism
 On a hexahedron, we take a tensor product of the polynomials on an interval
-with \\(z\\) as the varibles and the polynomials on a triangle with
+with \\(z\\) as the variables and the polynomials on a triangle with
 \\((x,y)\\) as the variables. The resulting ordering has polynomials containing
 only \\(z\\) first (low-to-high degree) then these polynomials times \\(y\\),
 then the same polynomials times \\(x\\), then \\(y^2\\) and so on (following

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -55,7 +55,7 @@ endif()
 
 # scikit-build specific steps
 if (SKBUILD)
-  # Add relative rpath so _basixcpp can find the Basix::basix libray
+  # Add relative rpath so _basixcpp can find the Basix::basix library
   # when the build is relocated
   if (APPLE)
     set_target_properties(_basixcpp PROPERTIES INSTALL_RPATH "@loader_path/lib")

--- a/test/test_interpolation_between_elements.py
+++ b/test/test_interpolation_between_elements.py
@@ -105,7 +105,7 @@ def test_different_element_interpolation(family1, args1, family2, args2, cell_ty
                                        basix.CellType.quadrilateral, basix.CellType.hexahedron])
 @pytest.mark.parametrize("order", [1, 4])
 def test_blocked_interpolation(cell_type, order):
-    """Test interpolation of Nedelec's componenets into a Lagrange space."""
+    """Test interpolation of Nedelec's components into a Lagrange space."""
     nedelec = basix.create_element(
         basix.ElementFamily.N2E, cell_type, order, basix.LagrangeVariant.legendre, basix.DPCVariant.legendre)
     lagrange = basix.create_element(basix.ElementFamily.P, cell_type, order, basix.LagrangeVariant.gll_isaac)


### PR DESCRIPTION
Found via `codespell -q 3 -L ans,nce,nd`