### PR TITLE
Relax some floating point comparisons

### DIFF
--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -23,8 +23,6 @@
 #include <limits>
 #include <numeric>
 
-#include <iostream>
-
 #define str_macro(X) #X
 #define str(X) str_macro(X)
 
@@ -777,13 +775,6 @@ FiniteElement<F>::FiniteElement(
         if ((trans.extent(2) != 1 and std::abs(rmin) > eps)
             or std::abs(rmax - 1.0) > eps or std::abs(rtot - 1.0) > eps)
         {
-          std::cout << "Basix (a): " << double(rmin) << ", " << double(rmax)
-                    << ", " << double(rtot) << std::endl;
-          std::cout << "Basix (b): " << std::abs(rmin) << ", "
-                    << std::abs(rmax - F(1.0)) << ", "
-                    << std::abs(rtot - F(1.0)) << std::endl;
-          std::cout << "Basix (eps): " << std::numeric_limits<F>::epsilon()
-                    << std::endl;
           _dof_transformations_are_permutations = false;
           _dof_transformations_are_identity = false;
           break;

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -756,7 +756,6 @@ FiniteElement<F>::FiniteElement(
   for (const auto& [ctype, trans_data] : _entity_transformations)
   {
     mdspan_t<const F, 3> trans(trans_data.first.data(), trans_data.second);
-
     for (std::size_t i = 0;
          _dof_transformations_are_permutations and i < trans.extent(0); ++i)
     {
@@ -771,7 +770,7 @@ FiniteElement<F>::FiniteElement(
           rtot += r;
         }
 
-        constexpr F eps = 10.0 * std::numeric_limits<F>::epsilon();
+        constexpr F eps = 10.0 * std::numeric_limits<float>::epsilon();
         if ((trans.extent(2) != 1 and std::abs(rmin) > eps)
             or std::abs(rmax - 1.0) > eps or std::abs(rtot - 1.0) > eps)
         {
@@ -780,7 +779,7 @@ FiniteElement<F>::FiniteElement(
           break;
         }
 
-        if (std::abs(trans(i, row, row) - 1) > 1.0e-8)
+        if (std::abs(trans(i, row, row) - 1) > eps)
           _dof_transformations_are_identity = false;
       }
     }
@@ -844,7 +843,6 @@ FiniteElement<F>::FiniteElement(
     }
     else
     {
-
       // Precompute the DOF transformations
       for (const auto& [ctype, trans_data] : _entity_transformations)
       {
@@ -852,7 +850,6 @@ FiniteElement<F>::FiniteElement(
 
         // Buffers for matrices
         std::vector<F> M_b, Minv_b, matint;
-
         auto& etrans = _etrans.try_emplace(ctype).first->second;
         auto& etransT = _etransT.try_emplace(ctype).first->second;
         auto& etrans_invT = _etrans_invT.try_emplace(ctype).first->second;
@@ -870,7 +867,6 @@ FiniteElement<F>::FiniteElement(
           {
             const std::size_t dim = trans.extent(1);
             assert(dim == trans.extent(2));
-
             {
               std::pair<std::vector<F>, std::array<std::size_t, 2>> mat
                   = {std::vector<F>(dim * dim), {dim, dim}};
@@ -952,7 +948,8 @@ FiniteElement<F>::FiniteElement(
     for (std::size_t col = 0; col < matM.extent(1); ++col)
     {
       F v = col == row ? 1.0 : 0.0;
-      if (std::abs(matM(row, col) - v) > 1.0e-12)
+      constexpr F eps = 100 * std::numeric_limits<F>::epsilon();
+      if (std::abs(matM(row, col) - v) > eps)
       {
         _interpolation_is_identity = false;
         break;


### PR DESCRIPTION
Some checks were too tight for `float32`. Issues picked up in testing `float` support in DOLFINx.

Eventually more tested is required, but only `float64` is supported via the Python interface at the moment. Test should be added once the Python interface is extended.