### PR TITLE
Pass manifold cell information to base element of vector elements

### DIFF
--- a/python/basix/ufl_wrapper.py
+++ b/python/basix/ufl_wrapper.py
@@ -1289,7 +1289,7 @@ def create_vector_element(
         dim: The length of the vector.
         gdim: The geometric dimension of the cell.
     """
-    e = create_element(family, cell, degree, lagrange_variant, dpc_variant, discontinuous)
+    e = create_element(family, cell, degree, lagrange_variant, dpc_variant, discontinuous, gdim)
     return VectorElement(e, dim, gdim=gdim)
 
 


### PR DESCRIPTION
Possible fix for https://github.com/FEniCS/dolfinx/issues/2389

Prior to this fix, the ufl_cell() in the basix sub element would not be correct.