### PR TITLE
Update `basix.ufl.mixed_element` factory function for case of a single element

### DIFF
--- a/python/basix/ufl.py
+++ b/python/basix/ufl.py
@@ -1985,7 +1985,7 @@ def _compute_signature(element: _basix.finite_element.FiniteElement) -> str:
     return signature
 
 
-@functools.singledisptach
+@functools.singledispatch
 def element(
     family: _typing.Union[_basix.ElementFamily, str],
     cell: _typing.Union[_basix.CellType, str],

--- a/python/basix/ufl.py
+++ b/python/basix/ufl.py
@@ -2070,7 +2070,7 @@ def element(
 
 
 @element.register(collections.Sequence)
-def _(elements: list[_ElementBase]) -> _ElementBase:
+def _(elements: _typing.Union[_ElementBase, list[_ElementBase]]) -> _ElementBase:
     """Create a UFL compatible mixed element from a list of elements.
 
     Args:

--- a/python/basix/ufl.py
+++ b/python/basix/ufl.py
@@ -2237,7 +2237,7 @@ def mixed_element(elements: list[_ElementBase]) -> _ElementBase:
     if len(elements) > 1:
         return _MixedElement(elements)
     else:
-        return elements
+        return elements[0]
 
 
 def quadrature_element(

--- a/python/basix/ufl.py
+++ b/python/basix/ufl.py
@@ -5,14 +5,12 @@
 # SPDX-License-Identifier:    MIT
 """Functions to directly wrap Basix elements in UFL."""
 
-import collections
 import hashlib as _hashlib
 import itertools as _itertools
 import typing as _typing
 from abc import abstractmethod as _abstractmethod
 from abc import abstractproperty as _abstractproperty
 from warnings import warn as _warn
-import functools
 
 import numpy as np
 import numpy.typing as _npt
@@ -1985,7 +1983,6 @@ def _compute_signature(element: _basix.finite_element.FiniteElement) -> str:
     return signature
 
 
-@functools.singledispatch
 def element(
     family: _typing.Union[_basix.ElementFamily, str],
     cell: _typing.Union[_basix.CellType, str],
@@ -2067,22 +2064,6 @@ def element(
         return ufl_e
     else:
         return blocked_element(ufl_e, shape=shape, symmetry=symmetry)
-
-
-@element.register(collections.Sequence)
-def _(elements: _typing.Union[_ElementBase, list[_ElementBase]]) -> _ElementBase:
-    """Create a UFL compatible mixed element from a list of elements.
-
-    Args:
-        elements: List of elements.
-
-    Returns:
-        A mixed finite element.
-    """
-    if len(elements) > 1:
-        return _MixedElement(elements)
-    else:
-        return elements
 
 
 def enriched_element(
@@ -2253,11 +2234,10 @@ def mixed_element(elements: list[_ElementBase]) -> _ElementBase:
     Returns:
         A mixed finite element.
     """
-    return element(elements)
-    # if len(elements) > 1:
-    #     return _MixedElement(elements)
-    # else:
-    #     return elements
+    if len(elements) > 1:
+        return _MixedElement(elements)
+    else:
+        return elements
 
 
 def quadrature_element(

--- a/test/test_ufl_wrapper.py
+++ b/test/test_ufl_wrapper.py
@@ -99,7 +99,19 @@ def test_enriched_element(elements):
     [
         (basix.ufl.element("Lagrange", basix.CellType.triangle, 2), "H1", basix.SobolevSpace.H1),
         (
+            basix.ufl.mixed_element([basix.ufl.element("Lagrange", basix.CellType.triangle, 2)]),
+            "H1",
+            basix.SobolevSpace.H1,
+        ),
+        (
             basix.ufl.element("Discontinuous Lagrange", basix.CellType.triangle, 0),
+            "L2",
+            basix.SobolevSpace.L2,
+        ),
+        (
+            basix.ufl.mixed_elementelement(
+                [basix.ufl.element("Discontinuous Lagrange", basix.CellType.triangle, 0)]
+            ),
             "L2",
             basix.SobolevSpace.L2,
         ),

--- a/test/test_ufl_wrapper.py
+++ b/test/test_ufl_wrapper.py
@@ -109,7 +109,7 @@ def test_enriched_element(elements):
             basix.SobolevSpace.L2,
         ),
         (
-            basix.ufl.mixed_elementelement(
+            basix.ufl.mixed_element(
                 [basix.ufl.element("Discontinuous Lagrange", basix.CellType.triangle, 0)]
             ),
             "L2",


### PR DESCRIPTION
With this change, a call to `basix.ufl.mixed_element` with a list of just one finite element simply returns the single element.

This allows an element to be 'constructed' from a list of one element without making a single element into a mixed element (when it's not a mixed element).