### PR TITLE
Test arm64 Mac wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ test-command = [
 ]
 test-requires = ["pytest-xdist"]
 test-extras = ["test"]
-test-skip = "*-macosx_arm64 *-*linux_aarch64"
+test-skip = "*-*linux_aarch64"
 manylinux-x86_64-image = "quay.io/pypa/manylinux_2_28_x86_64:2024-09-16-ab73a4b"
 manylinux-aarch64-image = "quay.io/pypa/manylinux_2_28_aarch64:2024-09-16-ab73a4b"
 
@@ -80,7 +80,7 @@ environment = { "MACOSX_DEPLOYMENT_TARGET" = "10.14" }
 archs = [
     "x86_64",
     "arm64",
-] # Forces arm64 build on x86_64 runner using cross-compilation.
+] # Forces x86_64 build on arm64 runner using cross-compilation.
 before-build = "export HOMEBREW_AUTO_UPDATING=0 && brew update && brew install ninja"
 test-command = [
     "cmake -G Ninja -DPython3_EXECUTABLE=$(which python) -B build-dir -S {project}/test/test_cmake",


### PR DESCRIPTION
This enables testing of our arm64 macOS wheels on macOS 14 only (this was not possible before - although x86-64 macOS runners can cross-compile arm64 wheels, they could not run the tests).

macOS 13 runners are x86-64 so arm64 wheel tests are still skipped there.