### PR TITLE
Check that dof ordering is the same in element equality check

### DIFF
--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -23,6 +23,8 @@
 #include <limits>
 #include <numeric>
 
+#include <iostream>
+
 #define str_macro(X) #X
 #define str(X) str_macro(X)
 
@@ -957,8 +959,8 @@ FiniteElement<F>::FiniteElement(
 }
 /// @endcond
 //-----------------------------------------------------------------------------
-template <std::floating_point F, std::floating_points F2>
-bool FiniteElement<F>::operator==(const FiniteElement<F2>& e) const
+template <std::floating_point F>
+bool FiniteElement<F>::operator==(const FiniteElement& e) const
 {
   if (this == &e)
     return true;
@@ -982,7 +984,8 @@ bool FiniteElement<F>::operator==(const FiniteElement<F2>& e) const
            and value_shape() == e.value_shape()
            and embedded_superdegree() == e.embedded_superdegree()
            and embedded_subdegree() == e.embedded_subdegree() and coeff_equal
-           and entity_dofs() == e.entity_dofs();
+           and entity_dofs() == e.entity_dofs()
+           and dof_ordering() == e.dof_ordering();
   }
   else
   {
@@ -990,7 +993,8 @@ bool FiniteElement<F>::operator==(const FiniteElement<F2>& e) const
            and degree() == e.degree() and discontinuous() == e.discontinuous()
            and lagrange_variant() == e.lagrange_variant()
            and dpc_variant() == e.dpc_variant() and map_type() == e.map_type()
-           and sobolev_space() == e.sobolev_space();
+           and sobolev_space() == e.sobolev_space()
+           and dof_ordering() == e.dof_ordering();
   }
 }
 //-----------------------------------------------------------------------------

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -23,8 +23,6 @@
 #include <limits>
 #include <numeric>
 
-#include <iostream>
-
 #define str_macro(X) #X
 #define str(X) str_macro(X)
 

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -957,8 +957,8 @@ FiniteElement<F>::FiniteElement(
 }
 /// @endcond
 //-----------------------------------------------------------------------------
-template <std::floating_point F>
-bool FiniteElement<F>::operator==(const FiniteElement& e) const
+template <std::floating_point F, std::floating_points F2>
+bool FiniteElement<F>::operator==(const FiniteElement<F2>& e) const
 {
   if (this == &e)
     return true;

--- a/test/test_equality.py
+++ b/test/test_equality.py
@@ -25,7 +25,7 @@ def test_element_equality():
     assert p1 != p1_quad
     assert p1 != rt1
 
-    assert p1 == p1_f32
+    assert p1 != p1_f32
 
 
 def test_custom_element_equality():

--- a/test/test_equality.py
+++ b/test/test_equality.py
@@ -2,8 +2,8 @@
 # FEniCS Project
 # SPDX-License-Identifier: MIT
 
-import pytest
 import numpy as np
+import pytest
 
 import basix
 

--- a/test/test_equality.py
+++ b/test/test_equality.py
@@ -16,6 +16,8 @@ def test_element_equality():
     p4_equi = basix.create_element(basix.ElementFamily.P, basix.CellType.triangle, 4, basix.LagrangeVariant.equispaced)
 
     p1_f32 = basix.create_element(basix.ElementFamily.P, basix.CellType.triangle, 1, dtype=np.float32)
+    p1_dofs = basix.create_element(basix.ElementFamily.P, basix.CellType.triangle, 1, dtype=np.float64, dof_ordering=[0, 1, 2])
+    p1_reverse_dofs = basix.create_element(basix.ElementFamily.P, basix.CellType.triangle, 1, dtype=np.float64, dof_ordering=[2, 1, 0])
 
     assert p1 == p1
     assert p1 == p1_again
@@ -26,6 +28,10 @@ def test_element_equality():
     assert p1 != rt1
 
     assert p1 != p1_f32
+
+    assert p1 == p1_dofs
+    assert p1 != p1_reverse_dofs
+    assert p1_dofs != p1_reverse_dofs
 
 
 def test_custom_element_equality():

--- a/test/test_equality.py
+++ b/test/test_equality.py
@@ -7,6 +7,7 @@ import numpy as np
 
 import basix
 
+
 def create_custom_p1():
     wcoeffs = np.eye(3)
     z = np.zeros((0, 2))

--- a/test/test_equality.py
+++ b/test/test_equality.py
@@ -2,65 +2,150 @@
 # FEniCS Project
 # SPDX-License-Identifier: MIT
 
+import pytest
 import numpy as np
 
 import basix
 
-
-def test_element_equality():
-    p1 = basix.create_element(basix.ElementFamily.P, basix.CellType.triangle, 1, dtype=np.float64)
-    p1_again = basix.create_element(basix.ElementFamily.P, basix.CellType.triangle, 1, dtype=np.float64)
-    rt1 = basix.create_element(basix.ElementFamily.RT, basix.CellType.triangle, 1)
-    p1_quad = basix.create_element(basix.ElementFamily.P, basix.CellType.quadrilateral, 1)
-    p4_gll = basix.create_element(basix.ElementFamily.P, basix.CellType.triangle, 4, basix.LagrangeVariant.gll_warped)
-    p4_equi = basix.create_element(basix.ElementFamily.P, basix.CellType.triangle, 4, basix.LagrangeVariant.equispaced)
-
-    p1_f32 = basix.create_element(basix.ElementFamily.P, basix.CellType.triangle, 1, dtype=np.float32)
-    p1_dofs = basix.create_element(basix.ElementFamily.P, basix.CellType.triangle, 1, dtype=np.float64, dof_ordering=[0, 1, 2])
-    p1_reverse_dofs = basix.create_element(basix.ElementFamily.P, basix.CellType.triangle, 1, dtype=np.float64, dof_ordering=[2, 1, 0])
-
-    assert p1 == p1
-    assert p1 == p1_again
-    assert p1 != p4_gll
-    assert p1 != p4_equi
-    assert p4_gll != p4_equi
-    assert p1 != p1_quad
-    assert p1 != rt1
-
-    assert p1 != p1_f32
-
-    assert p1 == p1_dofs
-    assert p1 != p1_reverse_dofs
-    assert p1_dofs != p1_reverse_dofs
-
-
-def test_custom_element_equality():
-    p1 = basix.create_element(basix.ElementFamily.P, basix.CellType.triangle, 1)
-    cr = basix.create_element(basix.ElementFamily.CR, basix.CellType.triangle, 1)
-
+def create_custom_p1():
     wcoeffs = np.eye(3)
     z = np.zeros((0, 2))
     x = [[np.array([[0., 0.]]), np.array([[1., 0.]]), np.array([[0., 1.]])], [z, z, z], [z], []]
     z = np.zeros((0, 1, 0, 1))
     M = [[np.array([[[[1.]]]]), np.array([[[[1.]]]]), np.array([[[[1.]]]])], [z, z, z], [z], []]
 
-    p1_custom = basix.create_custom_element(basix.CellType.triangle, [], wcoeffs,
-                                            x, M, 0, basix.MapType.identity, basix.SobolevSpace.H1,
-                                            False, 1, 1, basix.PolysetType.standard)
-    p1_custom_again = basix.create_custom_element(basix.CellType.triangle, [], wcoeffs,
-                                                  x, M, 0, basix.MapType.identity, basix.SobolevSpace.H1,
-                                                  False, 1, 1, basix.PolysetType.standard)
+    return basix.create_custom_element(basix.CellType.triangle, [], wcoeffs,
+                                       x, M, 0, basix.MapType.identity, basix.SobolevSpace.H1,
+                                       False, 1, 1, basix.PolysetType.standard)
+
+
+@pytest.fixture
+def p1_custom():
+    return create_custom_p1()
+
+
+@pytest.fixture
+def p1_custom_again():
+    return create_custom_p1()
+
+
+@pytest.fixture
+def cr_custom():
     wcoeffs = np.eye(3)
     z = np.zeros((0, 2))
     x = [[z, z, z], [np.array([[.5, .5]]), np.array([[0., .5]]), np.array([[.5, 0.]])], [z], []]
     z = np.zeros((0, 1, 0, 1))
     M = [[z, z, z], [np.array([[[[1.]]]]), np.array([[[[1.]]]]), np.array([[[[1.]]]])], [z], []]
 
-    cr_custom = basix.create_custom_element(basix.CellType.triangle, [], wcoeffs,
-                                            x, M, 0, basix.MapType.identity, basix.SobolevSpace.L2,
-                                            False, 1, 1, basix.PolysetType.standard)
+    return basix.create_custom_element(basix.CellType.triangle, [], wcoeffs,
+                                       x, M, 0, basix.MapType.identity, basix.SobolevSpace.L2,
+                                       False, 1, 1, basix.PolysetType.standard)
 
+
+@pytest.fixture
+def cr():
+    return basix.create_element(basix.ElementFamily.CR, basix.CellType.triangle, 1)
+
+
+@pytest.fixture
+def p1():
+    return basix.create_element(basix.ElementFamily.P, basix.CellType.triangle, 1)
+
+
+@pytest.fixture
+def p1_again():
+    return basix.create_element(basix.ElementFamily.P, basix.CellType.triangle, 1)
+
+
+@pytest.fixture
+def rt1():
+    return basix.create_element(basix.ElementFamily.RT, basix.CellType.triangle, 1)
+
+
+@pytest.fixture
+def p1_quad():
+    return basix.create_element(basix.ElementFamily.P, basix.CellType.quadrilateral, 1)
+
+
+@pytest.fixture
+def p4_gll():
+    return basix.create_element(basix.ElementFamily.P, basix.CellType.triangle, 4, basix.LagrangeVariant.gll_warped)
+
+
+@pytest.fixture
+def p4_equi():
+    return basix.create_element(basix.ElementFamily.P, basix.CellType.triangle, 4, basix.LagrangeVariant.equispaced)
+
+
+@pytest.fixture
+def p1_f32():
+    return basix.create_element(basix.ElementFamily.P, basix.CellType.triangle, 1, dtype=np.float32)
+
+
+@pytest.fixture
+def p1_f64():
+    return basix.create_element(basix.ElementFamily.P, basix.CellType.triangle, 1, dtype=np.float64)
+
+
+@pytest.fixture
+def p1_dofs():
+    return basix.create_element(basix.ElementFamily.P, basix.CellType.triangle, 1, dof_ordering=[0, 1, 2])
+
+
+@pytest.fixture
+def p1_dofs_again():
+    return basix.create_element(basix.ElementFamily.P, basix.CellType.triangle, 1, dof_ordering=[0, 1, 2])
+
+
+@pytest.fixture
+def p1_reverse_dofs():
+    return basix.create_element(basix.ElementFamily.P, basix.CellType.triangle, 1, dof_ordering=[2, 1, 0])
+
+
+def test_equal_same_element(p1, p1_again):
+    assert p1 == p1
+    assert p1 == p1_again
+
+
+def test_nonequal_degree(p1, p4_gll):
+    assert p1 != p4_gll
+
+
+def test_nonequal_degree_equi(p1, p4_equi):
+    assert p1 != p4_equi
+
+
+def test_nonequal_variants(p4_gll, p4_equi):
+    assert p4_gll != p4_equi
+
+
+def test_nonequal_celltype(p1, p1_quad):
+    assert p1 != p1_quad
+
+
+def test_nonequal_family(p1, rt1):
+    assert p1 != rt1
+
+
+def test_nonequal_dtype(p1_f64, p1_f32):
+    assert p1_f64 != p1_f32
+
+
+def test_equal_dof_ordering(p1, p1_dofs, p1_dofs_again):
+    assert p1_dofs == p1_dofs_again
+
+
+def test_nonequal_dof_ordering(p1, p1_reverse_dofs, p1_dofs):
+    assert p1 != p1_dofs
+    assert p1 != p1_reverse_dofs
+    assert p1_dofs != p1_reverse_dofs
+
+
+def test_equal_custom(p1_custom, p1_custom_again):
     assert p1_custom == p1_custom_again
+
+
+def test_nonequal_custom(p1_custom, cr_custom, cr, p1):
     assert p1_custom != cr_custom
     assert p1_custom != cr
     assert p1_custom != p1

--- a/test/test_equality.py
+++ b/test/test_equality.py
@@ -8,12 +8,14 @@ import basix
 
 
 def test_element_equality():
-    p1 = basix.create_element(basix.ElementFamily.P, basix.CellType.triangle, 1)
-    p1_again = basix.create_element(basix.ElementFamily.P, basix.CellType.triangle, 1)
+    p1 = basix.create_element(basix.ElementFamily.P, basix.CellType.triangle, 1, dtype=np.float64)
+    p1_again = basix.create_element(basix.ElementFamily.P, basix.CellType.triangle, 1, dtype=np.float64)
     rt1 = basix.create_element(basix.ElementFamily.RT, basix.CellType.triangle, 1)
     p1_quad = basix.create_element(basix.ElementFamily.P, basix.CellType.quadrilateral, 1)
     p4_gll = basix.create_element(basix.ElementFamily.P, basix.CellType.triangle, 4, basix.LagrangeVariant.gll_warped)
     p4_equi = basix.create_element(basix.ElementFamily.P, basix.CellType.triangle, 4, basix.LagrangeVariant.equispaced)
+
+    p1_f32 = basix.create_element(basix.ElementFamily.P, basix.CellType.triangle, 1, dtype=np.float32)
 
     assert p1 == p1
     assert p1 == p1_again
@@ -22,6 +24,8 @@ def test_element_equality():
     assert p4_gll != p4_equi
     assert p1 != p1_quad
     assert p1 != rt1
+
+    assert p1 == p1_f32
 
 
 def test_custom_element_equality():


### PR DESCRIPTION
- Add DOF ordering check to == check
- Added tests that == is correct for elements with different dtypes and dof ordering
- Split equality tests into multiple smaller tests