### PR TITLE
Lazy element creation

### DIFF
--- a/cpp/basix/dof-transformations.h
+++ b/cpp/basix/dof-transformations.h
@@ -38,12 +38,10 @@ std::map<cell::type, std::pair<std::vector<double>, std::array<std::size_t, 3>>>
 compute_entity_transformations(
     cell::type cell_type,
     const std::array<
-        std::vector<std::experimental::mdspan<
-            const double, std::experimental::dextents<std::size_t, 2>>>,
+        std::vector<std::pair<std::vector<double>, std::array<std::size_t, 2>>>,
         4>& x,
     const std::array<
-        std::vector<std::experimental::mdspan<
-            const double, std::experimental::dextents<std::size_t, 4>>>,
+        std::vector<std::pair<std::vector<double>, std::array<std::size_t, 4>>>,
         4>& M,
     const std::experimental::mdspan<
         const double, std::experimental::dextents<std::size_t, 2>>& coeffs,


### PR DESCRIPTION
Make it so that element coefficients and DOF transformations are only created when they are needed.

This means that these computations do not need to be done in order to use a Basix element as a UFL element.