### PR TITLE
Drop `fenics-dev@googlegroups.com` in favor of `fenics-steering-council@googlegroups.com`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ readme = "README.md"
 requires-python = ">=3.8.0"
 license = { file = "LICENSE" }
 authors = [
-    { email = "fenics-dev@googlegroups.com" },
-    { name = "FEniCS Project" },
+    { email = "fenics-steering-council@googlegroups.com" },
+    { name = "FEniCS Steering Council" },
 ]
 packages = ["basix"]
 dependencies = ["numpy>=1.21"]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -10,8 +10,8 @@ readme = "../README.md"
 requires-python = ">=3.8.0"
 license = { file = "../LICENSE" }
 authors = [
-    { email = "fenics-dev@googlegroups.com" },
-    { name = "FEniCS Project" },
+    { email = "fenics-steering-council@googlegroups.com" },
+    { name = "FEniCS Steering Council" },
 ]
 packages = ["basix"]
 dependencies = ["numpy>=1.21"]


### PR DESCRIPTION
In preparation of `fenics-dev@googlegroups.com` shutting down.