### PR TITLE
Re-enable Windows CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,7 +1,18 @@
 name: Basix CI on Windows
 
 on:
-  workflow_dispatch:
+   pull_request:
+     branches:
+       - main
+   push:
+     tags:
+       - "v*"
+     branches:
+       - "**"
+   merge_group:
+     branches:
+       - main
+   workflow_dispatch:
 
 jobs:
   build-combined:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,7 +8,7 @@ on:
      tags:
        - "v*"
      branches:
-       - "**"
+       - main
    merge_group:
      branches:
        - main

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Install Basix (Python)
         run: |
           cd python
-          python -m pip -v install --no-cache-dir .[ci] --config-settings=cmake.args=-DBasix_DIR=D:/a/basix/install/lib/cmake/basix
+          python -m pip -v install --no-build-isolation --no-cache-dir .[ci] --config-settings=cmake.args=-DBasix_DIR=D:/a/basix/install/lib/cmake/basix
           cd ../
       
       - name: Run units tests

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install build dependencies (workaround)
         run: |
-          python -m pip install scikit-build-core[pyproject] git+https://github.com/jhale/nanobind.git@jhale/msvc2022-workaround
+          python -m pip install scikit-build-core[pyproject] git+https://github.com/jhale/nanobind.git@jhale/msvc2022-workaround setuptools wheel
       - name: Install Basix (combined)
         run: |
           python -m pip -v install --no-build-isolation --no-cache-dir .[ci] --config-settings=cmake.args=-DINSTALL_RUNTIME_DEPENDENCIES=ON --config-settings=cmake.args=-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
@@ -75,7 +75,7 @@ jobs:
 
       - name: Install build dependencies (workaround)
         run: |
-          python -m pip install scikit-build-core[pyproject] git+https://github.com/jhale/nanobind.git@jhale/msvc2022-workaround
+          python -m pip install scikit-build-core[pyproject] git+https://github.com/jhale/nanobind.git@jhale/msvc2022-workaround setuptools wheel
       - name: Install Basix (Python)
         run: |
           cd python

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,10 +24,14 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      
+
+      - name: Install build dependencies (workaround)
+        run: |
+          python -m pip install scikit-build-core[pyproject] git+https://github.com/jhale/nanobind.git@jhale/msvc2022-workaround
       - name: Install Basix (combined)
         run: |
-          python -m pip -v install --no-cache-dir .[ci] --config-settings=cmake.args=-DINSTALL_RUNTIME_DEPENDENCIES=ON --config-settings=cmake.args=-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
+          python -m pip -v install --no-build-isolation --no-cache-dir .[ci] --config-settings=cmake.args=-DINSTALL_RUNTIME_DEPENDENCIES=ON --config-settings=cmake.args=-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
+
       - name: Run units tests
         run: |
           python -m pytest -n auto --durations 20 test/
@@ -68,6 +72,10 @@ jobs:
           cmake --build build-dir --config Release
           cmake --install build-dir --config Release --prefix D:/a/basix/install
           echo "D:/a/basix/install/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+
+      - name: Install build dependencies (workaround)
+        run: |
+          python -m pip install scikit-build-core[pyproject] git+https://github.com/jhale/nanobind.git@jhale/msvc2022-workaround
       - name: Install Basix (Python)
         run: |
           cd python


### PR DESCRIPTION
This uses a fork of nanobind created from tag `v2.0.0` with a patch applied from https://github.com/wjakob/nanobind/issues/613#issuecomment-2239868209

This isn't a long term solution but it at least ensures that the work done towards to the Windows port is not slowly reversed.