### PR TITLE
Disable windows tests

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,17 +1,6 @@
 name: Basix CI on Windows
 
 on:
-  pull_request:
-    branches:
-      - main
-  push:
-    tags:
-      - "v*"
-    branches:
-      - "**"
-  merge_group:
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Due to a compiler bug in MSVC nanobind build currently crashes.

MS have a fix, will have to look and see when it is rolled out on GitHub Actions.
