### PR TITLE
set gdim equal to tdim by default

### DIFF
--- a/python/basix/ufl.py
+++ b/python/basix/ufl.py
@@ -71,6 +71,28 @@ def _ufl_pullback_from_enum(m: _basix.MapType) -> _AbstractPullback:
     return _pullbackmap[m]
 
 
+def _repr_optional_args(**kwargs: _typing.Any) -> str:
+    """Augment an element `repr` by appending non-None optional arguments.
+
+    Args:
+        kwargs: Optional arguments to include in repr. All arguments for which
+            `value is not None` will be appended to `partial_repr`.
+
+    Returns:
+        A string representation of a finite element
+    """
+    out = ""
+    for name, value in kwargs.items():
+        if value is not None:
+            out += f", {name}={value}"
+    return out
+
+
+def _cellname_to_tdim(cellname: str) -> int:
+    """Get the tdim of a cell."""
+    return len(_basix.topology(getattr(_basix.CellType, cellname))) - 1
+
+
 class _ElementBase(_AbstractFiniteElement):
     """A base wrapper to allow elements to be used with UFL.
 
@@ -87,7 +109,7 @@ class _ElementBase(_AbstractFiniteElement):
         self._value_shape = value_shape
         self._degree = degree
         self._pullback = pullback
-        self._gdim = gdim
+        self._gdim = _cellname_to_tdim(cellname) if gdim is None else gdim
 
     # Implementation of methods for UFL AbstractFiniteElement
     def __repr__(self):
@@ -355,7 +377,7 @@ class _BasixElement(_ElementBase):
             self._is_custom = False
             repr = (f"Basix element ({element.family.__name__}, {element.cell_type.__name__}, {element.degree}, "
                     f"{element.lagrange_variant.__name__}, {element.dpc_variant.__name__}, {element.discontinuous}")
-        repr = _repr_optional_args(repr, ("gdim", gdim))
+        repr += _repr_optional_args(gdim=gdim) + ")"
 
         super().__init__(
             repr, element.cell_type.__name__, tuple(element.value_shape), element.degree,
@@ -568,8 +590,7 @@ class _ComponentElement(_ElementBase):
         """Initialise the element."""
         self.element = element
         self.component = component
-        repr = f"component element ({element._repr}, {component}"
-        repr = _repr_optional_args(repr, ("gdim", gdim))
+        repr = f"component element ({element!r}, {component}" + _repr_optional_args(gdim=gdim) + ")"
         super().__init__(repr, element.cell_type.__name__, (1, ), element._degree, gdim=gdim)
 
     def __eq__(self, other) -> bool:
@@ -756,8 +777,7 @@ class _MixedElement(_ElementBase):
         else:
             pullback = _MixedPullback(self)
 
-        repr = "mixed element (" + ", ".join(i._repr for i in sub_elements)
-        repr = _repr_optional_args(repr, ("gdim", gdim))
+        repr = "mixed element (" + ", ".join(i._repr for i in sub_elements) + _repr_optional_args(gdim=gdim) + ")"
         super().__init__(repr, sub_elements[0].cell_type.__name__,
                          (sum(i.value_size for i in sub_elements), ), pullback=pullback, gdim=gdim)
 
@@ -1002,12 +1022,7 @@ class _BlockedElement(_ElementBase):
         self._block_size = block_size
         self.block_shape = shape
 
-        repr = f"blocked element ({sub_element._repr}, {shape}"
-        if len(shape) == 2:
-            _symm: _typing.Tuple[str, _typing.Any] = ("symmetry", "True" if symmetry else "False")
-        else:
-            _symm = ("symmetry", None)
-        repr = _repr_optional_args(repr, _symm, ("gdim", gdim))
+        repr = f"blocked element ({sub_element!r}, {shape}" + _repr_optional_args(symmetry=symmetry, gdim=gdim) + ")"
 
         super().__init__(repr, sub_element.cell_type.__name__, shape,
                          sub_element._degree, sub_element._pullback, gdim=gdim)
@@ -1641,28 +1656,6 @@ def _compute_signature(element: _basix.finite_element.FiniteElement) -> str:
     signature += _hashlib.sha1(data.encode('utf-8')).hexdigest()
 
     return signature
-
-
-def _repr_optional_args(partial_repr: str, *args: _typing.Tuple[str, _typing.Any]) -> str:
-    """Augment an element `repr` by appending non-None optional arguments.
-
-    Args:
-        partial_repr: The initial `repr` of a finite element incorporating all required
-            arguments but not including any optional args
-        args: Sequence of tuples `(name: str, value: typing.Any)` where `name` is the name
-            of an optional argument to be including in the repr and `value` is its
-            value. All arguments for which `value is not None` will be appended to
-            `partial_repr`.
-
-    Returns:
-        A string representation of a finite element
-    """
-    repr = partial_repr
-    for name, value in args:
-        if value is not None:
-            repr += f", {name}={value}"
-    repr += ")"
-    return repr
 
 
 @_functools.lru_cache()

--- a/python/basix/ufl.py
+++ b/python/basix/ufl.py
@@ -377,7 +377,9 @@ class _BasixElement(_ElementBase):
             self._is_custom = False
             repr = (f"Basix element ({element.family.__name__}, {element.cell_type.__name__}, {element.degree}, "
                     f"{element.lagrange_variant.__name__}, {element.dpc_variant.__name__}, {element.discontinuous}")
-        repr += _repr_optional_args(gdim=gdim) + ")"
+        if gdim != _cellname_to_tdim(element.cell_type.__name__):
+            repr += _repr_optional_args(gdim=gdim)
+        repr += ")"
 
         super().__init__(
             repr, element.cell_type.__name__, tuple(element.value_shape), element.degree,
@@ -590,7 +592,10 @@ class _ComponentElement(_ElementBase):
         """Initialise the element."""
         self.element = element
         self.component = component
-        repr = f"component element ({element!r}, {component}" + _repr_optional_args(gdim=gdim) + ")"
+        repr = f"component element ({element!r}, {component}"
+        if gdim != _cellname_to_tdim(element.cell_type.__name__):
+            repr += _repr_optional_args(gdim=gdim)
+        repr += ")"
         super().__init__(repr, element.cell_type.__name__, (1, ), element._degree, gdim=gdim)
 
     def __eq__(self, other) -> bool:
@@ -777,7 +782,10 @@ class _MixedElement(_ElementBase):
         else:
             pullback = _MixedPullback(self)
 
-        repr = "mixed element (" + ", ".join(i._repr for i in sub_elements) + _repr_optional_args(gdim=gdim) + ")"
+        repr = "mixed element (" + ", ".join(i._repr for i in sub_elements)
+        if gdim != _cellname_to_tdim(sub_elements[0].cell_type.__name__):
+            repr += _repr_optional_args(gdim=gdim)
+        repr += ")"
         super().__init__(repr, sub_elements[0].cell_type.__name__,
                          (sum(i.value_size for i in sub_elements), ), pullback=pullback, gdim=gdim)
 
@@ -1022,7 +1030,12 @@ class _BlockedElement(_ElementBase):
         self._block_size = block_size
         self.block_shape = shape
 
-        repr = f"blocked element ({sub_element!r}, {shape}" + _repr_optional_args(symmetry=symmetry, gdim=gdim) + ")"
+        repr = f"blocked element ({sub_element!r}, {shape}"
+        if gdim != _cellname_to_tdim(sub_element.cell_type.__name__):
+            repr += _repr_optional_args(symmetry=symmetry, gdim=gdim)
+        else:
+            repr += _repr_optional_args(symmetry=symmetry)
+        repr += ")"
 
         super().__init__(repr, sub_element.cell_type.__name__, shape,
                          sub_element._degree, sub_element._pullback, gdim=gdim)

--- a/test/test_ufl_wrapper.py
+++ b/test/test_ufl_wrapper.py
@@ -111,7 +111,7 @@ def test_quadrature_element(cell, degree, shape):
 def test_finite_element_eq_hash(family, cell, degree, shape, gdim):
     e1 = basix.ufl.element("Lagrange", "triangle", 1, shape=None, gdim=None)
     e2 = basix.ufl.element(family, cell, degree, shape=shape, gdim=gdim)
-    assert (e1 == e2 and hash(e1) == hash(e2)) or (e1 != e2 and hash(e1) != hash(e2))
+    assert (e1 == e2) == (hash(e1) == hash(e2))
 
 
 @pytest.mark.parametrize("component,gdim", [(0, None), (1, None), (0, 2)])
@@ -119,7 +119,7 @@ def test_component_element_eq_hash(component, gdim):
     base_el = basix.ufl.element("Lagrange", "triangle", 1)
     e1 = basix.ufl._ComponentElement(base_el, component=0, gdim=None)
     e2 = basix.ufl._ComponentElement(base_el, component=component, gdim=gdim)
-    assert (e1 == e2 and hash(e1) == hash(e2)) or (e1 != e2 and hash(e1) != hash(e2))
+    assert (e1 == e2) == (hash(e1) == hash(e2))
 
 
 @pytest.mark.parametrize("e1,e2,gdim", [
@@ -139,8 +139,7 @@ def test_mixed_element_eq_hash(e1, e2, gdim):
          basix.ufl.element("Lagrange", "triangle", 1, shape=(2, 2), symmetry=True)],
         gdim=None)
     mixed2 = basix.ufl.mixed_element([e1, e2], gdim=gdim)
-    assert (mixed1 == mixed2 and hash(mixed1) == hash(mixed2)) or \
-        (mixed1 != mixed2 and hash(mixed1) != hash(mixed2))
+    assert (mixed1 == mixed2) == (hash(mixed1) == hash(mixed2))
 
 
 @pytest.mark.parametrize("cell_type,degree,pullback", [
@@ -152,11 +151,11 @@ def test_mixed_element_eq_hash(e1, e2, gdim):
 def test_quadrature_element_eq_hash(cell_type, degree, pullback):
     e1 = basix.ufl.quadrature_element("triangle", scheme="default", degree=2, pullback=basix.ufl._ufl.identity_pullback)
     e2 = basix.ufl.quadrature_element(cell_type, scheme="default", degree=degree, pullback=pullback)
-    assert (e1 == e2 and hash(e1) == hash(e2)) or (e1 != e2 and hash(e1) != hash(e2))
+    assert (e1 == e2) == (hash(e1) == hash(e2))
 
 
 @pytest.mark.parametrize("cell_type,value_shape", [("triangle", ()), ("quadrilateral", ()), ("triangle", (2,))])
 def test_real_element_eq_hash(cell_type, value_shape):
     e1 = basix.ufl.real_element("triangle", ())
     e2 = basix.ufl.real_element(cell_type, value_shape)
-    assert (e1 == e2 and hash(e1) == hash(e2)) or (e1 != e2 and hash(e1) != hash(e2))
+    assert (e1 == e2) == (hash(e1) == hash(e2))


### PR DESCRIPTION
After this PR, the following code now works:

```python
import basix.ufl

P2 = basix.ufl.element("Lagrange", "triangle", 2, gdim=2, shape=(2, ))
P1 = basix.ufl.element("Lagrange", "triangle", 1)
TH = basix.ufl.mixed_element([P2, P1])
```