### PR TITLE
Fix bug in N2E on tets: cells are 3D not 2D

### DIFF
--- a/cpp/basix/e-nedelec.cpp
+++ b/cpp/basix/e-nedelec.cpp
@@ -354,7 +354,7 @@ FiniteElement element::create_nedelec2(cell::type celltype, int degree,
     }
     else
     {
-      const std::size_t num_ent = cell::num_sub_entities(celltype, 2);
+      const std::size_t num_ent = cell::num_sub_entities(celltype, 3);
       x[3] = std::vector(num_ent, impl::mdarray2_t(0, tdim));
       M[3] = std::vector(num_ent, impl::mdarray4_t(0, tdim, 0, 1));
     }


### PR DESCRIPTION
Found this bug while working on https://github.com/FEniCS/dolfinx/issues/2586 (although it isn't the cause of that issue)