### PR TITLE
use gdim in default shape for an element with a rank

### DIFF
--- a/python/basix/ufl.py
+++ b/python/basix/ufl.py
@@ -1933,8 +1933,11 @@ def blocked_element(sub_element: _ElementBase, rank: _typing.Optional[int] = Non
         if rank is None:
             shape = tuple(sub_element.value_shape())
         else:
-            tdim = len(_basix.topology(sub_element.cell_type)) - 1
-            shape = tuple(tdim for _ in range(rank))
+            if gdim is None:
+                tdim = len(_basix.topology(sub_element.cell_type)) - 1
+                shape = tuple(tdim for _ in range(rank))
+            else:
+                shape = tuple(gdim for _ in range(rank))
     if rank is None:
         rank = len(shape)
     if rank != len(shape):


### PR DESCRIPTION
At a glance, this seems like a more sensible default: if you have a triangle embedded in 3D, it would seem more natural that an element with rank 1 has shape (3,) rather than (2,).