### PR TITLE
Add `overflow: scroll` to stop sidebar colliding with content in web docs

### DIFF
--- a/doc/web/assets/sty.css
+++ b/doc/web/assets/sty.css
@@ -14,3 +14,6 @@
 
 .fenicsnav {display:inline-block;font-size:20px;padding:0px 15px}
 
+.sphinxsidebarwrapper {
+    overflow: scroll
+}

--- a/doc/web/make_html.py
+++ b/doc/web/make_html.py
@@ -130,6 +130,10 @@ template = template.replace("<p>!!", "!!")
 template = template.replace("!!</p>", "!!")
 template = template.replace("=\"/", "=\"https://fenicsproject.org/")
 template = template.replace("(/assets", "(https://fenicsproject.org/assets")
+template = template.replace(
+    "/assets/css/customsty.css\">",
+    "/assets/css/customsty.css\">\n"
+    "   <link rel=\"stylesheet\" type=\"text/css\" href=\"/assets/sty.css\">")
 
 intro, outro = template.split("!!CONTENT!!")
 


### PR DESCRIPTION
Before this, docs look like this:

![image](https://github.com/FEniCS/basix/assets/9850599/8dccbf93-f697-4830-aabc-363072a9f4e3)

After this change, docs look like this, with a scrollbar at the bottom of the sidebar:

![image](https://github.com/FEniCS/basix/assets/9850599/767ea55e-f7fb-457a-ac31-576f47246f66)
