### PR TITLE
Windows: make runtime dependency install optional

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -31,6 +31,9 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 option(BUILD_SHARED_LIBS "Build Basix with shared libraries." ON)
 add_feature_info(BUILD_SHARED_LIBS BUILD_SHARED_LIBS "Build Basix with shared libraries.")
 
+option(INSTALL_RUNTIME_DEPENDENCIES "Include runtime dependencies in install (Windows-only)" ON)
+add_feature_info(INSTALL_RUNTIME_DEPENDENCIES INSTALL_RUNTIME_DEPENDENCIES "Include runtime dependencies in install (Windows-only)")
+
 find_package(BLAS REQUIRED)
 find_package(LAPACK REQUIRED)
 
@@ -136,10 +139,11 @@ if (WIN32)
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT RuntimeLibraries
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Development
   )
-  
-  LIST(APPEND PRE_EXCLUDE_REGEXES "api-ms-.*")
-  LIST(APPEND PRE_EXCLUDE_REGEXES "ext-ms-.*")
-  install(RUNTIME_DEPENDENCY_SET dependencies DESTINATION ${CMAKE_INSTALL_BINDIR} PRE_EXCLUDE_REGEXES ${PRE_EXCLUDE_REGEXES} POST_EXCLUDE_REGEXES ".*system32/.*\\.dll" )
+  if (INSTALL_RUNTIME_DEPENDENCIES)
+    LIST(APPEND PRE_EXCLUDE_REGEXES "api-ms-.*")
+    LIST(APPEND PRE_EXCLUDE_REGEXES "ext-ms-.*")
+    install(RUNTIME_DEPENDENCY_SET dependencies DESTINATION ${CMAKE_INSTALL_BINDIR} PRE_EXCLUDE_REGEXES ${PRE_EXCLUDE_REGEXES} POST_EXCLUDE_REGEXES ".*system32/.*\\.dll" )
+  endif()
 else()
   install(TARGETS basix
   EXPORT BasixTargets


### PR DESCRIPTION
Bundling dependencies is not desirable in a conda package, where packaging already handles this, plus it happens to be throwing an error because blas/lapack DLLs aren't found by cmake (their DIRECTORIES aren't specified).

I believe this was the only change I needed to get Windows builds to work on conda-forge: https://github.com/conda-forge/fenics-basix-feedstock/pull/18

I'm not sure what the default should be, but I'd _guess_ it should be OFF by default. I left the default behavior unchanged in this PR.

FWIW, the default vs2019 compiler failed with:

```
D:\bld\fenics-basix-meta_1714546306829\work\cpp\basix\mdspan.hpp(3847,15): error C2672: 'std::experimental::detail::get_actual_static_padding_value': no matching overloaded function found [D:\bld\fenics-basix-meta_1714546306829\work\cpp\build\basix.vcxproj]
D:\bld\fenics-basix-meta_1714546306829\work\cpp\basix\mdspan.hpp(3849): message : see reference to class template instantiation 'std::experimental::detail::static_array_type_for_padded_extent<_PaddingValue,_Extents,_ExtentToPadIdx,_Rank,Enabled>' being compiled [D:\bld\fenics-basix-meta_1714546306829\work\cpp\build\basix.vcxproj]
```

but this went away after upgrading to vs2022. In case anybody in the future reports a similar error, their compiler might be outdated.
