### PR TITLE
Build combined Windows CI run with LLVM/clang-cl

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -43,8 +43,14 @@ jobs:
           python-version: "3.11"
 
       - name: Install Basix (combined)
-        run: |
-          python -m pip -v install --no-cache-dir .[ci] --config-settings=cmake.args=-DCMAKE_C_COMPILER=clang-cl.exe --config-settings=cmake.args=-DCMAKE_CXX_COMPILER=clang-cl.exe  --config-settings=cmake.args=-DINSTALL_RUNTIME_DEPENDENCIES=ON --config-settings=cmake.args=-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake --config-settings=cmake.args=-DVCPKG_OVERLAY_TRIPLETS=vcpkg-triplets/ --config-settings=cmake.args=-DVCPKG_HOST_TRIPLET=x64-win-llvm
+        run: >
+          python -m pip -v install --no-cache-dir .[ci]
+            --config-settings=cmake.args=-DCMAKE_C_COMPILER="C:/Program Files/LLVM/bin/clang-cl.exe"
+            --config-settings=cmake.args=-DCMAKE_CXX_COMPILER="C:/Program Files/LLVM/bin/clang-cl.exe"
+            --config-settings=cmake.args=-DINSTALL_RUNTIME_DEPENDENCIES=ON
+            --config-settings=cmake.args=-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
+            --config-settings=cmake.args=-DVCPKG_OVERLAY_TRIPLETS=vcpkg-triplets/
+            --config-settings=cmake.args=-DVCPKG_HOST_TRIPLET=x64-win-llvm
 
       - name: Run units tests
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -31,6 +31,11 @@ jobs:
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
+      - uses: actions/checkout@v4
+        with:
+          repository: Neumann-A/my-vcpkg-triplets.git
+          path: vcpkg-triplets/
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -38,7 +43,7 @@ jobs:
 
       - name: Install Basix (combined)
         run: |
-          python -m pip -v install --no-cache-dir .[ci] --config-settings=cmake.args=-DINSTALL_RUNTIME_DEPENDENCIES=ON --config-settings=cmake.args=-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
+          python -m pip -v install --no-cache-dir .[ci] --config-settings=cmake.args=-DINSTALL_RUNTIME_DEPENDENCIES=ON --config-settings=cmake.args=-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake --overlay-triplets=vcpkg-triplets/ --host-triplet=x64-win-llvm
 
       - name: Run units tests
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install Basix (combined)
         run: |
-          python -m pip -v install --no-cache-dir .[ci] --config-settings=cmake.args=-DINSTALL_RUNTIME_DEPENDENCIES=ON --config-settings=cmake.args=-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake --config-settings=cmake.args=--overlay-triplets=vcpkg-triplets/ --config-settings=cmake.args=--host-triplet=x64-win-llvm
+          python -m pip -v install --no-cache-dir .[ci] --config-settings=cmake.args=-DINSTALL_RUNTIME_DEPENDENCIES=ON --config-settings=cmake.args=-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake --config-settings=cmake.args=-DVCPKG_OVERLAY_TRIPLETS=vcpkg-triplets/ --config-settings=cmake.args=-DVCPKG_HOST_TRIPLET=x64-win-llvm
 
       - name: Run units tests
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,7 +9,6 @@ on:
        - "v*"
      branches:
        - main
-       - "**" # To remove 
    merge_group:
      branches:
        - main
@@ -17,7 +16,7 @@ on:
 
 jobs:
   build-combined:
-    name: Combined build and test
+    name: Combined build and test (clang-cl.exe/LLVM)
     runs-on: windows-2022
     env:
       VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
@@ -32,7 +31,8 @@ jobs:
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
-      - uses: actions/checkout@v4
+      - name: Checkout custom vcpkg triplets
+        uses: actions/checkout@v4
         with:
           repository: Neumann-A/my-vcpkg-triplets
           path: vcpkg-triplets/
@@ -54,7 +54,7 @@ jobs:
         run: python -m pytest demo/python/test.py
 
   build-split:
-    name: Split build and test
+    name: Split build and test (cl.exe)
     runs-on: windows-2022
     env:
       VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -51,6 +51,7 @@ jobs:
           --config-settings=cmake.args=-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
           --config-settings=cmake.args=-DVCPKG_OVERLAY_TRIPLETS=vcpkg-triplets/
           --config-settings=cmake.args=-DVCPKG_HOST_TRIPLET=x64-win-llvm
+          --config-settings=cmake.args=-DVCPKG_TARGET_TRIPLET=x64-win-llvm
 
       - name: Run units tests
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install Basix (combined)
         run: |
-          python -m pip -v install --no-cache-dir .[ci] --config-settings=cmake.args=-DINSTALL_RUNTIME_DEPENDENCIES=ON --config-settings=cmake.args=-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake --overlay-triplets=vcpkg-triplets/ --host-triplet=x64-win-llvm
+          python -m pip -v install --no-cache-dir .[ci] --config-settings=cmake.args=-DINSTALL_RUNTIME_DEPENDENCIES=ON --config-settings=cmake.args=-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake --config-settings=cmake.args=--overlay-triplets=vcpkg-triplets/ --config-settings=cmake.args=--host-triplet=x64-win-llvm
 
       - name: Run units tests
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install Basix (combined)
         run: |
-          python -m pip -v install --no-cache-dir .[ci] --config-settings=cmake.args=-DINSTALL_RUNTIME_DEPENDENCIES=ON --config-settings=cmake.args=-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake --config-settings=cmake.args=-DVCPKG_OVERLAY_TRIPLETS=vcpkg-triplets/ --config-settings=cmake.args=-DVCPKG_HOST_TRIPLET=x64-win-llvm
+          python -m pip -v install --no-cache-dir .[ci] --config-settings=cmake.args=-DCMAKE_C_COMPILER=clang-cl.exe --config-settings=cmake.args=-DCMAKE_CXX_COMPILER=clang-cl.exe  --config-settings=cmake.args=-DINSTALL_RUNTIME_DEPENDENCIES=ON --config-settings=cmake.args=-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake --config-settings=cmake.args=-DVCPKG_OVERLAY_TRIPLETS=vcpkg-triplets/ --config-settings=cmake.args=-DVCPKG_HOST_TRIPLET=x64-win-llvm
 
       - name: Run units tests
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,6 +9,7 @@ on:
        - "v*"
      branches:
        - main
+       - "**" # To remove 
    merge_group:
      branches:
        - main

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -45,12 +45,12 @@ jobs:
       - name: Install Basix (combined)
         run: >
           python -m pip -v install --no-cache-dir .[ci]
-            --config-settings=cmake.args=-DCMAKE_C_COMPILER="C:/Program Files/LLVM/bin/clang-cl.exe"
-            --config-settings=cmake.args=-DCMAKE_CXX_COMPILER="C:/Program Files/LLVM/bin/clang-cl.exe"
-            --config-settings=cmake.args=-DINSTALL_RUNTIME_DEPENDENCIES=ON
-            --config-settings=cmake.args=-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
-            --config-settings=cmake.args=-DVCPKG_OVERLAY_TRIPLETS=vcpkg-triplets/
-            --config-settings=cmake.args=-DVCPKG_HOST_TRIPLET=x64-win-llvm
+          --config-settings=cmake.args=-DCMAKE_C_COMPILER="C:/Program Files/LLVM/bin/clang-cl.exe"
+          --config-settings=cmake.args=-DCMAKE_CXX_COMPILER="C:/Program Files/LLVM/bin/clang-cl.exe"
+          --config-settings=cmake.args=-DINSTALL_RUNTIME_DEPENDENCIES=ON
+          --config-settings=cmake.args=-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
+          --config-settings=cmake.args=-DVCPKG_OVERLAY_TRIPLETS=vcpkg-triplets/
+          --config-settings=cmake.args=-DVCPKG_HOST_TRIPLET=x64-win-llvm
 
       - name: Run units tests
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          repository: Neumann-A/my-vcpkg-triplets.git
+          repository: Neumann-A/my-vcpkg-triplets
           path: vcpkg-triplets/
 
       - name: Set up Python


### PR DESCRIPTION
This increases Windows CI coverage of Basix by building the combined build with `clang-cl.exe`, a light wrapper around LLVM. This is trivial to implement via vcpkg's host functionality. 

The split build which is relevant to Conda remains on `cl.exe` the Microsoft C/C++ compiler.
