### PR TITLE
Tidy up CI and packaging

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -48,7 +48,7 @@ jobs:
           ref: ${{ github.event.inputs.basix_ref }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2
+        uses: pypa/cibuildwheel@v2.11.1
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
@@ -83,14 +83,14 @@ jobs:
           name: artifact
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@v1
+      - uses: pypa/gh-action-pypi-publish@v1.5.1
         if: ${{ github.event.inputs.pypi_publish == 'true' }}
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}
           repository_url: https://upload.pypi.org/legacy/
 
-      - uses: pypa/gh-action-pypi-publish@v1
+      - uses: pypa/gh-action-pypi-publish@v1.5.1
         if: ${{ github.event.inputs.test_pypi_publish == 'true' }}
         with:
           user: __token__

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-11, macos-12]
+        os: [ubuntu-latest, macos-11, macos-12]
 
     steps:
       - uses: actions/checkout@v3
@@ -48,7 +48,7 @@ jobs:
           ref: ${{ github.event.inputs.basix_ref }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.9.0
+        uses: pypa/cibuildwheel@v2
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
@@ -83,14 +83,14 @@ jobs:
           name: artifact
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@v1.5.1
+      - uses: pypa/gh-action-pypi-publish@v1
         if: ${{ github.event.inputs.pypi_publish == 'true' }}
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}
           repository_url: https://upload.pypi.org/legacy/
 
-      - uses: pypa/gh-action-pypi-publish@v1.5.1
+      - uses: pypa/gh-action-pypi-publish@v1
         if: ${{ github.event.inputs.test_pypi_publish == 'true' }}
         with:
           user: __token__

--- a/.github/workflows/ffcx-tests.yml
+++ b/.github/workflows/ffcx-tests.yml
@@ -37,13 +37,13 @@ jobs:
 
       - name: Install UFL (default branch)
         if: github.event_name != 'workflow_dispatch'
-        run: pip install git+https://github.com/FEniCS/ufl.git
+        run: python3 -m pip install git+https://github.com/FEniCS/ufl.git
       - name: Install UFL (specified branch)
         if: github.event_name == 'workflow_dispatch'
-        run: pip install git+https://github.com/FEniCS/ufl.git@${{ github.event.inputs.ufl_branch }}
+        run: python3 -m pip install git+https://github.com/FEniCS/ufl.git@${{ github.event.inputs.ufl_branch }}
 
       - name: Install Basix
-        run: pip -v install .[ci]
+        run: python3 -m pip -v install .[ci]
 
       - name: Get FFCx source (default branch)
         if: github.event_name != 'workflow_dispatch'
@@ -60,9 +60,8 @@ jobs:
           ref: ${{ github.event.inputs.ffcx_branch }}
 
       - name: Install FFCx
-        run: pip install ./ffcx[ci]
+        run: python3 -m pip install ./ffcx[ci]
       - name: Run mypy checks
-        run: |
-          python -m mypy ffcx/ffcx
+        run: python3 -m mypy ffcx/ffcx
       - name: Run FFCx tests
-        run: python -m pytest -n auto ffcx/test
+        run: python3 -m pytest -n auto ffcx/test

--- a/.github/workflows/ffcx-tests.yml
+++ b/.github/workflows/ffcx-tests.yml
@@ -43,7 +43,7 @@ jobs:
         run: pip install git+https://github.com/FEniCS/ufl.git@${{ github.event.inputs.ufl_branch }}
 
       - name: Install Basix
-        run: pip -v install .
+        run: pip -v install .[ci]
 
       - name: Get FFCx source (default branch)
         if: github.event_name != 'workflow_dispatch'
@@ -59,12 +59,10 @@ jobs:
           repository: FEniCS/ffcx
           ref: ${{ github.event.inputs.ffcx_branch }}
 
-      - name: Run mypy checks
-        run: |
-          python -m pip install mypy types-setuptools
-          python -m mypy ffcx/ffcx
-
       - name: Install FFCx
         run: pip install ./ffcx[ci]
+      - name: Run mypy checks
+        run: |
+          python -m mypy ffcx/ffcx
       - name: Run FFCx tests
         run: python -m pytest -n auto ffcx/test

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -38,24 +38,20 @@ jobs:
       - name: Install Basix
         run: |
           . /opt/intel/oneapi/setvars.sh
-          export CMAKE_ARGS="-DDOWNLOAD_XTENSOR_LIBS:BOOL=true"
-          pip install scikit-build
-          pip install git+https://github.com/FEniCS/ufl.git
-          pip -v install .[test]
+          python3 -m pip -v install .[optional,test]
       - name: Run units tests
         # LD_PRELOAD is required to 'fix' library resolution problems
         # when Numpy is not built against MKL
         run: |
           . /opt/intel/oneapi/setvars.sh
-          pip install pytest-xdist
           export LD_PRELOAD=/opt/intel/oneapi/mkl/latest/lib/intel64/libmkl_core.so:/opt/intel/oneapi/mkl/latest/lib/intel64/libmkl_sequential.so
-          pytest -n auto --durations 20 test/
+          python3 -m pytest -n auto --durations 20 test/
 
       - name: Run Python demos
         run: |
           . /opt/intel/oneapi/setvars.sh
           export LD_PRELOAD=/opt/intel/oneapi/mkl/latest/lib/intel64/libmkl_core.so:/opt/intel/oneapi/mkl/latest/lib/intel64/libmkl_sequential.so
-          pytest demo/python/test.py
+          python3 -m pytest demo/python/test.py
 
       - name: Run C++ demos
         run: |
@@ -63,4 +59,4 @@ jobs:
           export LD_PRELOAD=/opt/intel/oneapi/mkl/latest/lib/intel64/libmkl_core.so:/opt/intel/oneapi/mkl/latest/lib/intel64/libmkl_sequential.so
           export INSTALL_DIR=$(pwd)/`python3 -c "import skbuild; print(skbuild.cmaker.CMAKE_INSTALL_DIR())"`
           export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:$INSTALL_DIR/python/basix/lib/cmake:$INSTALL_DIR/python/basix/share/cmake
-          pytest demo/cpp/test.py
+          python3 -m pytest demo/cpp/test.py

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     name: Build and test
     runs-on: ubuntu-latest
-    container: ubuntu:latest  # Run in container to test with minimal pre-installed packages
+    container: ubuntu:22.04  # Run in container to test with minimal pre-installed packages
 
     env:
       CC: icx
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Install required packages to install Intel compilers and to build
-        run: apt-get update && apt-get install -y cmake git gnupg ninja-build python3-pip wget
+        run: apt -y update && apt install -y cmake git gnupg ninja-build python3-pip wget
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -58,6 +58,4 @@ jobs:
         run: |
           . /opt/intel/oneapi/setvars.sh
           export LD_PRELOAD=/opt/intel/oneapi/mkl/latest/lib/intel64/libmkl_core.so:/opt/intel/oneapi/mkl/latest/lib/intel64/libmkl_sequential.so
-          export INSTALL_DIR=$(pwd)/`python3 -c "import skbuild; print(skbuild.cmaker.CMAKE_INSTALL_DIR())"`
-          export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:$INSTALL_DIR/python/basix/lib/cmake:$INSTALL_DIR/python/basix/share/cmake
           python3 -m pytest demo/cpp/test.py

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -45,6 +45,7 @@ jobs:
         run: |
           . /opt/intel/oneapi/setvars.sh
           export LD_PRELOAD=/opt/intel/oneapi/mkl/latest/lib/intel64/libmkl_core.so:/opt/intel/oneapi/mkl/latest/lib/intel64/libmkl_sequential.so
+          python3 -m pip install pytest-xdist
           python3 -m pytest -n auto --durations 20 test/
 
       - name: Run Python demos

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Basix
         run: |
           . /opt/intel/oneapi/setvars.sh
-          python3 -m pip -v install .[optional,test]
+          python3 -m pip -v install .[test]
       - name: Run units tests
         # LD_PRELOAD is required to 'fix' library resolution problems
         # when Numpy is not built against MKL

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Run C++ demos
         run: |
-          python3 -m pip install skbuild
+          python3 -m pip install scikit-build # Only installed previously in isolated build environment
           export INSTALL_DIR=$(pwd)/`python3 -c "import skbuild; print(skbuild.cmaker.CMAKE_INSTALL_DIR())"`
           export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:$INSTALL_DIR/python/basix/lib/cmake:$INSTALL_DIR/python/basix/share/cmake
           python3 -m pytest demo/cpp/test.py

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -28,17 +28,16 @@ jobs:
 
       - name: Install Basix
         run: |
-          python3 -m pip -v install .[test]
+          python -m pip -v install .[test]
 
       - name: Run units tests
         run: | 
-          python3 -m pip install pytest-xdist
-          python3 -m pytest -n auto --durations 20 test/
+          python -m pip install pytest-xdist
+          python -m pytest -n auto --durations 20 test/
 
       - name: Run python demos
-        run: python3 -m pytest demo/python/test.py
+        run: python -m pytest demo/python/test.py
 
       - name: Run C++ demos
         run: |
-          python3 -m pip install scikit-build # Only installed previously in isolated build environment
-          python3 -m pytest demo/cpp/test.py
+          python -m pytest demo/cpp/test.py

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install Basix
         run: |
-          python3 -m pip -v install .[optional,test]
+          python3 -m pip -v install .[test]
 
       - name: Run units tests
         run: python3 -m pytest -n auto --durations 20 test/

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -28,18 +28,17 @@ jobs:
 
       - name: Install Basix
         run: |
-          pip install scikit-build
-          pip install git+https://github.com/FEniCS/ufl.git
-          pip -v install .[ci]
+          python3 -m pip -v install .[optional,test]
 
       - name: Run units tests
-        run: pytest -n auto --durations 20 test/
+        run: python3 -m pytest -n auto --durations 20 test/
 
       - name: Run python demos
-        run: pytest demo/python/test.py
+        run: python3 -m pytest demo/python/test.py
 
       - name: Run C++ demos
         run: |
+          python3 -m pip install skbuild
           export INSTALL_DIR=$(pwd)/`python3 -c "import skbuild; print(skbuild.cmaker.CMAKE_INSTALL_DIR())"`
           export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:$INSTALL_DIR/python/basix/lib/cmake:$INSTALL_DIR/python/basix/share/cmake
-          pytest demo/cpp/test.py
+          python3 -m pytest demo/cpp/test.py

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -31,7 +31,9 @@ jobs:
           python3 -m pip -v install .[test]
 
       - name: Run units tests
-        run: python3 -m pytest -n auto --durations 20 test/
+        run: | 
+          python3 -m pip install pytest-xdist
+          python3 -m pytest -n auto --durations 20 test/
 
       - name: Run python demos
         run: python3 -m pytest demo/python/test.py

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -41,6 +41,4 @@ jobs:
       - name: Run C++ demos
         run: |
           python3 -m pip install scikit-build # Only installed previously in isolated build environment
-          export INSTALL_DIR=$(pwd)/`python3 -c "import skbuild; print(skbuild.cmaker.CMAKE_INSTALL_DIR())"`
-          export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:$INSTALL_DIR/python/basix/lib/cmake:$INSTALL_DIR/python/basix/share/cmake
           python3 -m pytest demo/cpp/test.py

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -171,6 +171,7 @@ jobs:
           sudo cmake --install build-dir
 
       - name: Install Basix Python wrapper
+        run: |
           cd python
           python3 -m pip install .[test]
 

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -9,8 +9,7 @@ on:
     branches:
       - "**"
     tags:
-      - "*.*.*.*"
-      - "*.*.*"
+      - "v*"
   pull_request:
     branches:
       - main
@@ -74,7 +73,7 @@ jobs:
 
       - name: Run C++ demos
         run: |
-          python3 -m pip install skbuild
+          python3 -m pip install scikit-build # Only installed previously in isolated environment
           export INSTALL_DIR=$(pwd)/`python3 -c "import skbuild; print(skbuild.cmaker.CMAKE_INSTALL_DIR())"`
           export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:$INSTALL_DIR/python/basix/lib/cmake:$INSTALL_DIR/python/basix/share/cmake
           python3 -m pytest demo/cpp/test.py
@@ -145,7 +144,7 @@ jobs:
           git push
 
   build-cmake:
-    name: Build using cmake and test
+    name: Build using C++ and Python parts separately and run tests
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -166,14 +165,16 @@ jobs:
 
       - name: Install Basix
         run: |
-          cmake -DCMAKE_BUILD_TYPE=Release -DDOWNLOAD_XTENSOR_LIBS=ON -B build-dir -S .
+          cd cpp
+          cmake -DCMAKE_BUILD_TYPE=Release -B build-dir -S .
           cmake --build build-dir
           sudo cmake --install build-dir
-          cd python && pip install .[test]
+          cd python
+          python3 -m pip install .[test]
 
       - name: Run units tests
         run: |
-          pytest -n auto --durations 20 test/
+          python3 -m pytest -n auto --durations 20 test/
 
       - name: Run python demos
         run: |

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -177,6 +177,7 @@ jobs:
 
       - name: Run units tests
         run: |
+          python3 -m pip install pytest-xdist
           python3 -m pytest -n auto --durations 20 test/
 
       - name: Run python demos
@@ -210,5 +211,5 @@ jobs:
           python-version: "3.10"
       - name: Run C++ demos
         run: |
-          pip install pytest
-          pytest demo/cpp/test.py
+          python3 -m pip install pytest
+          python3 -m pytest demo/cpp/test.py

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -177,7 +177,7 @@ jobs:
 
       - name: Run units tests
         run: |
-          python3 -m pip install pytest-xdist
+          python3 -m pip install pytest-xdist # in ci extras, but most not needed.
           python3 -m pytest -n auto --durations 20 test/
 
       - name: Run python demos

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Run simple CMake integration test
         run: |
           cd test/test_cmake
-          cmake -DCMAKE_BUILD_TYPE=Debug -DPython3_EXECUTABLE=python -G Ninja -B build-dir -S .
+          cmake -DCMAKE_BUILD_TYPE=Debug -DPython3_EXECUTABLE=python3 -G Ninja -B build-dir -S .
           cmake --build build-dir/
           build-dir/a.out
 
@@ -73,9 +73,6 @@ jobs:
 
       - name: Run C++ demos
         run: |
-          python3 -m pip install scikit-build # Only installed previously in isolated environment
-          export INSTALL_DIR=$(pwd)/`python3 -c "import skbuild; print(skbuild.cmaker.CMAKE_INSTALL_DIR())"`
-          export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:$INSTALL_DIR/python/basix/lib/cmake:$INSTALL_DIR/python/basix/share/cmake
           python3 -m pytest demo/cpp/test.py
 
       - name: Build documentation
@@ -180,9 +177,13 @@ jobs:
           python3 -m pip install pytest-xdist # in ci extras, but most not needed.
           python3 -m pytest -n auto --durations 20 test/
 
-      - name: Run python demos
+      - name: Run Python demos
         run: |
-          pytest demo/python/test.py
+          python3 -m pytest demo/python/test.py
+      
+      - name: Run C++ demos
+        run: |
+          python3 -m pytest demo/cpp/test.py
 
   build-cpp-only:
     name: Build C++ only and run demos

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -161,12 +161,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: sudo apt-get install -y libopenblas-dev liblapack-dev ninja-build
+        run: sudo apt-get install -y libopenblas-dev liblapack-dev
 
       - name: Install Basix C++ library
         run: |
           cd cpp
-          cmake -DCMAKE_BUILD_TYPE=Release -B build-dir -S .
+          cmake -DCMAKE_BUILD_TYPE=Release -B build-dir -S . # Use make (not ninja)
           cmake --build build-dir
           sudo cmake --install build-dir
 
@@ -200,7 +200,7 @@ jobs:
 
       - name: Install Basix
         run: |
-          cmake -DCMAKE_BUILD_TYPE=Release -DDOWNLOAD_XTENSOR_LIBS=ON -B build-dir -S cpp
+          cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -B build-dir -S cpp
           cmake --build build-dir
           sudo cmake --install build-dir
 

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -38,33 +38,28 @@ jobs:
           sudo apt-get update
           sudo apt-get -y upgrade
           sudo apt-get install -y doxygen libgraphviz-dev libopenblas-dev liblapack-dev ninja-build
-          pip install git+https://github.com/FEniCS/ufl.git
-          pip install scikit-build
 
       - name: Install Basix
-        run: pip -v install .[ci]
+        run: python3 -m pip -v install .[ci]
 
       - name: Lint with flake8
         run: |
-          pip install flake8
           flake8 --statistics test/
           flake8 --statistics python/
           flake8 --statistics demo/python
 
       - name: Run mypy checks
-        run: |
-          pip install mypy
-          python -m mypy python/basix
         if: matrix.python-version != '3.10'
+        run: |
+          python3 -m mypy python/basix
 
       - name: pydocstyle checks
         run: |
-          pip install pydocstyle
-          python -m pydocstyle python/basix
+          python3 -m pydocstyle python/basix
 
       - name: Run units tests
         run: |
-          pytest -n auto --durations 20 test/
+          python3 -m pytest -n auto --durations 20 test/
 
       - name: Run simple CMake integration test
         run: |
@@ -75,17 +70,17 @@ jobs:
 
       - name: Run Python demos
         run: |
-          pytest demo/python/test.py
+          python3 -m pytest demo/python/test.py
 
       - name: Run C++ demos
         run: |
+          python3 -m pip install skbuild
           export INSTALL_DIR=$(pwd)/`python3 -c "import skbuild; print(skbuild.cmaker.CMAKE_INSTALL_DIR())"`
           export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:$INSTALL_DIR/python/basix/lib/cmake:$INSTALL_DIR/python/basix/share/cmake
-          pytest demo/cpp/test.py
+          python3 -m pytest demo/cpp/test.py
 
       - name: Build documentation
         run: |
-          pip install git+https://github.com/FEniCS/ufl.git
           export BASIX_VERSION=`python3 -c "import basix; print(basix.__version__)"`
           cd doc/cpp
           doxygen
@@ -169,17 +164,12 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get install -y libopenblas-dev liblapack-dev ninja-build
 
-      - name: Install CI dependencies
-        run: |
-          pip install pytest sympy numba scipy matplotlib pytest-xdist pybind11
-          pip install git+https://github.com/FEniCS/ufl.git
-
       - name: Install Basix
         run: |
           cmake -DCMAKE_BUILD_TYPE=Release -DDOWNLOAD_XTENSOR_LIBS=ON -B build-dir -S .
           cmake --build build-dir
           sudo cmake --install build-dir
-          cd python && pip install .
+          cd python && pip install .[test]
 
       - name: Run units tests
         run: |

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -163,12 +163,14 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get install -y libopenblas-dev liblapack-dev ninja-build
 
-      - name: Install Basix
+      - name: Install Basix C++ library
         run: |
           cd cpp
           cmake -DCMAKE_BUILD_TYPE=Release -B build-dir -S .
           cmake --build build-dir
           sudo cmake --install build-dir
+
+      - name: Install Basix Python wrapper
           cd python
           python3 -m pip install .[test]
 

--- a/.github/workflows/redhat.yml
+++ b/.github/workflows/redhat.yml
@@ -44,6 +44,4 @@ jobs:
         run: python3 -m pytest demo/python/test.py
       - name: Run C++ demos
         run: |
-          export INSTALL_DIR=`python3 -c "import basix; print('/'.join(basix.__file__.split('/')[:-1]))"`
-          export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:$INSTALL_DIR/lib/cmake:$INSTALL_DIR/share/cmake
           python3 -m pytest demo/cpp/test.py

--- a/.github/workflows/redhat.yml
+++ b/.github/workflows/redhat.yml
@@ -24,7 +24,8 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-          dnf install -y blas-devel cmake gcc gcc-c++ git lapack-devel python3 python3-devel python3-pip
+          dnf -y update
+          dnf install -y cmake gcc gcc-c++ git lapack-devel python3 python3-devel python3-pip
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/redhat.yml
+++ b/.github/workflows/redhat.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install Basix
         run: |
           source /opt/rh/gcc-toolset-11/enable
-          python3 -m pip install .[optional,test]
+          python3 -m pip install .[test]
 
       - name: Run units tests
         run: |

--- a/.github/workflows/redhat.yml
+++ b/.github/workflows/redhat.yml
@@ -18,8 +18,8 @@ jobs:
     container: rockylinux/rockylinux:8
 
     env:
-      CC: gcc-11
-      CXX: g++-11
+      CC: gcc
+      CXX: g++
 
     steps:
       - name: Install dependencies

--- a/.github/workflows/redhat.yml
+++ b/.github/workflows/redhat.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           dnf -y update
-          dnf install -y cmake gcc gcc-c++ git lapack-devel python3 python3-devel python3-pip
+          dnf install -y blas-devel cmake gcc gcc-c++ git lapack-devel python3 python3-devel python3-pip
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/redhat.yml
+++ b/.github/workflows/redhat.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     name: Build and test (Red Hat)
     runs-on: ubuntu-latest
-    container: rockylinux/rockylinux:8
+    container: rockylinux/rockylinux:9
 
     env:
       CC: gcc
@@ -24,14 +24,12 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-          sed -i 's/enabled=0/enabled=1/' /etc/yum.repos.d/Rocky-PowerTools.repo
-          dnf install -y gcc-toolset-11-toolchain git blas-devel lapack-devel python39 python39-devel python39-pip cmake
+          dnf install -y blas-devel cmake gcc gcc-c++ git lapack-devel python3 python3-devel python3-pip
 
       - uses: actions/checkout@v3
 
       - name: Install Basix
         run: |
-          source /opt/rh/gcc-toolset-11/enable
           python3 -m pip install .[test]
 
       - name: Run units tests
@@ -43,7 +41,6 @@ jobs:
         run: python3 -m pytest demo/python/test.py
       - name: Run C++ demos
         run: |
-          source /opt/rh/gcc-toolset-11/enable
           export INSTALL_DIR=`python3 -c "import basix; print('/'.join(basix.__file__.split('/')[:-1]))"`
           export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:$INSTALL_DIR/lib/cmake:$INSTALL_DIR/share/cmake
           python3 -m pytest demo/cpp/test.py

--- a/.github/workflows/redhat.yml
+++ b/.github/workflows/redhat.yml
@@ -36,6 +36,7 @@ jobs:
 
       - name: Run units tests
         run: |
+          python3 -m pip install pytest-xdist
           python3 -m pytest -n auto --durations 20 test/
 
       - name: Run Python demos

--- a/.github/workflows/redhat.yml
+++ b/.github/workflows/redhat.yml
@@ -18,8 +18,8 @@ jobs:
     container: rockylinux/rockylinux:8
 
     env:
-      CC: gcc
-      CXX: g++
+      CC: gcc-11
+      CXX: g++-11
 
     steps:
       - name: Install dependencies
@@ -32,12 +32,10 @@ jobs:
       - name: Install Basix
         run: |
           source /opt/rh/gcc-toolset-11/enable
-          python3 -m pip install git+https://github.com/FEniCS/ufl.git
-          python3 -m pip install .[test]
+          python3 -m pip install .[optional,test]
 
       - name: Run units tests
         run: |
-          python3 -m pip install pytest-xdist
           python3 -m pytest -n auto --durations 20 test/
 
       - name: Run Python demos

--- a/.github/workflows/redhat.yml
+++ b/.github/workflows/redhat.yml
@@ -25,6 +25,8 @@ jobs:
       - name: Install dependencies
         run: |
           dnf -y update
+          dnf install -y dnf-plugins-core
+          dnf config-manager --set-enabled crb
           dnf install -y blas-devel cmake gcc gcc-c++ git lapack-devel python3 python3-devel python3-pip
 
       - uses: actions/checkout@v3

--- a/demo/cpp/demo_create_and_tabulate/CMakeLists.txt
+++ b/demo/cpp/demo_create_and_tabulate/CMakeLists.txt
@@ -5,7 +5,15 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-find_package(Basix REQUIRED)
+execute_process(
+  COMMAND ${Python3_EXECUTABLE} -c "import basix, os, sys; sys.stdout.write(os.path.dirname(basix.__file__))"
+  OUTPUT_VARIABLE BASIX_PY_DIR
+  RESULT_VARIABLE BASIX_PY_COMMAND_RESULT
+  ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+if (BASIX_PY_DIR)
+  message(STATUS "Adding ${BASIX_PY_DIR} to Basix search hints")
+endif()
+find_package(Basix REQUIRED CONFIG HINTS ${BASIX_PY_DIR})
 
 add_executable(${PROJECT_NAME} main.cpp)
 target_link_libraries(${PROJECT_NAME} Basix::basix)

--- a/demo/cpp/demo_create_and_tabulate/CMakeLists.txt
+++ b/demo/cpp/demo_create_and_tabulate/CMakeLists.txt
@@ -20,4 +20,8 @@ endif()
 find_package(Basix REQUIRED CONFIG HINTS ${BASIX_PY_DIR})
 
 add_executable(${PROJECT_NAME} main.cpp)
+if (BASIX_PY_DIR AND IS_DIRECTORY ${BASIX_PY_DIR}/../fenics_basix.libs)
+    set_target_properties(${PROJECT_NAME} PROPERTIES BUILD_RPATH ${BASIX_PY_DIR}/../fenics_basix.libs)
+    set_target_properties(${PROJECT_NAME} PROPERTIES INSTALL_RPATH ${BASIX_PY_DIR}/../fenics_basix.libs)
+endif()
 target_link_libraries(${PROJECT_NAME} Basix::basix)

--- a/demo/cpp/demo_create_and_tabulate/CMakeLists.txt
+++ b/demo/cpp/demo_create_and_tabulate/CMakeLists.txt
@@ -5,13 +5,17 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-execute_process(
-  COMMAND ${Python3_EXECUTABLE} -c "import basix, os, sys; sys.stdout.write(os.path.dirname(basix.__file__))"
-  OUTPUT_VARIABLE BASIX_PY_DIR
-  RESULT_VARIABLE BASIX_PY_COMMAND_RESULT
-  ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
-if (BASIX_PY_DIR)
-  message(STATUS "Adding ${BASIX_PY_DIR} to Basix search hints")
+# Use Python for detecting Basix when installed using combined build
+find_package(Python3 COMPONENTS Interpreter)
+if (${Python3_FOUND})
+  execute_process(
+    COMMAND ${Python3_EXECUTABLE} -c "import basix, os, sys; sys.stdout.write(os.path.dirname(basix.__file__))"
+    OUTPUT_VARIABLE BASIX_PY_DIR
+    RESULT_VARIABLE BASIX_PY_COMMAND_RESULT
+    ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+  if (BASIX_PY_DIR)
+    message(STATUS "Adding ${BASIX_PY_DIR} to Basix search hints")
+  endif()
 endif()
 find_package(Basix REQUIRED CONFIG HINTS ${BASIX_PY_DIR})
 

--- a/demo/cpp/demo_dof_transformations/CMakeLists.txt
+++ b/demo/cpp/demo_dof_transformations/CMakeLists.txt
@@ -5,7 +5,15 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-find_package(Basix REQUIRED)
+execute_process(
+  COMMAND ${Python3_EXECUTABLE} -c "import basix, os, sys; sys.stdout.write(os.path.dirname(basix.__file__))"
+  OUTPUT_VARIABLE BASIX_PY_DIR
+  RESULT_VARIABLE BASIX_PY_COMMAND_RESULT
+  ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+if (BASIX_PY_DIR)
+  message(STATUS "Adding ${BASIX_PY_DIR} to Basix search hints")
+endif()
+find_package(Basix REQUIRED CONFIG HINTS ${BASIX_PY_DIR})
 
 add_executable(${PROJECT_NAME} main.cpp)
 target_link_libraries(${PROJECT_NAME} Basix::basix)

--- a/demo/cpp/demo_dof_transformations/CMakeLists.txt
+++ b/demo/cpp/demo_dof_transformations/CMakeLists.txt
@@ -20,4 +20,8 @@ endif()
 find_package(Basix REQUIRED CONFIG HINTS ${BASIX_PY_DIR})
 
 add_executable(${PROJECT_NAME} main.cpp)
+if (BASIX_PY_DIR AND IS_DIRECTORY ${BASIX_PY_DIR}/../fenics_basix.libs)
+    set_target_properties(${PROJECT_NAME} PROPERTIES BUILD_RPATH ${BASIX_PY_DIR}/../fenics_basix.libs)
+    set_target_properties(${PROJECT_NAME} PROPERTIES INSTALL_RPATH ${BASIX_PY_DIR}/../fenics_basix.libs)
+endif()
 target_link_libraries(${PROJECT_NAME} Basix::basix)

--- a/demo/cpp/demo_dof_transformations/CMakeLists.txt
+++ b/demo/cpp/demo_dof_transformations/CMakeLists.txt
@@ -5,13 +5,17 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-execute_process(
-  COMMAND ${Python3_EXECUTABLE} -c "import basix, os, sys; sys.stdout.write(os.path.dirname(basix.__file__))"
-  OUTPUT_VARIABLE BASIX_PY_DIR
-  RESULT_VARIABLE BASIX_PY_COMMAND_RESULT
-  ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
-if (BASIX_PY_DIR)
-  message(STATUS "Adding ${BASIX_PY_DIR} to Basix search hints")
+# Use Python for detecting Basix when installed using combined build
+find_package(Python3 COMPONENTS Interpreter)
+if (${Python3_FOUND})
+  execute_process(
+    COMMAND ${Python3_EXECUTABLE} -c "import basix, os, sys; sys.stdout.write(os.path.dirname(basix.__file__))"
+    OUTPUT_VARIABLE BASIX_PY_DIR
+    RESULT_VARIABLE BASIX_PY_COMMAND_RESULT
+    ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+  if (BASIX_PY_DIR)
+    message(STATUS "Adding ${BASIX_PY_DIR} to Basix search hints")
+  endif()
 endif()
 find_package(Basix REQUIRED CONFIG HINTS ${BASIX_PY_DIR})
 

--- a/demo/cpp/test.py
+++ b/demo/cpp/test.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+import sys
 
 # Get all the demos in this folder
 path = os.path.dirname(os.path.realpath(__file__))
@@ -14,4 +15,4 @@ for folder in os.listdir(path):
 @pytest.mark.parametrize("demo", demos)
 def test_demo(demo):
     demo_build = f"{path}/{demo}/_build"
-    assert os.system(f"mkdir -p {demo_build} && cd {demo_build} && cmake .. && make && ./{demo}") == 0
+    assert os.system(f"mkdir -p {demo_build} && cd {demo_build} && cmake -DPython3_EXECUTABLE={sys.executable} .. && make && ./{demo}") == 0

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,4 @@
+[build-system]
+requires = ["setuptools>=42", "wheel", "pybind11>=2.6.4", "cmake>=3.16", "scikit-build>=0.12"]
+
+build-backend = "setuptools.build_meta"

--- a/python/setup.py
+++ b/python/setup.py
@@ -87,7 +87,7 @@ setup(name='fenics-basix',
       extras_require={
           "docs": ["markdown", "pylit3", "pyyaml", "sphinx==5.0.2", "sphinx_rtd_theme"],
           "lint": ["flake8", "pydocstyle"],
-          "optional": ["numba", "fenics-ufl@git+https://github.com/fenics/ufl"],
+          "optional": ["numba", "fenics-ufl>=2022.3.0.dev0@git+https://github.com/fenics/ufl"],
           "test": ["pytest", "sympy", "scipy", "matplotlib", "fenics-basix[optional]"],
           "ci": ["mypy", "pytest-xdist", "fenics-basix[docs]", "fenics-basix[lint]", "fenics-basix[optional]",
                  "fenics-basix[test]"]

--- a/python/setup.py
+++ b/python/setup.py
@@ -88,7 +88,7 @@ setup(name='fenics-basix',
           "docs": ["markdown", "pylit3", "pyyaml", "sphinx==5.0.2", "sphinx_rtd_theme"],
           "lint": ["flake8", "pydocstyle"],
           "optional": ["numba", "fenics-ufl@git+https://github.com/fenics/ufl"],
-          "test": ["pytest", "sympy", "numba", "scipy", "matplotlib"],
+          "test": ["pytest", "sympy", "scipy", "matplotlib", "fenics-basix[optional]"],
           "ci": ["mypy", "pytest-xdist", "fenics-basix[docs]", "fenics-basix[lint]", "fenics-basix[optional]",
                  "fenics-basix[test]"]
       },

--- a/python/setup.py
+++ b/python/setup.py
@@ -82,9 +82,16 @@ setup(name='fenics-basix',
       classifiers=[_f for _f in CLASSIFIERS.split('\n') if _f],
       platforms=["Linux", "Mac OS-X", "Unix"],
       packages=["basix"],
-      install_requires=["numpy>=1.21"],
       package_data={"basix": ["py.typed"]},
-      setup_requires=["pybind11"],
+      install_requires=["numpy>=1.21"],
+      extras_require={
+          "docs": ["markdown", "pylit3", "pyyaml", "sphinx==5.0.2", "sphinx_rtd_theme"],
+          "lint": ["flake8", "pydocstyle"],
+          "optional": ["numba", "fenics-ufl@git+https://github.com/fenics/ufl"],
+          "test": ["pytest", "sympy", "numba", "scipy", "matplotlib"],
+          "ci": ["mypy", "pytest-xdist", "fenics-basix[docs]", "fenics-basix[lint]", "fenics-basix[optional]",
+                 "fenics-basix[test]"]
+      },
       ext_modules=[CMakeExtension('basix._basixcpp')],
       cmdclass=dict(build_ext=CMakeBuild),
       zip_safe=False)

--- a/python/setup.py
+++ b/python/setup.py
@@ -87,7 +87,7 @@ setup(name='fenics-basix',
       extras_require={
           "docs": ["markdown", "pylit3", "pyyaml", "sphinx==5.0.2", "sphinx_rtd_theme"],
           "lint": ["flake8", "pydocstyle"],
-          "optional": ["numba", "fenics-ufl>=2022.3.0.dev0@git+https://github.com/fenics/ufl"],
+          "optional": ["numba", "fenics-ufl@git+https://github.com/fenics/ufl"],
           "test": ["pytest", "sympy", "scipy", "matplotlib", "fenics-basix[optional]"],
           "ci": ["mypy", "pytest-xdist", "fenics-basix[docs]", "fenics-basix[lint]", "fenics-basix[optional]",
                  "fenics-basix[test]"]

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,5 @@
 from skbuild import setup
 
-import sys
-import sysconfig
-
 from pathlib import Path
 this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text()
@@ -24,11 +21,10 @@ setup(name="fenics-basix",
       extras_require={
           "docs": ["markdown", "pylit3", "pyyaml", "sphinx==5.0.2", "sphinx_rtd_theme"],
           "lint": ["flake8", "pydocstyle"],
-          "optional": ["numba"],
-          "test": ["pytest", "sympy", "numba", "scipy", "matplotlib", "fenics-ufl"],
-          "ci": ["pytest-xdist", "fenics-basix[docs]", "fenics-basix[lint]", "fenics-basix[optional]",
+          "optional": ["numba", "fenics-ufl@git+https://github.com/fenics/ufl"],
+          "test": ["pytest", "sympy", "numba", "scipy", "matplotlib"],
+          "ci": ["mypy", "pytest-xdist", "fenics-basix[docs]", "fenics-basix[lint]", "fenics-basix[optional]",
                  "fenics-basix[test]"]
       },
-      cmake_args=['-DDOWNLOAD_XTENSOR_LIBS=ON'],
       package_dir={"": "python"},
       cmake_install_dir="python/basix/")

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(name="fenics-basix",
           "docs": ["markdown", "pylit3", "pyyaml", "sphinx==5.0.2", "sphinx_rtd_theme"],
           "lint": ["flake8", "pydocstyle"],
           "optional": ["numba", "fenics-ufl@git+https://github.com/fenics/ufl"],
-          "test": ["pytest", "sympy", "numba", "scipy", "matplotlib"],
+          "test": ["pytest", "sympy", "numba", "scipy", "matplotlib", "fenics-ufl@git+https://github.com/fenics/ufl"],
           "ci": ["mypy", "pytest-xdist", "fenics-basix[docs]", "fenics-basix[lint]", "fenics-basix[optional]",
                  "fenics-basix[test]"]
       },

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(name="fenics-basix",
           "docs": ["markdown", "pylit3", "pyyaml", "sphinx==5.0.2", "sphinx_rtd_theme"],
           "lint": ["flake8", "pydocstyle"],
           "optional": ["numba", "fenics-ufl@git+https://github.com/fenics/ufl"],
-          "test": ["pytest", "sympy", "numba", "scipy", "matplotlib", "fenics-ufl@git+https://github.com/fenics/ufl"],
+          "test": ["pytest", "sympy", "scipy", "matplotlib", "fenics-basix[optional]"],
           "ci": ["mypy", "pytest-xdist", "fenics-basix[docs]", "fenics-basix[lint]", "fenics-basix[optional]",
                  "fenics-basix[test]"]
       },

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(name="fenics-basix",
       extras_require={
           "docs": ["markdown", "pylit3", "pyyaml", "sphinx==5.0.2", "sphinx_rtd_theme"],
           "lint": ["flake8", "pydocstyle"],
-          "optional": ["numba", "fenics-ufl@git+https://github.com/fenics/ufl"],
+          "optional": ["numba", "fenics-ufl>=2022.3.0.dev0@git+https://github.com/fenics/ufl"],
           "test": ["pytest", "sympy", "scipy", "matplotlib", "fenics-basix[optional]"],
           "ci": ["mypy", "pytest-xdist", "fenics-basix[docs]", "fenics-basix[lint]", "fenics-basix[optional]",
                  "fenics-basix[test]"]

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(name="fenics-basix",
       extras_require={
           "docs": ["markdown", "pylit3", "pyyaml", "sphinx==5.0.2", "sphinx_rtd_theme"],
           "lint": ["flake8", "pydocstyle"],
-          "optional": ["numba", "fenics-ufl>=2022.3.0.dev0@git+https://github.com/fenics/ufl"],
+          "optional": ["numba", "fenics-ufl@git+https://github.com/fenics/ufl"],
           "test": ["pytest", "sympy", "scipy", "matplotlib", "fenics-basix[optional]"],
           "ci": ["mypy", "pytest-xdist", "fenics-basix[docs]", "fenics-basix[lint]", "fenics-basix[optional]",
                  "fenics-basix[test]"]

--- a/test/test_cmake/CMakeLists.txt
+++ b/test/test_cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Example of CMakeLists.txt for downstream C++ project (eg DOLFINx)
+# Example of CMakeLists.txt for downstream C++ project (eg DOLFINx or a Basix demo)
 # Used to check correctly installed package during tests and wheel creation.
 cmake_minimum_required(VERSION 3.16)
 
@@ -10,16 +10,17 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Use Python for detecting Basix
-find_package(Python3 COMPONENTS Interpreter REQUIRED)
+find_package(Python3 COMPONENTS Interpreter)
 
-# From DOLFINx
-execute_process(
-  COMMAND ${Python3_EXECUTABLE} -c "import basix, os, sys; sys.stdout.write(os.path.dirname(basix.__file__))"
-  OUTPUT_VARIABLE BASIX_PY_DIR
-  RESULT_VARIABLE BASIX_PY_COMMAND_RESULT
-  ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
-if (BASIX_PY_DIR)
-  message(STATUS "Adding ${BASIX_PY_DIR} to Basix search hints")
+if (${Python3_FOUND})
+  execute_process(
+    COMMAND ${Python3_EXECUTABLE} -c "import basix, os, sys; sys.stdout.write(os.path.dirname(basix.__file__))"
+    OUTPUT_VARIABLE BASIX_PY_DIR
+    RESULT_VARIABLE BASIX_PY_COMMAND_RESULT
+    ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+  if (BASIX_PY_DIR)
+    message(STATUS "Adding ${BASIX_PY_DIR} to Basix search hints")
+  endif()
 endif()
 find_package(Basix REQUIRED CONFIG HINTS ${BASIX_PY_DIR})
 


### PR DESCRIPTION
- Removes pip install from the CI (except for pytest-xdist in a few cases). If I could remind people *not* to pip install dependencies in the CI pipelines; there is always a better and more maintainable way to do this!
- Use `python3 -m` throughout, except on Mac, where it seems you must use `python -m` to get the the GitHub action activated versions of Python.
- Adds fenics-ufl as an optional dep installed from git.
- When building C++ demos, the cmake configuration file now asks Python for the location of the basix directory.
- One of the tests now uses the split C++/Python build as used in Spack.
- Moved to Redhat 9 compatible build where GCC 11 is default.
- Ensure that macOS builder uses the setup python installed python.
- Small updates to wheel builder.