### PR TITLE
Update to std::ranges usage

### DIFF
--- a/cpp/basix/cell.cpp
+++ b/cpp/basix/cell.cpp
@@ -460,7 +460,7 @@ cell::facet_normals(cell::type cell_type)
   switch (tdim)
   {
   case 1:
-    std::fill(normal.begin(), normal.end(), 1.0);
+    std::ranges::fill(normal, 1.0);
     return {normal, shape};
   case 2:
   {

--- a/cpp/basix/dof-transformations.cpp
+++ b/cpp/basix/dof-transformations.cpp
@@ -39,7 +39,7 @@ int find_first_subentity(cell::type cell_type, cell::type entity_type)
 {
   const int edim = cell::topological_dimension(entity_type);
   std::vector<cell::type> entities = cell::subentity_types(cell_type)[edim];
-  if (auto it = std::find(entities.begin(), entities.end(), entity_type);
+  if (auto it = std::ranges::find(entities, entity_type);
       it != entities.end())
   {
     return std::distance(entities.begin(), it);

--- a/cpp/basix/e-lagrange.cpp
+++ b/cpp/basix/e-lagrange.cpp
@@ -383,7 +383,7 @@ FiniteElement<T> create_bernstein(cell::type celltype, int degree,
         impl::mdspan_t<T, 2> _id(id.data(), nb[d], nb[d]);
         impl::mdspan_t<T, 2> _mat(mat.data(), mat.extents());
         std::vector<T> minv_data = math::solve<T>(_mat, _id);
-        std::ranges::copy(minv_data, minv.data());
+        std::copy(minv_data.begin(), minv_data.end(), minv.data());
       }
 
       M[d] = std::vector<impl::mdarray_t<T, 4>>(

--- a/cpp/basix/e-lagrange.cpp
+++ b/cpp/basix/e-lagrange.cpp
@@ -383,7 +383,7 @@ FiniteElement<T> create_bernstein(cell::type celltype, int degree,
         impl::mdspan_t<T, 2> _id(id.data(), nb[d], nb[d]);
         impl::mdspan_t<T, 2> _mat(mat.data(), mat.extents());
         std::vector<T> minv_data = math::solve<T>(_mat, _id);
-        std::copy(minv_data.begin(), minv_data.end(), minv.data());
+        std::ranges::copy(minv_data, minv.data());
       }
 
       M[d] = std::vector<impl::mdarray_t<T, 4>>(

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -17,6 +17,7 @@
 #include "e-serendipity.h"
 #include "math.h"
 #include "polyset.h"
+#include <algorithm>
 #include <basix/version.h>
 #include <cmath>
 #include <concepts>
@@ -651,7 +652,7 @@ FiniteElement<T> basix::create_custom_element(
     if (x[i].size()
         != (i > tdim ? 0
                      : static_cast<std::size_t>(
-                         cell::num_sub_entities(cell_type, i))))
+                           cell::num_sub_entities(cell_type, i))))
     {
       throw std::runtime_error("x has the wrong number of entities");
     }
@@ -669,7 +670,7 @@ FiniteElement<T> basix::create_custom_element(
     if (M[i].size()
         != (i > tdim ? 0
                      : static_cast<std::size_t>(
-                         cell::num_sub_entities(cell_type, i))))
+                           cell::num_sub_entities(cell_type, i))))
       throw std::runtime_error("M has the wrong number of entities");
     for (std::size_t j = 0; j < M[i].size(); ++j)
     {
@@ -940,7 +941,7 @@ FiniteElement<F>::FiniteElement(
         }
       }
 
-      std::sort(_e_closure_dofs[d][e].begin(), _e_closure_dofs[d][e].end());
+      std::ranges::sort(_e_closure_dofs[d][e]);
     }
   }
 
@@ -1020,7 +1021,7 @@ FiniteElement<F>::FiniteElement(
           std::pair<std::vector<F>, std::array<std::size_t, 2>> identity
               = {std::vector<F>(perm.size() * perm.size()),
                  {perm.size(), perm.size()}};
-          std::fill(identity.first.begin(), identity.first.end(), 0.);
+          std::ranges::fill(identity.first, 0.);
           for (std::size_t i = 0; i < perm.size(); ++i)
             identity.first[i * perm.size() + i] = 1;
 
@@ -1457,10 +1458,9 @@ bool FiniteElement<F>::operator==(const FiniteElement& e) const
     bool coeff_equal = false;
     if (_coeffs.first.size() == e.coefficient_matrix().first.size()
         and _coeffs.second == e.coefficient_matrix().second
-        and std::equal(_coeffs.first.begin(), _coeffs.first.end(),
-                       e.coefficient_matrix().first.begin(),
-                       [](auto x, auto y)
-                       { return std::abs(x - y) < 1.0e-10; }))
+        and std::ranges::equal(_coeffs.first, e.coefficient_matrix().first,
+                               [](auto x, auto y)
+                               { return std::abs(x - y) < 1.0e-10; }))
     {
       coeff_equal = true;
     }

--- a/cpp/basix/lattice.cpp
+++ b/cpp/basix/lattice.cpp
@@ -403,7 +403,7 @@ std::vector<T> isaac_point(lattice::type lattice_type,
       denominator += x[sub_size];
     }
 
-    std::ranges::for_each(res, [denominator](auto x) { return x / denominator; });
+    std::ranges::for_each(res, [denominator](auto& x) { x /= denominator; });
 
     return res;
   }

--- a/cpp/basix/lattice.cpp
+++ b/cpp/basix/lattice.cpp
@@ -7,6 +7,7 @@
 #include "math.h"
 #include "polyset.h"
 #include "quadrature.h"
+#include <algorithm>
 #include <cmath>
 #include <concepts>
 #include <math.h>
@@ -402,8 +403,7 @@ std::vector<T> isaac_point(lattice::type lattice_type,
       denominator += x[sub_size];
     }
 
-    std::transform(res.begin(), res.end(), res.begin(),
-                   [denominator](auto x) { return x / denominator; });
+    std::ranges::for_each(res, [denominator](auto x) { return x / denominator; });
 
     return res;
   }

--- a/cpp/basix/quadrature.cpp
+++ b/cpp/basix/quadrature.cpp
@@ -52,19 +52,18 @@ std::array<std::vector<T>, 2> rec_jacobi(int N, T a, T b)
   std::vector<T> n(N - 1);
   std::iota(n.begin(), n.end(), 1.0);
   std::vector<T> nab(n.size());
-  std::transform(n.begin(), n.end(), nab.begin(),
+  std::ranges::transform(n, nab.begin(),
                  [a, b](auto x) { return 2.0 * x + a + b; });
 
   std::vector<T> alpha(N);
   alpha.front() = nu;
-  std::transform(nab.begin(), nab.end(), std::next(alpha.begin()),
+  std::ranges::transform(nab, std::next(alpha.begin()),
                  [a, b](auto nab)
                  { return (b * b - a * a) / (nab * (nab + 2.0)); });
 
   std::vector<T> beta(N);
   beta.front() = mu;
-  std::transform(n.begin(), n.end(), nab.begin(), std::next(beta.begin()),
-                 [a, b](auto n, auto nab)
+  std::ranges::transform(n, nab, std::next(beta.begin()), [a, b](auto n, auto nab)
                  {
                    return 4 * (n + a) * (n + b) * n * (n + a + b)
                           / (nab * nab * (nab + 1.0) * (nab - 1.0));
@@ -279,10 +278,8 @@ template <std::floating_point T>
 std::array<std::vector<T>, 2> make_quadrature_line(int m)
 {
   auto [ptx, wx] = compute_gauss_jacobi_rule<T>(0.0, m);
-  std::transform(wx.begin(), wx.end(), wx.begin(),
-                 [](auto w) { return 0.5 * w; });
-  std::transform(ptx.begin(), ptx.end(), ptx.begin(),
-                 [](auto x) { return 0.5 * (x + 1.0); });
+  std::ranges::transform(wx, wx.begin(), [](auto w) { return 0.5 * w; });
+  std::ranges::transform(ptx, ptx.begin(), [](auto x) { return 0.5 * (x + 1.0); });
   return {std::move(ptx), std::move(wx)};
 }
 //-----------------------------------------------------------------------------
@@ -469,10 +466,8 @@ template <std::floating_point T>
 std::array<std::vector<T>, 2> make_gll_line(int m)
 {
   auto [ptx, wx] = compute_gll_rule<T>(m);
-  std::transform(wx.begin(), wx.end(), wx.begin(),
-                 [](auto w) { return 0.5 * w; });
-  std::transform(ptx.begin(), ptx.end(), ptx.begin(),
-                 [](auto x) { return 0.5 * (x + 1.0); });
+  std::ranges::transform(wx, wx.begin(), [](auto w) { return 0.5 * w; });
+  std::ranges::transform(ptx, ptx.begin(), [](auto x) { return 0.5 * (x + 1.0); });
   return {ptx, wx};
 }
 //-----------------------------------------------------------------------------
@@ -4961,8 +4956,7 @@ template <std::floating_point T>
 std::vector<T> quadrature::get_gl_points(int m)
 {
   std::vector<T> pts = compute_gauss_jacobi_points<T>(0, m);
-  std::transform(pts.begin(), pts.end(), pts.begin(),
-                 [](auto x) { return 0.5 + 0.5 * x; });
+  std::ranges::transform(pts, pts.begin(), [](auto x) { return 0.5 + 0.5 * x; });
   return pts;
 }
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Note currently both `std::accumulate` and `std::reduce` which are frequently used in `basix` do not offer `::ranges` equivalents in `C++20`.  
