### PR TITLE
Use absolute imports in place of relative imports

### DIFF
--- a/.github/workflows/dolfin-tests.yml
+++ b/.github/workflows/dolfin-tests.yml
@@ -29,7 +29,7 @@ jobs:
     container: ghcr.io/fenics/test-env:current-openmpi
 
     env:
-      PETSC_ARCH: linux-gnu-real64-32
+      PETSC_ARCH: linux-gnu-complex64-32
       OMPI_ALLOW_RUN_AS_ROOT: 1
       OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
       OMPI_MCA_rmaps_base_oversubscribe: 1

--- a/.github/workflows/dolfin-tests.yml
+++ b/.github/workflows/dolfin-tests.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Install DOLFINx (Python)
         run: |
           python3 -m pip install -r dolfinx/python/build-requirements.txt # TO REMOVE
-          python3 -m pip -v install --global-option build --global-option --debug dolfinx/python/
+          python3 -m pip -v install --check-build-dependencies --no-build-isolation dolfinx/python/
 
       - name: Run mypy checks
         run: |

--- a/.github/workflows/dolfin-tests.yml
+++ b/.github/workflows/dolfin-tests.yml
@@ -25,11 +25,11 @@ on:
 jobs:
   build:
     name: Run DOLFINx tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container: ghcr.io/fenics/test-env:current-openmpi
 
     env:
-      PETSC_ARCH: linux-gnu-complex-32
+      PETSC_ARCH: linux-gnu-real64-32
       OMPI_ALLOW_RUN_AS_ROOT: 1
       OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
       OMPI_MCA_rmaps_base_oversubscribe: 1

--- a/.github/workflows/dolfin-tests.yml
+++ b/.github/workflows/dolfin-tests.yml
@@ -26,7 +26,7 @@ jobs:
   build:
     name: Run DOLFINx tests
     runs-on: ubuntu-22.04
-    container: fenicsproject/test-env:nightly-openmpi
+    container: ghcr.io/fenics/test-env:current-openmpi
 
     env:
       PETSC_ARCH: linux-gnu-complex-32
@@ -77,6 +77,7 @@ jobs:
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build -S dolfinx/cpp/
           cmake --build build
           cmake --install build
+          python3 -m pip install -r python/build-requirements.txt # TO REMOVE
           python3 -m pip -v install --global-option build --global-option --debug dolfinx/python/
 
       - name: Run mypy checks

--- a/.github/workflows/dolfin-tests.yml
+++ b/.github/workflows/dolfin-tests.yml
@@ -72,12 +72,14 @@ jobs:
           path: ./dolfinx
           repository: FEniCS/dolfinx
           ref: ${{ github.event.inputs.dolfinx_branch }}
-      - name: Install DOLFINx
+      - name: Install DOLFINx (C++)
         run: |
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build -S dolfinx/cpp/
           cmake --build build
           cmake --install build
-          python3 -m pip install -r python/build-requirements.txt # TO REMOVE
+      - name: Install DOLFINx (Python)
+        run: |
+          python3 -m pip install -r dolfinx/python/build-requirements.txt # TO REMOVE
           python3 -m pip -v install --global-option build --global-option --debug dolfinx/python/
 
       - name: Run mypy checks

--- a/python/basix/__init__.py
+++ b/python/basix/__init__.py
@@ -4,11 +4,11 @@ The core of the library is written in C++, but the majority of Basix's
 functionality can be used via this Python interface.
 """
 
-from . import cell, finite_element, lattice, polynomials, quadrature, sobolev_spaces, variants
+from basix import cell, finite_element, lattice, polynomials, quadrature, sobolev_spaces, variants
 from basix._basixcpp import (CellType, DPCVariant, ElementFamily, LagrangeVariant, LatticeSimplexMethod, LatticeType,
                              MapType, PolynomialType, PolysetType, QuadratureType, SobolevSpace, __version__,
-                             compute_interpolation_operator, create_custom_element, create_element, create_lattice, geometry,
-                             index)
+                             compute_interpolation_operator, create_custom_element, create_element, create_lattice,
+                             geometry, index)
 from basix._basixcpp import restriction as polyset_restriction
 from basix._basixcpp import superset as polyset_superset
 from basix._basixcpp import tabulate_polynomials, topology

--- a/python/basix/__init__.py
+++ b/python/basix/__init__.py
@@ -5,11 +5,11 @@ functionality can be used via this Python interface.
 """
 
 from . import cell, finite_element, lattice, polynomials, quadrature, sobolev_spaces, variants
-from ._basixcpp import (CellType, DPCVariant, ElementFamily, LagrangeVariant, LatticeSimplexMethod, LatticeType,
-                        MapType, PolynomialType, PolysetType, QuadratureType, SobolevSpace, __version__,
-                        compute_interpolation_operator, create_custom_element, create_element, create_lattice, geometry,
-                        index)
-from ._basixcpp import restriction as polyset_restriction
-from ._basixcpp import superset as polyset_superset
-from ._basixcpp import tabulate_polynomials, topology
-from .quadrature import make_quadrature
+from basix._basixcpp import (CellType, DPCVariant, ElementFamily, LagrangeVariant, LatticeSimplexMethod, LatticeType,
+                             MapType, PolynomialType, PolysetType, QuadratureType, SobolevSpace, __version__,
+                             compute_interpolation_operator, create_custom_element, create_element, create_lattice, geometry,
+                             index)
+from basix._basixcpp import restriction as polyset_restriction
+from basix._basixcpp import superset as polyset_superset
+from basix._basixcpp import tabulate_polynomials, topology
+from basix.quadrature import make_quadrature

--- a/python/basix/cell.py
+++ b/python/basix/cell.py
@@ -1,13 +1,13 @@
 """Functions to get cell geometry information and manipulate cell types."""
 
-from ._basixcpp import CellType as _CT
-from ._basixcpp import cell_facet_jacobians as facet_jacobians  # noqa: F401
-from ._basixcpp import cell_facet_normals as facet_normals  # noqa: F401
-from ._basixcpp import cell_facet_orientations as facet_orientations  # noqa: F401
-from ._basixcpp import cell_facet_outward_normals as facet_outward_normals  # noqa: F401
-from ._basixcpp import cell_facet_reference_volumes as facet_reference_volumes  # noqa: F401
-from ._basixcpp import cell_volume as volume  # noqa: F401
-from ._basixcpp import sub_entity_connectivity  # noqa: F401
+from basix._basixcpp import CellType as _CT
+from basix._basixcpp import cell_facet_jacobians as facet_jacobians  # noqa: F401
+from basix._basixcpp import cell_facet_normals as facet_normals  # noqa: F401
+from basix._basixcpp import cell_facet_orientations as facet_orientations  # noqa: F401
+from basix._basixcpp import cell_facet_outward_normals as facet_outward_normals  # noqa: F401
+from basix._basixcpp import cell_facet_reference_volumes as facet_reference_volumes  # noqa: F401
+from basix._basixcpp import cell_volume as volume  # noqa: F401
+from basix._basixcpp import sub_entity_connectivity  # noqa: F401
 
 
 def string_to_type(cell: str) -> _CT:

--- a/python/basix/finite_element.py
+++ b/python/basix/finite_element.py
@@ -1,7 +1,7 @@
 """Functions for creating finite elements."""
 
-from ._basixcpp import ElementFamily as _EF
-from ._basixcpp import FiniteElement  # noqa: F401
+from basix._basixcpp import ElementFamily as _EF
+from basix._basixcpp import FiniteElement  # noqa: F401
 
 
 def string_to_family(family: str, cell: str) -> _EF:

--- a/python/basix/lattice.py
+++ b/python/basix/lattice.py
@@ -1,7 +1,7 @@
 """Functions to manipulate lattice types."""
 
-from ._basixcpp import LatticeSimplexMethod as _LSM
-from ._basixcpp import LatticeType as _LT
+from basix._basixcpp import LatticeSimplexMethod as _LSM
+from basix._basixcpp import LatticeType as _LT
 
 
 def string_to_type(lattice: str) -> _LT:

--- a/python/basix/polynomials.py
+++ b/python/basix/polynomials.py
@@ -5,10 +5,10 @@ import typing as _typing
 import numpy as _numpy
 import numpy.typing as _numpy_typing
 
-from ._basixcpp import CellType as _CT
-from ._basixcpp import PolynomialType as _PT
-from ._basixcpp import index as _index
-from ._basixcpp import polynomials_dim as dim  # noqa: F401
+from basix._basixcpp import CellType as _CT
+from basix._basixcpp import PolynomialType as _PT
+from basix._basixcpp import index as _index
+from basix._basixcpp import polynomials_dim as dim  # noqa: F401
 
 _nda_f64 = _numpy_typing.NDArray[_numpy.float64]
 

--- a/python/basix/quadrature.py
+++ b/python/basix/quadrature.py
@@ -5,10 +5,10 @@ import typing as _typing
 import numpy as _np
 import numpy.typing as _npt
 
-from ._basixcpp import CellType as _CT
-from ._basixcpp import PolysetType as _PT
-from ._basixcpp import QuadratureType as _QT
-from ._basixcpp import make_quadrature as _mq
+from basix._basixcpp import CellType as _CT
+from basix._basixcpp import PolysetType as _PT
+from basix._basixcpp import QuadratureType as _QT
+from basix._basixcpp import make_quadrature as _mq
 
 
 def string_to_type(rule: str) -> _QT:

--- a/python/basix/sobolev_spaces.py
+++ b/python/basix/sobolev_spaces.py
@@ -2,8 +2,8 @@
 
 import typing as _typing
 
-from ._basixcpp import SobolevSpace as _SS
-from ._basixcpp import sobolev_space_intersection as _ssi
+from basix._basixcpp import SobolevSpace as _SS
+from basix._basixcpp import sobolev_space_intersection as _ssi
 
 
 def intersection(spaces: _typing.List[_SS]) -> _SS:

--- a/python/basix/variants.py
+++ b/python/basix/variants.py
@@ -1,7 +1,7 @@
 """Functions to manipulate variant types."""
 
-from ._basixcpp import DPCVariant as _DV
-from ._basixcpp import LagrangeVariant as _LV
+from basix._basixcpp import DPCVariant as _DV
+from basix._basixcpp import LagrangeVariant as _LV
 
 
 def string_to_lagrange_variant(variant: str) -> _LV:


### PR DESCRIPTION
Absolute imports and generally recommended over relative imports in Python.

Plus this fixes #719.

Updates the DOLFINx integration test with the up-to-date images.