### PR TITLE
Add better warning when using *

### DIFF
--- a/python/basix/ufl.py
+++ b/python/basix/ufl.py
@@ -710,6 +710,11 @@ class _ComponentElement(_ElementBase):
         """The Basix map type."""
         raise NotImplementedError()
 
+    def __mul__(self, other):
+        _warn("Use of * to create mixed elements is deprecated and will be removed after December 2023. "
+              "Please, use basix.ufl.mixed_element.", FutureWarning)
+        return mixed_element([self, other])
+
 
 class _MixedElement(_ElementBase):
     """A mixed element that combines two or more elements.


### PR DESCRIPTION
This will warn that the `*` syntax is deprecated rather than the slightly cryptic `Converting elements created in UFL to Basix elements is deprecated` that it currently gives instead (see https://github.com/FEniCS/dolfinx/issues/2773)