### PR TITLE
use gdim as default for VectorElement (not tdim)

### DIFF
--- a/python/basix/ufl_wrapper.py
+++ b/python/basix/ufl_wrapper.py
@@ -1127,8 +1127,10 @@ class VectorElement(BlockedElement):
 
     def __init__(self, sub_element: _BasixElementBase, size: int = None, gdim: int = None):
         """Initialise the element."""
+        if gdim is None:
+            gdim = len(_basix.topology(sub_element.cell_type)) - 1
         if size is None:
-            size = len(_basix.topology(sub_element.cell_type)) - 1
+            size = gdim
         super().__init__(f"VectorElement({sub_element._repr}, {size})", sub_element, size, (size, ), gdim=gdim)
 
 
@@ -1138,9 +1140,10 @@ class TensorElement(BlockedElement):
     def __init__(self, sub_element: _BasixElementBase, shape: _typing.Tuple[int, int] = None, symmetric: bool = False,
                  gdim: int = None):
         """Initialise the element."""
+        if gdim is None:
+            gdim = len(_basix.topology(sub_element.cell_type)) - 1
         if shape is None:
-            size = len(_basix.topology(sub_element.cell_type)) - 1
-            shape = (size, size)
+            shape = (gdim, gdim)
         if symmetric:
             assert shape[0] == shape[1]
             bs = shape[0] * (shape[0] + 1) // 2


### PR DESCRIPTION
Fixes #603.

This might mean FEniCS/dolfinx#2389 is fixed