### PR TITLE
Fix tolerances for determining DOF transformation type and add test

### DIFF
--- a/cpp/basix/dof-transformations.cpp
+++ b/cpp/basix/dof-transformations.cpp
@@ -423,21 +423,9 @@ std::pair<std::vector<T>, std::array<std::size_t, 2>> compute_transformation(
 
   std::vector<T> tabulated_data_b(npts * total_ndofs * vs);
   mdspan_t<T, 3> tabulated_data(tabulated_data_b.data(), npts, total_ndofs, vs);
-  // mdarray_t<T, 3> tabulated_data(npts, total_ndofs, vs);
-
-  // std::vector<T> result_b(polyset_vals.extent(1) * coeffs.extent(0));
-  // mdspan_t<T, 2> result(result_b.data(), polyset_vals.extent(1),
-  //                       coeffs.extent(0));
-
-  std::vector<T> resultT_b(polyset_vals.extent(1) * coeffs.extent(0));
-  mdspan_t<T, 2> resultT(resultT_b.data(), coeffs.extent(0),
-                         polyset_vals.extent(1));
-  // mdarray_t<T, 2> result(polyset_vals.extent(1), coeffs.extent(0));
-
-  // std::cout << "3: transform: " << vs << ", " << coeffs.extent(0) << ", "
-  //           << polyset_vals.extent(1) << ", " << polyset_vals.extent(0)
-  //           << std::endl;
-
+  std::vector<T> result_b(polyset_vals.extent(1) * coeffs.extent(0));
+  mdspan_t<T, 2> result(result_b.data(), coeffs.extent(0),
+                        polyset_vals.extent(1));
   std::vector<T> coeffs_b(coeffs.extent(0) * polyset_vals.extent(0));
   mdspan_t<T, 2> _coeffs(coeffs_b.data(), coeffs.extent(0),
                          polyset_vals.extent(0));
@@ -460,13 +448,13 @@ std::pair<std::vector<T>, std::array<std::size_t, 2>> compute_transformation(
     // c: coeffs.extent(1) x polyset_vals.extent(0)   [k0, k2]
     // p: polyset_vals.extent(0) x polyset_vals.extent(1)  [k2, k1]
 
-    math::dot(_coeffs, polyset_vals, resultT);
+    math::dot(_coeffs, polyset_vals, result);
 
     // std::cout << "4: transform" << std::endl;
 
-    for (std::size_t k0 = 0; k0 < resultT.extent(1); ++k0)
-      for (std::size_t k1 = 0; k1 < resultT.extent(0); ++k1)
-        tabulated_data(k0, k1, j) = resultT(k1, k0);
+    for (std::size_t k0 = 0; k0 < result.extent(1); ++k0)
+      for (std::size_t k1 = 0; k1 < result.extent(0); ++k1)
+        tabulated_data(k0, k1, j) = result(k1, k0);
 
     // for (std::size_t k0 = 0; k0 < result.extent(0); ++k0)
     //   for (std::size_t k1 = 0; k1 < result.extent(1); ++k1)
@@ -502,10 +490,16 @@ std::pair<std::vector<T>, std::array<std::size_t, 2>> compute_transformation(
     for (std::size_t i = 0; i < vs; ++i)
     {
       for (std::size_t k0 = 0; k0 < transform.extent(1); ++k0)
+      {
         for (std::size_t k1 = 0; k1 < transform.extent(0); ++k1)
+        {
           for (std::size_t k2 = 0; k2 < imat.extent(2); ++k2)
+          {
             transform(k1, k0)
                 += imat(k0, i, k2, d) * pushed_data(k2, k1 + dofstart, i);
+          }
+        }
+      }
     }
   }
 

--- a/cpp/basix/dof-transformations.cpp
+++ b/cpp/basix/dof-transformations.cpp
@@ -13,6 +13,8 @@
 #include <span>
 #include <tuple>
 
+#include <iostream>
+
 using namespace basix;
 
 namespace stdex
@@ -39,8 +41,7 @@ int find_first_subentity(cell::type cell_type, cell::type entity_type)
 {
   const int edim = cell::topological_dimension(entity_type);
   std::vector<cell::type> entities = cell::subentity_types(cell_type)[edim];
-  if (auto it = std::ranges::find(entities, entity_type);
-      it != entities.end())
+  if (auto it = std::ranges::find(entities, entity_type); it != entities.end())
   {
     return std::distance(entities.begin(), it);
   }
@@ -93,9 +94,7 @@ mapinfo_t<T> get_mapinfo(cell::type cell_type)
   {
     mapinfo_t<T> mapinfo;
     auto& data = mapinfo.try_emplace(cell::type::interval).first->second;
-    auto map = [](auto pt) -> std::array<T, 3> {
-      return {pt[1], pt[0], 0.0};
-    };
+    auto map = [](auto pt) -> std::array<T, 3> { return {pt[1], pt[0], 0.0}; };
     stdex::mdarray<T, stdex::extents<std::size_t, 2, 2>> J(
         stdex::extents<std::size_t, 2, 2>{}, {0., 1., 1., 0.});
 
@@ -109,9 +108,8 @@ mapinfo_t<T> get_mapinfo(cell::type cell_type)
   {
     mapinfo_t<T> mapinfo;
     auto& data = mapinfo.try_emplace(cell::type::interval).first->second;
-    auto map = [](auto pt) -> std::array<T, 3> {
-      return {1 - pt[0], pt[1], 0};
-    };
+    auto map
+        = [](auto pt) -> std::array<T, 3> { return {1 - pt[0], pt[1], 0}; };
     stdex::mdarray<T, stdex::extents<std::size_t, 2, 2>> J(
         stdex::extents<std::size_t, 2, 2>{}, {-1., 0., 0., 1.});
 
@@ -126,9 +124,8 @@ mapinfo_t<T> get_mapinfo(cell::type cell_type)
     mapinfo_t<T> mapinfo;
     {
       auto& data = mapinfo.try_emplace(cell::type::interval).first->second;
-      auto map = [](auto pt) -> std::array<T, 3> {
-        return {pt[0], pt[2], pt[1]};
-      };
+      auto map
+          = [](auto pt) -> std::array<T, 3> { return {pt[0], pt[2], pt[1]}; };
       stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> J(
           stdex::extents<std::size_t, 3, 3>{},
           {1., 0., 0., 0., 0., 1., 0., 1., 0.});
@@ -143,9 +140,8 @@ mapinfo_t<T> get_mapinfo(cell::type cell_type)
     {
       auto& data = mapinfo.try_emplace(cell::type::triangle).first->second;
       {
-        auto map = [](auto pt) -> std::array<T, 3> {
-          return {pt[2], pt[0], pt[1]};
-        };
+        auto map
+            = [](auto pt) -> std::array<T, 3> { return {pt[2], pt[0], pt[1]}; };
         stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> J(
             stdex::extents<std::size_t, 3, 3>{},
             {0., 1., 0., 0., 0., 1., 1., 0., 0.});
@@ -157,9 +153,8 @@ mapinfo_t<T> get_mapinfo(cell::type cell_type)
         data.push_back(std::tuple(map, J, detJ, K));
       }
       {
-        auto map = [](auto pt) -> std::array<T, 3> {
-          return {pt[0], pt[2], pt[1]};
-        };
+        auto map
+            = [](auto pt) -> std::array<T, 3> { return {pt[0], pt[2], pt[1]}; };
         stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> J(
             stdex::extents<std::size_t, 3, 3>{},
             {1., 0., 0., 0., 0., 1., 0., 1., 0.});
@@ -179,9 +174,8 @@ mapinfo_t<T> get_mapinfo(cell::type cell_type)
     mapinfo_t<T> mapinfo;
     {
       auto& data = mapinfo.try_emplace(cell::type::interval).first->second;
-      auto map = [](auto pt) -> std::array<T, 3> {
-        return {1 - pt[0], pt[1], pt[2]};
-      };
+      auto map = [](auto pt) -> std::array<T, 3>
+      { return {1 - pt[0], pt[1], pt[2]}; };
       stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> J(
           stdex::extents<std::size_t, 3, 3>{},
           {-1., 0., 0., 0., 1., 0., 0., 0., 1.});
@@ -196,9 +190,8 @@ mapinfo_t<T> get_mapinfo(cell::type cell_type)
     {
       auto& data = mapinfo.try_emplace(cell::type::quadrilateral).first->second;
       {
-        auto map = [](auto pt) -> std::array<T, 3> {
-          return {1 - pt[1], pt[0], pt[2]};
-        };
+        auto map = [](auto pt) -> std::array<T, 3>
+        { return {1 - pt[1], pt[0], pt[2]}; };
         stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> J(
             stdex::extents<std::size_t, 3, 3>{},
             {0., 1., 0., -1., 0., 0., 0., 0., 1.});
@@ -210,9 +203,8 @@ mapinfo_t<T> get_mapinfo(cell::type cell_type)
         data.push_back(std::tuple(map, J, detJ, K));
       }
       {
-        auto map = [](auto pt) -> std::array<T, 3> {
-          return {pt[1], pt[0], pt[2]};
-        };
+        auto map
+            = [](auto pt) -> std::array<T, 3> { return {pt[1], pt[0], pt[2]}; };
         stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> J(
             stdex::extents<std::size_t, 3, 3>{},
             {0., 1., 0., 1., 0., 0., 0., 0., 1.});
@@ -231,9 +223,8 @@ mapinfo_t<T> get_mapinfo(cell::type cell_type)
     mapinfo_t<T> mapinfo;
     {
       auto& data = mapinfo.try_emplace(cell::type::interval).first->second;
-      auto map = [](auto pt) -> std::array<T, 3> {
-        return {1 - pt[0], pt[1], pt[2]};
-      };
+      auto map = [](auto pt) -> std::array<T, 3>
+      { return {1 - pt[0], pt[1], pt[2]}; };
       stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> J(
           stdex::extents<std::size_t, 3, 3>{},
           {-1., 0., 0., 0., 1., 0., 0., 0., 1.});
@@ -246,9 +237,8 @@ mapinfo_t<T> get_mapinfo(cell::type cell_type)
     {
       auto& data = mapinfo.try_emplace(cell::type::triangle).first->second;
       {
-        auto map = [](auto pt) -> std::array<T, 3> {
-          return {1 - pt[1] - pt[0], pt[0], pt[2]};
-        };
+        auto map = [](auto pt) -> std::array<T, 3>
+        { return {1 - pt[1] - pt[0], pt[0], pt[2]}; };
         stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> J(
             stdex::extents<std::size_t, 3, 3>{},
             {0., 1., 0., -1., -1., 0., 0., 0., 1.});
@@ -259,9 +249,8 @@ mapinfo_t<T> get_mapinfo(cell::type cell_type)
         data.push_back(std::tuple(map, J, detJ, K));
       }
       {
-        auto map = [](auto pt) -> std::array<T, 3> {
-          return {pt[1], pt[0], pt[2]};
-        };
+        auto map
+            = [](auto pt) -> std::array<T, 3> { return {pt[1], pt[0], pt[2]}; };
         stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> J(
             stdex::extents<std::size_t, 3, 3>{},
             {0., 1., 0., 1., 0., 0., 0., 0., 1.});
@@ -275,9 +264,8 @@ mapinfo_t<T> get_mapinfo(cell::type cell_type)
     {
       auto& data = mapinfo.try_emplace(cell::type::quadrilateral).first->second;
       {
-        auto map = [](auto pt) -> std::array<T, 3> {
-          return {1 - pt[2], pt[1], pt[0]};
-        };
+        auto map = [](auto pt) -> std::array<T, 3>
+        { return {1 - pt[2], pt[1], pt[0]}; };
         stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> J(
             stdex::extents<std::size_t, 3, 3>{},
             {0., 0., 1., 0., 1., 0., -1., 0., 0.});
@@ -288,9 +276,8 @@ mapinfo_t<T> get_mapinfo(cell::type cell_type)
         data.push_back(std::tuple(map, J, detJ, K));
       }
       { // scope
-        auto map = [](auto pt) -> std::array<T, 3> {
-          return {pt[2], pt[1], pt[0]};
-        };
+        auto map
+            = [](auto pt) -> std::array<T, 3> { return {pt[2], pt[1], pt[0]}; };
         stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> J(
             stdex::extents<std::size_t, 3, 3>{},
             {0., 0., 1., 0., 1., 0., 1., 0., 0.});
@@ -309,9 +296,8 @@ mapinfo_t<T> get_mapinfo(cell::type cell_type)
     mapinfo_t<T> mapinfo;
     {
       auto& data = mapinfo.try_emplace(cell::type::interval).first->second;
-      auto map = [](auto pt) -> std::array<T, 3> {
-        return {1 - pt[0], pt[1], pt[2]};
-      };
+      auto map = [](auto pt) -> std::array<T, 3>
+      { return {1 - pt[0], pt[1], pt[2]}; };
       stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> J(
           stdex::extents<std::size_t, 3, 3>{},
           {-1., 0., 0., 0., 1., 0., 0., 0., 1.});
@@ -325,9 +311,8 @@ mapinfo_t<T> get_mapinfo(cell::type cell_type)
     {
       auto& data = mapinfo.try_emplace(cell::type::quadrilateral).first->second;
       {
-        auto map = [](auto pt) -> std::array<T, 3> {
-          return {1 - pt[1], pt[0], pt[2]};
-        };
+        auto map = [](auto pt) -> std::array<T, 3>
+        { return {1 - pt[1], pt[0], pt[2]}; };
         stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> J(
             stdex::extents<std::size_t, 3, 3>{},
             {0., 1., 0., -1., 0., 0., 0., 0., 1.});
@@ -338,9 +323,8 @@ mapinfo_t<T> get_mapinfo(cell::type cell_type)
         data.push_back(std::tuple(map, J, detJ, K));
       }
       {
-        auto map = [](auto pt) -> std::array<T, 3> {
-          return {pt[1], pt[0], pt[2]};
-        };
+        auto map
+            = [](auto pt) -> std::array<T, 3> { return {pt[1], pt[0], pt[2]}; };
         stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> J(
             stdex::extents<std::size_t, 3, 3>{},
             {0., 1., 0., 1., 0., 0., 0., 0., 1.});
@@ -355,9 +339,8 @@ mapinfo_t<T> get_mapinfo(cell::type cell_type)
     {
       auto& data = mapinfo.try_emplace(cell::type::triangle).first->second;
       {
-        auto map = [](auto pt) -> std::array<T, 3> {
-          return {1 - pt[2] - pt[0], pt[1], pt[0]};
-        };
+        auto map = [](auto pt) -> std::array<T, 3>
+        { return {1 - pt[2] - pt[0], pt[1], pt[0]}; };
         stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> J(
             stdex::extents<std::size_t, 3, 3>{},
             {0., 0., 1., 0., 1., 0., -1., 0., -1.});
@@ -368,9 +351,8 @@ mapinfo_t<T> get_mapinfo(cell::type cell_type)
         data.push_back(std::tuple(map, J, detJ, K));
       }
       {
-        auto map = [](auto pt) -> std::array<T, 3> {
-          return {pt[2], pt[1], pt[0]};
-        };
+        auto map
+            = [](auto pt) -> std::array<T, 3> { return {pt[2], pt[1], pt[0]}; };
         stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> J(
             stdex::extents<std::size_t, 3, 3>{},
             {0., 0., 1., 0., 1., 0., 1., 0., 0.});
@@ -426,7 +408,7 @@ std::pair<std::vector<T>, std::array<std::size_t, 2>> compute_transformation(
   mdarray_t<T, 2> mapped_pts(pts.extents());
   for (std::size_t p = 0; p < mapped_pts.extent(0); ++p)
   {
-    auto mp = map_point(
+    std::array<T, 3> mp = map_point(
         std::span(pts.data_handle() + p * pts.extent(1), pts.extent(1)));
     for (std::size_t k = 0; k < mapped_pts.extent(1); ++k)
       mapped_pts(p, k) = mp[k];
@@ -439,18 +421,56 @@ std::pair<std::vector<T>, std::array<std::size_t, 2>> compute_transformation(
   mdspan_t<const T, 2> polyset_vals(polyset_vals_b.data(), polyset_shape[1],
                                     polyset_shape[2]);
 
-  mdarray_t<T, 3> tabulated_data(npts, total_ndofs, vs);
+  std::vector<T> tabulated_data_b(npts * total_ndofs * vs);
+  mdspan_t<T, 3> tabulated_data(tabulated_data_b.data(), npts, total_ndofs, vs);
+  // mdarray_t<T, 3> tabulated_data(npts, total_ndofs, vs);
+
+  // std::vector<T> result_b(polyset_vals.extent(1) * coeffs.extent(0));
+  // mdspan_t<T, 2> result(result_b.data(), polyset_vals.extent(1),
+  //                       coeffs.extent(0));
+
+  std::vector<T> resultT_b(polyset_vals.extent(1) * coeffs.extent(0));
+  mdspan_t<T, 2> resultT(resultT_b.data(), coeffs.extent(0),
+                         polyset_vals.extent(1));
+  // mdarray_t<T, 2> result(polyset_vals.extent(1), coeffs.extent(0));
+
+  // std::cout << "3: transform: " << vs << ", " << coeffs.extent(0) << ", "
+  //           << polyset_vals.extent(1) << ", " << polyset_vals.extent(0)
+  //           << std::endl;
+
+  std::vector<T> coeffs_b(coeffs.extent(0) * polyset_vals.extent(0));
+  mdspan_t<T, 2> _coeffs(coeffs_b.data(), coeffs.extent(0),
+                         polyset_vals.extent(0));
   for (std::size_t j = 0; j < vs; ++j)
   {
-    mdarray_t<T, 2> result(polyset_vals.extent(1), coeffs.extent(0));
-    for (std::size_t k0 = 0; k0 < coeffs.extent(0); ++k0)
-      for (std::size_t k1 = 0; k1 < polyset_vals.extent(1); ++k1)
-        for (std::size_t k2 = 0; k2 < polyset_vals.extent(0); ++k2)
-          result(k1, k0) += coeffs(k0, k2 + psize * j) * polyset_vals(k2, k1);
+    // std::fill(result_b.begin(), result_b.end(), 0);
 
-    for (std::size_t k0 = 0; k0 < result.extent(0); ++k0)
-      for (std::size_t k1 = 0; k1 < result.extent(1); ++k1)
-        tabulated_data(k0, k1, j) = result(k0, k1);
+    for (std::size_t k0 = 0; k0 < coeffs.extent(0); ++k0)
+      for (std::size_t k2 = 0; k2 < polyset_vals.extent(0); ++k2)
+        _coeffs(k0, k2) = coeffs(k0, k2 + psize * j);
+
+    // R^T = coeffs * polyset_vals
+    // for (std::size_t k0 = 0; k0 < coeffs.extent(0); ++k0) // big
+    //   for (std::size_t k1 = 0; k1 < polyset_vals.extent(1); ++k1)
+    //     for (std::size_t k2 = 0; k2 < polyset_vals.extent(0); ++k2) // big
+    //       result(k1, k0) += _coeffs(k0, k2) * polyset_vals(k2, k1);
+    // result(k1, k0) += coeffs(k0, k2 + psize * j) * polyset_vals(k2, k1);
+
+    // r^t: coeffs.extent(0) x polyset_vals.extent(1) [k0, k1]
+    // c: coeffs.extent(1) x polyset_vals.extent(0)   [k0, k2]
+    // p: polyset_vals.extent(0) x polyset_vals.extent(1)  [k2, k1]
+
+    math::dot(_coeffs, polyset_vals, resultT);
+
+    // std::cout << "4: transform" << std::endl;
+
+    for (std::size_t k0 = 0; k0 < resultT.extent(1); ++k0)
+      for (std::size_t k1 = 0; k1 < resultT.extent(0); ++k1)
+        tabulated_data(k0, k1, j) = resultT(k1, k0);
+
+    // for (std::size_t k0 = 0; k0 < result.extent(0); ++k0)
+    //   for (std::size_t k1 = 0; k1 < result.extent(1); ++k1)
+    //     tabulated_data(k0, k1, j) = result(k0, k1);
   }
 
   // push forward
@@ -460,7 +480,7 @@ std::pair<std::vector<T>, std::array<std::size_t, 2>> compute_transformation(
     for (std::size_t i = 0; i < npts; ++i)
     {
       mdspan_t<const T, 2> tab(
-          tabulated_data.data()
+          tabulated_data_b.data()
               + i * tabulated_data.extent(1) * tabulated_data.extent(2),
           tabulated_data.extent(1), tabulated_data.extent(2));
 

--- a/cpp/basix/dof-transformations.h
+++ b/cpp/basix/dof-transformations.h
@@ -40,14 +40,16 @@ template <std::floating_point T>
 std::map<cell::type, std::pair<std::vector<T>, std::array<std::size_t, 3>>>
 compute_entity_transformations(
     cell::type cell_type,
-    const std::array<
+    std::array<
         std::vector<MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
             const T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>>,
-        4>& x,
-    const std::array<
+        4>
+        x,
+    std::array<
         std::vector<MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
             const T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 4>>>,
-        4>& M,
+        4>
+        M,
     MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
         const T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
         coeffs,

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -23,6 +23,7 @@
 #include <concepts>
 #include <limits>
 #include <numeric>
+
 #define str_macro(X) #X
 #define str(X) str_macro(X)
 

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -1436,7 +1436,7 @@ FiniteElement<F>::FiniteElement(
     for (std::size_t col = 0; col < matM.extent(1); ++col)
     {
       F v = col == row ? 1.0 : 0.0;
-      constexpr F eps = 100 * std::numeric_limits<F>::epsilon();
+      const F eps = 10 * degree * degree * std::numeric_limits<F>::epsilon();
       if (std::abs(matM(row, col) - v) > eps)
       {
         _interpolation_is_identity = false;

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -965,7 +965,7 @@ FiniteElement<F>::FiniteElement(
           rtot += r;
         }
 
-        constexpr F eps = 10.0 * std::numeric_limits<float>::epsilon();
+        const F eps = 10 * degree * degree * std::numeric_limits<F>::epsilon();
         if ((trans.extent(2) != 1 and std::abs(rmin) > eps)
             or std::abs(rmax - 1.0) > eps or std::abs(rtot - 1.0) > eps)
         {

--- a/cpp/basix/finite-element.h
+++ b/cpp/basix/finite-element.h
@@ -26,7 +26,6 @@
 /// Basix: FEniCS runtime basis evaluation library
 namespace basix
 {
-
 namespace impl
 {
 template <typename T, std::size_t d>

--- a/cpp/basix/math.h
+++ b/cpp/basix/math.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <array>
 #include <cmath>
 #include <concepts>
@@ -330,13 +331,22 @@ void dot(const U& A, const V& B, W&& C)
   }
   else
   {
-    static_assert(std::is_same_v<typename U::layout_type, std::layout_right>);
-    static_assert(std::is_same_v<typename V::layout_type, std::layout_right>);
-    // static_assert(
+    static_assert(std::is_same_v<typename std::decay_t<U>::layout_type,
+                                 std::layout_right>);
+    static_assert(std::is_same_v<typename std::decay_t<V>::layout_type,
+                                 std::layout_right>);
+    static_assert(std::is_same_v<typename std::decay_t<W>::layout_type,
+                                 std::layout_right>);
+
+    // static_assert(std::is_same_v<typename U::layout_type,
+    // std::layout_right>); static_assert(std::is_same_v<typename
+    // V::layout_type, std::layout_right>); static_assert(
     //     std::is_same_v<typename std::remove_cv<typename W::layout_type>,
     //                    std::layout_right>);
 
     using T = typename std::decay_t<U>::value_type;
+    // static_assert(std::is_same_v<typename std::decay_t<V>::value_type, T>);
+    // static_assert(std::is_same_v<typename std::decay_t<W>::value_type, T>);
     impl::dot_blas<T>(
         std::span(A.data_handle(), A.size()), {A.extent(0), A.extent(1)},
         std::span(B.data_handle(), B.size()), {B.extent(0), B.extent(1)},

--- a/cpp/basix/math.h
+++ b/cpp/basix/math.h
@@ -345,8 +345,8 @@ void dot(const U& A, const V& B, W&& C)
     //                    std::layout_right>);
 
     using T = typename std::decay_t<U>::value_type;
-    // static_assert(std::is_same_v<typename std::decay_t<V>::value_type, T>);
-    // static_assert(std::is_same_v<typename std::decay_t<W>::value_type, T>);
+    static_assert(std::is_same_v<typename std::decay_t<V>::value_type, T>);
+    static_assert(std::is_same_v<typename std::decay_t<W>::value_type, T>);
     impl::dot_blas<T>(
         std::span(A.data_handle(), A.size()), {A.extent(0), A.extent(1)},
         std::span(B.data_handle(), B.size()), {B.extent(0), B.extent(1)},

--- a/cpp/basix/math.h
+++ b/cpp/basix/math.h
@@ -331,12 +331,14 @@ void dot(const U& A, const V& B, W&& C)
   }
   else
   {
+    // #if defined(_MSC_VER) && !defined(__clang__)
     static_assert(std::is_same_v<typename std::decay_t<U>::layout_type,
-                                 std::layout_right>);
+                                 MDSPAN_IMPL_STANDARD_NAMESPACE::layout_left>);
     static_assert(std::is_same_v<typename std::decay_t<V>::layout_type,
-                                 std::layout_right>);
+                                 MDSPAN_IMPL_STANDARD_NAMESPACE::layout_left>);
     static_assert(std::is_same_v<typename std::decay_t<W>::layout_type,
-                                 std::layout_right>);
+                                 MDSPAN_IMPL_STANDARD_NAMESPACE::layout_left>);
+    // #endif
 
     // static_assert(std::is_same_v<typename U::layout_type,
     // std::layout_right>); static_assert(std::is_same_v<typename

--- a/cpp/basix/math.h
+++ b/cpp/basix/math.h
@@ -331,21 +331,14 @@ void dot(const U& A, const V& B, W&& C)
   }
   else
   {
-    // #if defined(_MSC_VER) && !defined(__clang__)
+#if defined(_MSC_VER) && !defined(__clang__)
     static_assert(std::is_same_v<typename std::decay_t<U>::layout_type,
                                  MDSPAN_IMPL_STANDARD_NAMESPACE::layout_right>);
     static_assert(std::is_same_v<typename std::decay_t<V>::layout_type,
                                  MDSPAN_IMPL_STANDARD_NAMESPACE::layout_right>);
     static_assert(std::is_same_v<typename std::decay_t<W>::layout_type,
                                  MDSPAN_IMPL_STANDARD_NAMESPACE::layout_right>);
-    // #endif
-
-    // static_assert(std::is_same_v<typename U::layout_type,
-    // std::layout_right>); static_assert(std::is_same_v<typename
-    // V::layout_type, std::layout_right>); static_assert(
-    //     std::is_same_v<typename std::remove_cv<typename W::layout_type>,
-    //                    std::layout_right>);
-
+#endif
     using T = typename std::decay_t<U>::value_type;
     static_assert(std::is_same_v<typename std::decay_t<V>::value_type, T>);
     static_assert(std::is_same_v<typename std::decay_t<W>::value_type, T>);

--- a/cpp/basix/math.h
+++ b/cpp/basix/math.h
@@ -331,7 +331,7 @@ void dot(const U& A, const V& B, W&& C)
   }
   else
   {
-#if defined(_MSC_VER) && !defined(__clang__)
+#ifndef _MSVC_LANG
     static_assert(std::is_same_v<typename std::decay_t<U>::layout_type,
                                  MDSPAN_IMPL_STANDARD_NAMESPACE::layout_right>);
     static_assert(std::is_same_v<typename std::decay_t<V>::layout_type,

--- a/cpp/basix/math.h
+++ b/cpp/basix/math.h
@@ -333,11 +333,11 @@ void dot(const U& A, const V& B, W&& C)
   {
     // #if defined(_MSC_VER) && !defined(__clang__)
     static_assert(std::is_same_v<typename std::decay_t<U>::layout_type,
-                                 MDSPAN_IMPL_STANDARD_NAMESPACE::layout_left>);
+                                 MDSPAN_IMPL_STANDARD_NAMESPACE::layout_right>);
     static_assert(std::is_same_v<typename std::decay_t<V>::layout_type,
-                                 MDSPAN_IMPL_STANDARD_NAMESPACE::layout_left>);
+                                 MDSPAN_IMPL_STANDARD_NAMESPACE::layout_right>);
     static_assert(std::is_same_v<typename std::decay_t<W>::layout_type,
-                                 MDSPAN_IMPL_STANDARD_NAMESPACE::layout_left>);
+                                 MDSPAN_IMPL_STANDARD_NAMESPACE::layout_right>);
     // #endif
 
     // static_assert(std::is_same_v<typename U::layout_type,

--- a/cpp/basix/math.h
+++ b/cpp/basix/math.h
@@ -50,7 +50,7 @@ namespace basix::math
 {
 namespace impl
 {
-/// @brief Compute C = alpha A * B  + \beta C using BLAS (GEMM).
+/// @brief Compute C = alpha A * B  + beta C using BLAS (GEMM).
 /// @param[in] A Input matrix.
 /// @param[in] B Input matrix.
 /// @param[in] alpha
@@ -310,7 +310,7 @@ transpose_lu(std::pair<std::vector<T>, std::array<std::size_t, 2>>& A)
   return perm;
 }
 
-/// @brief Compute C = \alpha A * B + \beta C
+/// @brief Compute C = alpha A * B + beta C
 /// @param[in] A Input matrix
 /// @param[in] B Input matrix
 /// @param[out] C Output matrix. Must be sized correctly before calling

--- a/cpp/basix/math.h
+++ b/cpp/basix/math.h
@@ -330,6 +330,12 @@ void dot(const U& A, const V& B, W&& C)
   }
   else
   {
+    static_assert(std::is_same_v<typename U::layout_type, std::layout_right>);
+    static_assert(std::is_same_v<typename V::layout_type, std::layout_right>);
+    // static_assert(
+    //     std::is_same_v<typename std::remove_cv<typename W::layout_type>,
+    //                    std::layout_right>);
+
     using T = typename std::decay_t<U>::value_type;
     impl::dot_blas<T>(
         std::span(A.data_handle(), A.size()), {A.extent(0), A.extent(1)},

--- a/cpp/basix/math.h
+++ b/cpp/basix/math.h
@@ -180,7 +180,7 @@ std::pair<std::vector<T>, std::vector<T>> eigh(std::span<const T> A,
 
 /// @brief Solve A X = B.
 /// @param[in] A The matrix.
-/// @param[in] B Right-hand side matrix/vector.@brief
+/// @param[in] B Right-hand side matrix/vector.
 /// @return A^{-1} B.
 template <std::floating_point T>
 std::vector<T>

--- a/test/test_lagrange.py
+++ b/test/test_lagrange.py
@@ -949,6 +949,19 @@ def test_dof_transformations_tetrahedron(degree):
         assert np.allclose(t, actual)
 
 
+@pytest.mark.parametrize(
+    "celltype",
+    [basix.CellType.interval, basix.CellType.triangle, basix.CellType.tetrahedron],
+)
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_lagrange_transform(celltype, dtype):
+    for p in range(1, 15):
+        e = basix.create_element(
+            basix.ElementFamily.P, celltype, p, basix.LagrangeVariant.gll_warped, dtype=dtype
+        )
+        assert e.dof_transformations_are_permutations
+
+
 @pytest.mark.parametrize("degree", [1, 2, 3, 4])
 @pytest.mark.parametrize(
     "celltype",

--- a/test/test_lagrange.py
+++ b/test/test_lagrange.py
@@ -856,7 +856,7 @@ def test_tet(degree):
         (basix.CellType.tetrahedron, basix.CellType.tetrahedron),
     ],
 )
-@pytest.mark.parametrize("degree", [1, 2, 3, 4])
+@pytest.mark.parametrize("degree", [1, 2, 3, 4, 12])
 def test_lagrange(celltype, degree):
     lagrange = basix.create_element(
         basix.ElementFamily.P, celltype[1], degree, basix.LagrangeVariant.equispaced
@@ -866,7 +866,7 @@ def test_lagrange(celltype, degree):
     assert np.isclose(np.sum(w, axis=1), 1.0).all()
 
 
-@pytest.mark.parametrize("degree", [1, 2, 3, 4])
+@pytest.mark.parametrize("degree", [1, 2, 3, 4, 12])
 def test_dof_transformations_interval(degree):
     lagrange = basix.create_element(
         basix.ElementFamily.P, basix.CellType.interval, degree, basix.LagrangeVariant.equispaced

--- a/test/test_lagrange.py
+++ b/test/test_lagrange.py
@@ -951,11 +951,23 @@ def test_dof_transformations_tetrahedron(degree):
 
 @pytest.mark.parametrize(
     "celltype",
-    [basix.CellType.interval, basix.CellType.triangle, basix.CellType.tetrahedron],
+    [
+        basix.CellType.interval,
+        basix.CellType.triangle,
+        basix.CellType.tetrahedron,
+        basix.CellType.quadrilateral,
+        basix.CellType.hexahedron,
+    ],
 )
-@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        np.float32,
+        np.float64,
+    ],
+)
 def test_lagrange_transform(celltype, dtype):
-    for p in range(1, 15):
+    for p in range(1, 12):
         e = basix.create_element(
             basix.ElementFamily.P, celltype, p, basix.LagrangeVariant.gll_warped, dtype=dtype
         )


### PR DESCRIPTION
The check for determining the DOF transformation type was failing for float32 at higher-orders for Lagrange elements. This PR relaxes a tolerance. It is somewhat arbitrary, but does seem to work.

Also makes more use of the BLAS GEMM wrappers to dramatically improve performance at high orders.

Resolves #874. 

