### PR TITLE
Include tensor element symmetry in its hash

### DIFF
--- a/.github/workflows/dolfin-tests.yml
+++ b/.github/workflows/dolfin-tests.yml
@@ -93,7 +93,11 @@ jobs:
           ctest -V --output-on-failure -R unittests
 
       - name: Run DOLFINx Python unit tests
-        run: python3 -m pytest -n auto dolfinx/python/test/unit
+        run: |
+          python3 -m pytest -n auto python/test/unit
+          cd dolfinx
 
       - name: Run DOLFINx Python demos
-        run: python3 -m pytest -n auto dolfinx/python/demo/test.py
+        run: |
+          cd dolfinx
+          python3 -m pytest -n auto python/demo/test.py

--- a/.github/workflows/dolfin-tests.yml
+++ b/.github/workflows/dolfin-tests.yml
@@ -100,4 +100,4 @@ jobs:
       - name: Run DOLFINx Python demos
         run: |
           cd dolfinx
-          python3 -m pytest -n auto python/demo/test.py
+          python3 -m pytest python/demo/test.py

--- a/.github/workflows/dolfin-tests.yml
+++ b/.github/workflows/dolfin-tests.yml
@@ -94,8 +94,8 @@ jobs:
 
       - name: Run DOLFINx Python unit tests
         run: |
-          python3 -m pytest -n auto python/test/unit
           cd dolfinx
+          python3 -m pytest -n auto python/test/unit
 
       - name: Run DOLFINx Python demos
         run: |

--- a/python/basix/ufl_wrapper.py
+++ b/python/basix/ufl_wrapper.py
@@ -1153,7 +1153,7 @@ class TensorElement(BlockedElement):
         else:
             bs = shape[0] * shape[1]
         assert len(shape) == 2
-        super().__init__(f"TensorElement({sub_element._repr}, {shape})", sub_element, bs, shape,
+        super().__init__(f"TensorElement({sub_element._repr}, {shape}, {symmetric})", sub_element, bs, shape,
                          symmetric=symmetric, gdim=gdim)
 
 

--- a/test/test_ufl_wrapper.py
+++ b/test/test_ufl_wrapper.py
@@ -33,6 +33,7 @@ def test_create_vector_element(inputs):
 def test_create_tensor_element(inputs):
     basix.ufl_wrapper.create_tensor_element(*inputs)
 
+
 @pytest.mark.parametrize("inputs", [
     ("Lagrange", "triangle", 2),
     ("Lagrange", basix.CellType.triangle, 2),
@@ -45,6 +46,7 @@ def test_tensor_element_hash(inputs):
     asym = basix.ufl_wrapper.TensorElement(e, symmetric=None)
     assert sym != asym
     assert hash(sym) != hash(asym)
+
 
 @pytest.mark.parametrize("e", [
     ufl.FiniteElement("Q", "quadrilateral", 1),

--- a/test/test_ufl_wrapper.py
+++ b/test/test_ufl_wrapper.py
@@ -33,6 +33,18 @@ def test_create_vector_element(inputs):
 def test_create_tensor_element(inputs):
     basix.ufl_wrapper.create_tensor_element(*inputs)
 
+@pytest.mark.parametrize("inputs", [
+    ("Lagrange", "triangle", 2),
+    ("Lagrange", basix.CellType.triangle, 2),
+    (basix.ElementFamily.P, basix.CellType.triangle, 2),
+    (basix.ElementFamily.P, "triangle", 2),
+])
+def test_tensor_element_hash(inputs):
+    e = basix.ufl_wrapper.create_element(*inputs)
+    sym = basix.ufl_wrapper.TensorElement(e, symmetric=True)
+    asym = basix.ufl_wrapper.TensorElement(e, symmetric=None)
+    assert sym != asym
+    assert hash(sym) != hash(asym)
 
 @pytest.mark.parametrize("e", [
     ufl.FiniteElement("Q", "quadrilateral", 1),


### PR DESCRIPTION
As reported in #611, the `symmetric` argument was previously not considered when hashing a `ufl_wrapper.TensorElement`. This caused dolfinx to reuse the element with whatever symmetry was chosen after the last cache clear. This completely ignored the symmetry information and resulted in wrong block sizes.
This PR fixes this by simply adding `symmetric` to the corresponding `_repr`.