### PR TITLE
Do not store `.doctrees` binary files on website

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -65,6 +65,7 @@ jobs:
           doxygen
           cd ../python
           python -m sphinx -W -b html source build/html
+          rm -rf build/html/.doctrees
       - name: Upload C++ documentation artifact
         uses: actions/upload-artifact@v3
         with:

--- a/doc/web/make_html.py
+++ b/doc/web/make_html.py
@@ -267,5 +267,5 @@ with open(path("python/source/index.rst"), "a") as f:
     f.write("   demo/index")
 
 # Make python docs
-system(f"cd {path('python')} && python3 -m sphinx -W -b html source/ build/html")
+system(f"cd {path('python')} && python3 -m sphinx -W -b html source/ build/html && rm -rf build/html/.doctrees")
 system(f"cp -r {path('python/build/html')} {path('html/python')}")


### PR DESCRIPTION
Side effect of #744, since these files used to be stored in `build/doctrees` rather than `build/html/.doctrees`.

See e.g. https://github.com/FEniCS/docs/commit/9dbb9f04823216c6b659efc35a2fea10ede24818 for a diff