### PR TITLE
Expose and enforce compile time configuration of mdspan

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -106,6 +106,9 @@ target_include_directories(basix PUBLIC
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR};${CMAKE_CURRENT_SOURCE_DIR}>")
 
+target_compile_definitions(basix PUBLIC MDSPAN_USE_PAREN_OPERATOR=1)
+target_compile_definitions(basix PUBLIC MDSPAN_USE_BRACKET_OPERATOR=0)
+
 target_link_libraries(basix PRIVATE BLAS::BLAS)
 target_link_libraries(basix PRIVATE LAPACK::LAPACK)
 


### PR DESCRIPTION
When using `basix` as a third-party library within a `C++23` compliant project the include of `mdspan` will trigger a default use of the bracket operator `[]`, however `basix` currently relies on parentheses based element access and thus compilation is not possible (especially due to presence of `mdspan` based computations in the `basix` headers).

This (re-)adds the public config for the `mdspan` headers. Previously removed after a comment at https://github.com/FEniCS/basix/pull/844#discussion_r1670320564.

Since `basix` does not install any headers during the python build, we do not need to (re-)add this in the Python config.