### PR TITLE
Specify C++20 in wheel integration test CMakeLists.txt

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -48,7 +48,7 @@ jobs:
           ref: ${{ github.event.inputs.basix_ref }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.5.0
+        uses: pypa/cibuildwheel@v2.9.0
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -83,14 +83,14 @@ jobs:
           name: artifact
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@v1.5.0
+      - uses: pypa/gh-action-pypi-publish@v1.5.1
         if: ${{ github.event.inputs.pypi_publish == 'true' }}
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}
           repository_url: https://upload.pypi.org/legacy/
 
-      - uses: pypa/gh-action-pypi-publish@v1.5.0
+      - uses: pypa/gh-action-pypi-publish@v1.5.1
         if: ${{ github.event.inputs.test_pypi_publish == 'true' }}
         with:
           user: __token__

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -64,7 +64,14 @@ jobs:
         run: |
           pytest -n auto --durations 20 test/
 
-      - name: Run python demos
+      - name: Run simple CMake integration test
+        run: |
+          cd test/test_cmake
+          cmake -DCMAKE_BUILD_TYPE=Debug -DPython3_EXECUTABLE=python -G Ninja -B build-dir -S .
+          cmake --build build-dir/
+          build-dir/a.out
+
+      - name: Run Python demos
         run: |
           pytest demo/python/test.py
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,9 @@ requires = ["setuptools>=42", "wheel", "pybind11>=2.6.4", "cmake>=3.16", "scikit
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
-build = ["cp{38,39,310,311}-manylinux_x86_64", "cp{38,39,310,311}-macosx_x86_64"]
+build = ["cp{38,39,310}-manylinux_x86_64", "cp{38,39,310}-macosx_x86_64"]
 
-test-command = "cmake -DPython3_EXECUTABLE=$(which python) -G Ninja -B build -S {project}/test/test_cmake && cmake --build build/ && build/a.out && python -m pytest -v -n auto --durations 20 {project}/test/"
+test-command = "cmake -DPython3_EXECUTABLE=$(which python) -G Ninja -B build-dir -S {project}/test/test_cmake && cmake --build build-dir/ && build-dir/a.out && python -m pytest -v -n auto --durations 20 {project}/test/"
 test-requires = ["pytest-xdist"]
 test-extras = ["test"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,13 @@ requires = ["setuptools>=42", "wheel", "pybind11>=2.6.4", "cmake>=3.16", "scikit
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
-build = ["cp{37,38,39}-manylinux_x86_64", "cp{37,38,39}-macosx_x86_64"]
+build = ["cp{38,39}-manylinux_x86_64", "cp{38,39}-macosx_x86_64"]
 
 test-command = "cmake -DPython3_EXECUTABLE=$(which python) -G Ninja -B build -S {project}/test/test_cmake && cmake --build build/ && build/a.out && python -m pytest -v -n auto --durations 20 {project}/test/"
 test-requires = ["pytest-xdist"]
 test-extras = ["test"]
 
-manylinux-x86_64-image = "manylinux2014"
+manylinux-x86_64-image = "manylinux_2_28"
 
 [tool.cibuildwheel.linux]
 before-build = "yum -y update && yum install -y openblas-devel ninja-build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,13 @@ requires = ["setuptools>=42", "wheel", "pybind11>=2.6.4", "cmake>=3.16", "scikit
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
-build = ["cp{38,39}-manylinux_x86_64", "cp{38,39}-macosx_x86_64"]
+build = ["cp{38,39,310,311}-manylinux_x86_64", "cp{38,39,310,311}-macosx_x86_64"]
 
 test-command = "cmake -DPython3_EXECUTABLE=$(which python) -G Ninja -B build -S {project}/test/test_cmake && cmake --build build/ && build/a.out && python -m pytest -v -n auto --durations 20 {project}/test/"
 test-requires = ["pytest-xdist"]
 test-extras = ["test"]
 
-manylinux-x86_64-image = "manylinux_2_28"
+manylinux-x86_64-image = "manylinux2014"
 
 [tool.cibuildwheel.linux]
 before-build = "yum -y update && yum install -y openblas-devel ninja-build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools>=42", "wheel", "pybind11>=2.6.4", "cmake>=3.16", "scikit
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
-build = ["cp{38,39,310}-manylinux_x86_64", "cp{38,39,310}-macosx_x86_64"]
+build = ["cp{37,38,39,310}-manylinux_x86_64", "cp{37,38,39,310}-macosx_x86_64"]
 
 test-command = "cmake -DPython3_EXECUTABLE=$(which python) -G Ninja -B build-dir -S {project}/test/test_cmake && cmake --build build-dir/ && build-dir/a.out && python -m pytest -v -n auto --durations 20 {project}/test/"
 test-requires = ["pytest-xdist"]

--- a/test/test_cmake/CMakeLists.txt
+++ b/test/test_cmake/CMakeLists.txt
@@ -4,6 +4,11 @@ cmake_minimum_required(VERSION 3.16)
 
 project(basix_test)
 
+# Set the C++ standard
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 # Use Python for detecting Basix
 find_package(Python3 COMPONENTS Interpreter REQUIRED)
 

--- a/test/test_cmake/CMakeLists.txt
+++ b/test/test_cmake/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Example of CMakeLists.txt for downstream C++ project (eg DOLFINx)
-# Used to check correctly installed package during wheel creation.:
+# Used to check correctly installed package during tests and wheel creation.
 cmake_minimum_required(VERSION 3.16)
 
 project(basix_test)


### PR DESCRIPTION
Basix requires C++20, so the `test_cmake/` CMakeLists.txt file should explicitly specify this.

I will also makes sure that this is run as part of the normal CI tests.

