### PR TITLE
Make runtime dependency install OFF by default

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -38,7 +38,7 @@ jobs:
       
       - name: Install Basix (combined)
         run: |
-          python -m pip -v install --no-cache-dir .[ci] --config-settings=cmake.args=-DINSTALL_RUNTIME_DEPENDENCES=ON --config-settings=cmake.args=-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
+          python -m pip -v install --no-cache-dir .[ci] --config-settings=cmake.args=-DINSTALL_RUNTIME_DEPENDENCIES=ON --config-settings=cmake.args=-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
       - name: Run units tests
         run: |
           python -m pytest -n auto --durations 20 test/

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -38,7 +38,7 @@ jobs:
       
       - name: Install Basix (combined)
         run: |
-          python -m pip -v install --no-cache-dir .[ci] --config-settings=cmake.args=-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
+          python -m pip -v install --no-cache-dir .[ci] --config-settings=cmake.args=-DINSTALL_RUNTIME_DEPENDENCES=ON --config-settings=cmake.args=-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
       - name: Run units tests
         run: |
           python -m pytest -n auto --durations 20 test/
@@ -69,7 +69,7 @@ jobs:
       - name: Install Basix (C++)
         run: |
           cd cpp
-          cmake -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -B build-dir -S .
+          cmake -DINSTALL_RUNTIME_DEPENDENCES=ON -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -B build-dir -S .
           cmake --build build-dir --config Release
           cmake --install build-dir --config Release --prefix D:/a/basix/install
           echo "D:/a/basix/install/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Install Basix (C++)
         run: |
           cd cpp
-          cmake -DINSTALL_RUNTIME_DEPENDENCES=ON -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -B build-dir -S .
+          cmake -DINSTALL_RUNTIME_DEPENDENCIES=ON -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -B build-dir -S .
           cmake --build build-dir --config Release
           cmake --install build-dir --config Release --prefix D:/a/basix/install
           echo "D:/a/basix/install/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -31,7 +31,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 option(BUILD_SHARED_LIBS "Build Basix with shared libraries." ON)
 add_feature_info(BUILD_SHARED_LIBS BUILD_SHARED_LIBS "Build Basix with shared libraries.")
 
-option(INSTALL_RUNTIME_DEPENDENCIES "Include runtime dependencies in install (Windows-only)" ON)
+option(INSTALL_RUNTIME_DEPENDENCIES "Include runtime dependencies in install (Windows-only)" OFF)
 add_feature_info(INSTALL_RUNTIME_DEPENDENCIES INSTALL_RUNTIME_DEPENDENCIES "Include runtime dependencies in install (Windows-only)")
 
 find_package(BLAS REQUIRED)


### PR DESCRIPTION
Installing runtime dependencies interferes with downstream package managers who will be primary creators of Windows builds.