### PR TITLE
Use np.tile for blocked tabulation

### DIFF
--- a/python/basix/ufl.py
+++ b/python/basix/ufl.py
@@ -994,10 +994,8 @@ class _BlockedElement(_ElementBase):
         assert self.value_size == self._block_size  # TODO: remove this assumption
         output = []
         for table in self.sub_element.tabulate(nderivs, points):
-            new_table = _np.zeros((table.shape[0], table.shape[1] * self._block_size**2))
-            for block in range(self._block_size):
-                col = block * (self._block_size + 1)
-                new_table[:, col: col + table.shape[1] * self._block_size**2: self._block_size**2] = table
+            # Repeat sub element horizontally
+            new_table = _np.tile(table, (1, self._block_size))
             output.append(new_table)
         return _np.asarray(output, dtype=_np.float64)
 

--- a/test/test_ufl_wrapper.py
+++ b/test/test_ufl_wrapper.py
@@ -16,13 +16,16 @@ def test_finite_element(inputs):
 
 
 @pytest.mark.parametrize("inputs", [
+    ("Lagrange", "triangle", 1),
     ("Lagrange", "triangle", 2),
     ("Lagrange", basix.CellType.triangle, 2),
     (basix.ElementFamily.P, basix.CellType.triangle, 2),
     (basix.ElementFamily.P, "triangle", 2),
 ])
 def test_vector_element(inputs):
-    basix.ufl.element(*inputs, rank=1)
+    e = basix.ufl.element(*inputs, rank=1)
+    table = e.tabulate(0, [[0, 0]])
+    assert table.shape == (1, 1, e.dim)
 
 
 @pytest.mark.parametrize("inputs", [
@@ -45,6 +48,8 @@ def test_tensor_element_hash(inputs):
     e = basix.ufl.element(*inputs)
     sym = basix.ufl.blocked_element(e, shape=(2, 2), symmetry=True)
     asym = basix.ufl.blocked_element(e, shape=(2, 2), symmetry=False)
+    table = e.tabulate(0, [[0, 0]])
+    assert table.shape == (1, 1, e.dim)
     assert sym != asym
     assert hash(sym) != hash(asym)
 


### PR DESCRIPTION
Fixes tabulation of BlockedElement to produce tables of shape `(num_points, num_sub_element_dofs * block_size)`, since current main returns `(num_points, num_sub_element_dofs * block_size**2)`.

Reproducible with
```python
import dolfinx
from mpi4py import MPI

mesh = dolfinx.mesh.create_unit_square(MPI.COMM_WORLD, 1, 1)
V = dolfinx.fem.VectorFunctionSpace(mesh, ("Lagrange", 1))
basis_wrapped = V.ufl_element().tabulate(0, [[0.0, 0.0]])
print(basis_wrapped.shape)
```
returns `(1, 1, 12)` instead of `(1, 1, 6)`.