### PR TITLE
Fix compilation with gcc-13 (#678)

### DIFF
--- a/cpp/basix/finite-element.h
+++ b/cpp/basix/finite-element.h
@@ -21,6 +21,7 @@
 #include <tuple>
 #include <utility>
 #include <vector>
+#include <cstdint>
 
 /// Basix: FEniCS runtime basis evaluation library
 namespace basix


### PR DESCRIPTION
* Including `<cstdint>` is required for the std::int32_t type.