### PR TITLE
Rational functions for pyramid

### DIFF
--- a/cpp/basix/polyset.cpp
+++ b/cpp/basix/polyset.cpp
@@ -2267,6 +2267,7 @@ void tabulate_polyset_pyramid_derivs(
             {
               r_pq[i] = (0.5 + (x1[i] * 2.0 - 1.0) + (x2[i] * 2.0 - 1.0) * 0.5)
                         * _p[i] * (a + 1.0);
+              if (q <= p) r_pq[i] /= (1 - x2[i]);
             }
 
             if (ky > 0)
@@ -2295,7 +2296,12 @@ void tabulate_polyset_pyramid_derivs(
               for (std::size_t i = 0; i < r_pq.size(); ++i)
               {
                 const T f2 = 1.0 - x2[i];
-                r_pq[i] -= f2 * f2 * _p[i] * a;
+                if (q <= p)
+                    r_pq[i] -=_p[i] * a;
+                else if (q <= p + 1)
+                    r_pq[i] -= f2 * _p[i] * a;
+                else
+                  r_pq[i] -= f2 * f2 * _p[i] * a;
               }
 
               if (kz > 0)
@@ -2335,7 +2341,7 @@ void tabulate_polyset_pyramid_derivs(
             {
               r_pq1[i]
                   = r_pq0[i]
-                    * ((1.0 + p + q) + (x2[i] * 2.0 - 1.0) * (2.0 + p + q));
+                    * ((1.0 + std::max(p, q)) + (x2[i] * 2.0 - 1.0) * (2.0 + std::max(p, q)));
             }
 
             if (kz > 0)
@@ -2344,7 +2350,7 @@ void tabulate_polyset_pyramid_derivs(
                   P, idx(kx, ky, kz - 1), pyr_idx(p, q, 0),
                   MDSPAN_IMPL_STANDARD_NAMESPACE::full_extent);
               for (std::size_t i = 0; i < r_pq1.size(); ++i)
-                r_pq1[i] += 2 * kz * r_pq[i] * (2.0 + p + q);
+                r_pq1[i] += 2 * kz * r_pq[i] * (2.0 + std::max(p, q));
             }
           }
         }
@@ -2355,7 +2361,7 @@ void tabulate_polyset_pyramid_derivs(
           {
             for (std::size_t q = 0; q < n - r; ++q)
             {
-              auto [ar, br, cr] = jrc<T>(2 * p + 2 * q + 2, r);
+              auto [ar, br, cr] = jrc<T>(2 * std::max(p, q) + 2, r);
               auto r_pqr = MDSPAN_IMPL_STANDARD_NAMESPACE::submdspan(
                   P, idx(kx, ky, kz), pyr_idx(p, q, r + 1),
                   MDSPAN_IMPL_STANDARD_NAMESPACE::full_extent);
@@ -2398,7 +2404,7 @@ void tabulate_polyset_pyramid_derivs(
         for (std::size_t i = 0; i < pqr.extent(0); ++i)
           for (std::size_t j = 0; j < pqr.extent(1); ++j)
             pqr(i, j)
-                *= std::sqrt(2 * (q + 0.5) * (p + 0.5) * (p + q + r + 1.5)) * 2;
+                *= std::sqrt(2 * (q + 0.5) * (p + 0.5) * (std::max(p, q) + r + 1.5)) * 2;
       }
     }
   }


### PR DESCRIPTION
This commit generates the proper orthonormal rational functions for the pyramid.

THE (z) DERIVATIVES MAY NOT BE CORRECT.