### PR TITLE
Switch back to C++20 and use modern set_compile_features to set minimum C++ standard

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -18,13 +18,6 @@ endif()
 
 include(FeatureSummary)
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
-  # Only newer CMake passes non-standard Intel C++23 flag.
-  # see https://github.com/FEniCS/basix/pull/838
-  # When Intel C++23 support meets ISO standard this can be removed.
-  cmake_minimum_required(3.26) 
-endif()
-
 # Options
 option(BUILD_SHARED_LIBS "Build Basix with shared libraries." ON)
 add_feature_info(BUILD_SHARED_LIBS BUILD_SHARED_LIBS "Build Basix with shared libraries.")
@@ -47,10 +40,10 @@ endif()
 add_library(basix)
 
 # Set the C++ standard
-target_compile_features(basix PUBLIC cxx_std_23)
+target_compile_features(basix PUBLIC cxx_std_20)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/basix/version.h.in basix/version.h)
-include_directories(${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories(basix PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 set(HEADERS_basix
   ${CMAKE_CURRENT_SOURCE_DIR}/basix/cell.h
@@ -113,10 +106,6 @@ target_include_directories(basix PUBLIC
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR};${CMAKE_CURRENT_SOURCE_DIR}>")
 
-# TODO: remove after issue https://github.com/FEniCS/basix/issues/842 is resolved
-target_compile_definitions(basix PUBLIC MDSPAN_USE_PAREN_OPERATOR=1)
-target_compile_definitions(basix PUBLIC MDSPAN_USE_BRACKET_OPERATOR=0)
-
 target_link_libraries(basix PRIVATE BLAS::BLAS)
 target_link_libraries(basix PRIVATE LAPACK::LAPACK)
 
@@ -129,7 +118,7 @@ endif()
 
 if (MSVC)
     # M_PI etc. are not not in the standard-compliant MSVC headers.
-    add_compile_definitions(_USE_MATH_DEFINES)
+    target_compile_definitions(basix PUBLIC _USE_MATH_DEFINES)
 endif()
 
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -114,8 +114,8 @@ target_include_directories(basix PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR};${CMAKE_CURRENT_SOURCE_DIR}>")
 
 # TODO: remove after issue https://github.com/FEniCS/basix/issues/842 is resolved
-target_compile_definitions(basix PRIVATE MDSPAN_USE_PAREN_OPERATOR=1)
-target_compile_definitions(basix PRIVATE MDSPAN_USE_BRACKET_OPERATOR=0)
+target_compile_definitions(basix PUBLIC MDSPAN_USE_PAREN_OPERATOR=1)
+target_compile_definitions(basix PUBLIC MDSPAN_USE_BRACKET_OPERATOR=0)
 
 target_link_libraries(basix PRIVATE BLAS::BLAS)
 target_link_libraries(basix PRIVATE LAPACK::LAPACK)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -18,11 +18,6 @@ endif()
 
 include(FeatureSummary)
 
-# Set the C++ standard
-set(CMAKE_CXX_STANDARD 23)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
   # Only newer CMake passes non-standard Intel C++23 flag.
   # see https://github.com/FEniCS/basix/pull/838
@@ -50,6 +45,9 @@ endif()
 
 # Source files
 add_library(basix)
+
+# Set the C++ standard
+target_compile_features(basix PUBLIC cxx_std_23)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/basix/version.h.in basix/version.h)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})

--- a/demo/cpp/demo_create_and_tabulate/CMakeLists.txt
+++ b/demo/cpp/demo_create_and_tabulate/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.16)
 project(demo_create_and_tabulate LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
@@ -20,10 +20,6 @@ endif()
 find_package(Basix REQUIRED CONFIG HINTS ${BASIX_PY_DIR})
 
 add_executable(${PROJECT_NAME} main.cpp)
-
-# TODO: remove after issue https://github.com/FEniCS/basix/issues/842 is resolved
-target_compile_definitions(${PROJECT_NAME} PRIVATE MDSPAN_USE_PAREN_OPERATOR=1)
-target_compile_definitions(${PROJECT_NAME} PRIVATE MDSPAN_USE_BRACKET_OPERATOR=0)
 
 if (BASIX_PY_DIR AND IS_DIRECTORY ${BASIX_PY_DIR}/../fenics_basix.libs)
     set_target_properties(${PROJECT_NAME} PROPERTIES BUILD_RPATH ${BASIX_PY_DIR}/../fenics_basix.libs)

--- a/demo/cpp/demo_dof_transformations/CMakeLists.txt
+++ b/demo/cpp/demo_dof_transformations/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.16)
 project(demo_dof_transformations LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
@@ -20,10 +20,6 @@ endif()
 find_package(Basix REQUIRED CONFIG HINTS ${BASIX_PY_DIR})
 
 add_executable(${PROJECT_NAME} main.cpp)
-
-# TODO: remove after issue https://github.com/FEniCS/basix/issues/842 is resolved
-target_compile_definitions(${PROJECT_NAME} PRIVATE MDSPAN_USE_PAREN_OPERATOR=1)
-target_compile_definitions(${PROJECT_NAME} PRIVATE MDSPAN_USE_BRACKET_OPERATOR=0)
 
 if (BASIX_PY_DIR AND IS_DIRECTORY ${BASIX_PY_DIR}/../fenics_basix.libs)
     set_target_properties(${PROJECT_NAME} PROPERTIES BUILD_RPATH ${BASIX_PY_DIR}/../fenics_basix.libs)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -8,16 +8,9 @@ endif()
 project(basix_nanobind VERSION "0.9.0.0" LANGUAGES CXX)
 
 # Set C++ standard
-set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-
-if(CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
-  # Only newer CMake passes non-standard Intel C++23 flag.
-  # see https://github.com/FEniCS/basix/pull/838
-  # When Intel C++23 support meets ISO standard this can be removed.
-  cmake_minimum_required(3.26) 
-endif()
 
 if (WIN32)
     # Windows requires all symbols to be manually exported.

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -7,11 +7,6 @@ endif()
 
 project(basix_nanobind VERSION "0.9.0.0" LANGUAGES CXX)
 
-# Set C++ standard
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
 if (WIN32)
     # Windows requires all symbols to be manually exported.
     # This flag exports all symbols automatically, as in Unix.
@@ -36,6 +31,7 @@ find_package(nanobind CONFIG REQUIRED)
 
 # Create the binding library
 nanobind_add_module(_basixcpp wrapper.cpp)
+target_compile_definitions(_basixcpp PRIVATE cxx_std_20)
 target_link_libraries(_basixcpp PRIVATE Basix::basix)
 
 # Add strict compiler flags


### PR DESCRIPTION
### Summary
When building `basix` as a a library to be used by other projects, it needs to communicate its c++ standard requirements, especially now since c++23 is required to some extend. Currently the library is configured by setting the global cmake variable `CMAKE_CXX_STANDARD` etc. This works perfectly fine for this library, but is not included in the exported targets. With the current PR the way of enforcing the c++ standard is changed to a compile feature `cxx_std_23`  set directly on the `basix` target. This way it is included in the exported target.