### PR TITLE
Simplify: `MDSPAN_IMPL_STANDARD_NAMESPACE` -> `md`

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -73,6 +73,7 @@ set(HEADERS_basix
   ${CMAKE_CURRENT_SOURCE_DIR}/basix/e-serendipity.h
   ${CMAKE_CURRENT_SOURCE_DIR}/basix/e-hermite.h
   ${CMAKE_CURRENT_SOURCE_DIR}/basix/mdspan.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/basix/types.h
   ${CMAKE_CURRENT_BINARY_DIR}/basix/version.h)
 
 target_sources(basix PRIVATE

--- a/cpp/basix/cell.cpp
+++ b/cpp/basix/cell.cpp
@@ -12,8 +12,7 @@
 using namespace basix;
 
 template <typename T, std::size_t D>
-using mdspan_t = MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-    T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, D>>;
+using mdspan_t = md::mdspan<T, md::dextents<std::size_t, D>>;
 
 //-----------------------------------------------------------------------------
 template <std::floating_point T>

--- a/cpp/basix/dof-transformations.cpp
+++ b/cpp/basix/dof-transformations.cpp
@@ -17,15 +17,10 @@ using namespace basix;
 
 namespace
 {
-namespace stdex
-    = MDSPAN_IMPL_STANDARD_NAMESPACE::MDSPAN_IMPL_PROPOSED_NAMESPACE;
 template <typename T, std::size_t d>
-using mdarray_t
-    = stdex::mdarray<T,
-                     MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, d>>;
+using mdarray_t = mdex::mdarray<T, md::dextents<std::size_t, d>>;
 template <typename T, std::size_t d>
-using mdspan_t = MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-    T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, d>>;
+using mdspan_t = md::mdspan<T, md::dextents<std::size_t, d>>;
 
 template <typename T>
 using map_data_t
@@ -91,12 +86,12 @@ mapinfo_t<T> get_mapinfo(cell::type cell_type)
     mapinfo_t<T> mapinfo;
     auto& data = mapinfo.try_emplace(cell::type::interval).first->second;
     auto map = [](auto pt) -> std::array<T, 3> { return {pt[1], pt[0], 0}; };
-    stdex::mdarray<T, stdex::extents<std::size_t, 2, 2>> J(
-        stdex::extents<std::size_t, 2, 2>{}, {0., 1., 1., 0.});
+    mdex::mdarray<T, md::extents<std::size_t, 2, 2>> J(
+        md::extents<std::size_t, 2, 2>{}, {0., 1., 1., 0.});
 
     T detJ = -1;
-    stdex::mdarray<T, stdex::extents<std::size_t, 2, 2>> K(
-        stdex::extents<std::size_t, 2, 2>{}, {0., 1., 1., 0.});
+    mdex::mdarray<T, md::extents<std::size_t, 2, 2>> K(
+        md::extents<std::size_t, 2, 2>{}, {0., 1., 1., 0.});
     data.push_back(std::tuple(map, J, detJ, K));
     return mapinfo;
   }
@@ -106,12 +101,12 @@ mapinfo_t<T> get_mapinfo(cell::type cell_type)
     auto& data = mapinfo.try_emplace(cell::type::interval).first->second;
     auto map
         = [](auto pt) -> std::array<T, 3> { return {1 - pt[0], pt[1], 0}; };
-    stdex::mdarray<T, stdex::extents<std::size_t, 2, 2>> J(
-        stdex::extents<std::size_t, 2, 2>{}, {-1., 0., 0., 1.});
+    mdex::mdarray<T, md::extents<std::size_t, 2, 2>> J(
+        md::extents<std::size_t, 2, 2>{}, {-1., 0., 0., 1.});
 
     T detJ = -1.0;
-    stdex::mdarray<T, stdex::extents<std::size_t, 2, 2>> K(
-        stdex::extents<std::size_t, 2, 2>{}, {-1., 0., 0., 1.});
+    mdex::mdarray<T, md::extents<std::size_t, 2, 2>> K(
+        md::extents<std::size_t, 2, 2>{}, {-1., 0., 0., 1.});
     data.push_back(std::tuple(map, J, detJ, K));
     return mapinfo;
   }
@@ -122,13 +117,13 @@ mapinfo_t<T> get_mapinfo(cell::type cell_type)
       auto& data = mapinfo.try_emplace(cell::type::interval).first->second;
       auto map
           = [](auto pt) -> std::array<T, 3> { return {pt[0], pt[2], pt[1]}; };
-      stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> J(
-          stdex::extents<std::size_t, 3, 3>{},
+      mdex::mdarray<T, md::extents<std::size_t, 3, 3>> J(
+          md::extents<std::size_t, 3, 3>{},
           {1., 0., 0., 0., 0., 1., 0., 1., 0.});
 
       T detJ = -1.0;
-      stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> K(
-          stdex::extents<std::size_t, 3, 3>{},
+      mdex::mdarray<T, md::extents<std::size_t, 3, 3>> K(
+          md::extents<std::size_t, 3, 3>{},
           {1., 0., 0., 0., 0., 1., 0., 1., 0.});
       data.push_back(std::tuple(map, J, detJ, K));
     }
@@ -138,26 +133,26 @@ mapinfo_t<T> get_mapinfo(cell::type cell_type)
       {
         auto map
             = [](auto pt) -> std::array<T, 3> { return {pt[2], pt[0], pt[1]}; };
-        stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> J(
-            stdex::extents<std::size_t, 3, 3>{},
+        mdex::mdarray<T, md::extents<std::size_t, 3, 3>> J(
+            md::extents<std::size_t, 3, 3>{},
             {0., 1., 0., 0., 0., 1., 1., 0., 0.});
 
         T detJ = 1.0;
-        stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> K(
-            stdex::extents<std::size_t, 3, 3>{},
+        mdex::mdarray<T, md::extents<std::size_t, 3, 3>> K(
+            md::extents<std::size_t, 3, 3>{},
             {0., 0., 1., 1., 0., 0., 0., 1., 0.});
         data.push_back(std::tuple(map, J, detJ, K));
       }
       {
         auto map
             = [](auto pt) -> std::array<T, 3> { return {pt[0], pt[2], pt[1]}; };
-        stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> J(
-            stdex::extents<std::size_t, 3, 3>{},
+        mdex::mdarray<T, md::extents<std::size_t, 3, 3>> J(
+            md::extents<std::size_t, 3, 3>{},
             {1., 0., 0., 0., 0., 1., 0., 1., 0.});
 
         T detJ = -1.0;
-        stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> K(
-            stdex::extents<std::size_t, 3, 3>{},
+        mdex::mdarray<T, md::extents<std::size_t, 3, 3>> K(
+            md::extents<std::size_t, 3, 3>{},
             {1., 0., 0., 0., 0., 1., 0., 1., 0.});
         data.push_back(std::tuple(map, J, detJ, K));
       }
@@ -172,13 +167,13 @@ mapinfo_t<T> get_mapinfo(cell::type cell_type)
       auto& data = mapinfo.try_emplace(cell::type::interval).first->second;
       auto map = [](auto pt) -> std::array<T, 3>
       { return {1 - pt[0], pt[1], pt[2]}; };
-      stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> J(
-          stdex::extents<std::size_t, 3, 3>{},
+      mdex::mdarray<T, md::extents<std::size_t, 3, 3>> J(
+          md::extents<std::size_t, 3, 3>{},
           {-1., 0., 0., 0., 1., 0., 0., 0., 1.});
 
       T detJ = -1.0;
-      stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> K(
-          stdex::extents<std::size_t, 3, 3>{},
+      mdex::mdarray<T, md::extents<std::size_t, 3, 3>> K(
+          md::extents<std::size_t, 3, 3>{},
           {-1., 0., 0., 0., 1., 0., 0., 0., 1.});
       data.push_back(std::tuple(map, J, detJ, K));
     }
@@ -188,26 +183,26 @@ mapinfo_t<T> get_mapinfo(cell::type cell_type)
       {
         auto map = [](auto pt) -> std::array<T, 3>
         { return {1 - pt[1], pt[0], pt[2]}; };
-        stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> J(
-            stdex::extents<std::size_t, 3, 3>{},
+        mdex::mdarray<T, md::extents<std::size_t, 3, 3>> J(
+            md::extents<std::size_t, 3, 3>{},
             {0., 1., 0., -1., 0., 0., 0., 0., 1.});
 
         T detJ = 1.0;
-        stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> K(
-            stdex::extents<std::size_t, 3, 3>{},
+        mdex::mdarray<T, md::extents<std::size_t, 3, 3>> K(
+            md::extents<std::size_t, 3, 3>{},
             {0., -1., 0., 1., 0., 0., 0., 0., 1.});
         data.push_back(std::tuple(map, J, detJ, K));
       }
       {
         auto map
             = [](auto pt) -> std::array<T, 3> { return {pt[1], pt[0], pt[2]}; };
-        stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> J(
-            stdex::extents<std::size_t, 3, 3>{},
+        mdex::mdarray<T, md::extents<std::size_t, 3, 3>> J(
+            md::extents<std::size_t, 3, 3>{},
             {0., 1., 0., 1., 0., 0., 0., 0., 1.});
 
         T detJ = -1.0;
-        stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> K(
-            stdex::extents<std::size_t, 3, 3>{},
+        mdex::mdarray<T, md::extents<std::size_t, 3, 3>> K(
+            md::extents<std::size_t, 3, 3>{},
             {0., 1., 0., 1., 0., 0., 0., 0., 1.});
         data.push_back(std::tuple(map, J, detJ, K));
       }
@@ -221,12 +216,12 @@ mapinfo_t<T> get_mapinfo(cell::type cell_type)
       auto& data = mapinfo.try_emplace(cell::type::interval).first->second;
       auto map = [](auto pt) -> std::array<T, 3>
       { return {1 - pt[0], pt[1], pt[2]}; };
-      stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> J(
-          stdex::extents<std::size_t, 3, 3>{},
+      mdex::mdarray<T, md::extents<std::size_t, 3, 3>> J(
+          md::extents<std::size_t, 3, 3>{},
           {-1., 0., 0., 0., 1., 0., 0., 0., 1.});
       T detJ = -1.0;
-      stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> K(
-          stdex::extents<std::size_t, 3, 3>{},
+      mdex::mdarray<T, md::extents<std::size_t, 3, 3>> K(
+          md::extents<std::size_t, 3, 3>{},
           {-1., 0., 0., 0., 1., 0., 0., 0., 1.});
       data.push_back(std::tuple(map, J, detJ, K));
     }
@@ -235,24 +230,24 @@ mapinfo_t<T> get_mapinfo(cell::type cell_type)
       {
         auto map = [](auto pt) -> std::array<T, 3>
         { return {1 - pt[1] - pt[0], pt[0], pt[2]}; };
-        stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> J(
-            stdex::extents<std::size_t, 3, 3>{},
+        mdex::mdarray<T, md::extents<std::size_t, 3, 3>> J(
+            md::extents<std::size_t, 3, 3>{},
             {0., 1., 0., -1., -1., 0., 0., 0., 1.});
         T detJ = 1.0;
-        stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> K(
-            stdex::extents<std::size_t, 3, 3>{},
+        mdex::mdarray<T, md::extents<std::size_t, 3, 3>> K(
+            md::extents<std::size_t, 3, 3>{},
             {-1., -1., 0., 1., 0., 0., 0., 0., 1.});
         data.push_back(std::tuple(map, J, detJ, K));
       }
       {
         auto map
             = [](auto pt) -> std::array<T, 3> { return {pt[1], pt[0], pt[2]}; };
-        stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> J(
-            stdex::extents<std::size_t, 3, 3>{},
+        mdex::mdarray<T, md::extents<std::size_t, 3, 3>> J(
+            md::extents<std::size_t, 3, 3>{},
             {0., 1., 0., 1., 0., 0., 0., 0., 1.});
         T detJ = -1.;
-        stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> K(
-            stdex::extents<std::size_t, 3, 3>{},
+        mdex::mdarray<T, md::extents<std::size_t, 3, 3>> K(
+            md::extents<std::size_t, 3, 3>{},
             {0., 1., 0., 1., 0., 0., 0., 0., 1.});
         data.push_back(std::tuple(map, J, detJ, K));
       }
@@ -262,24 +257,24 @@ mapinfo_t<T> get_mapinfo(cell::type cell_type)
       {
         auto map = [](auto pt) -> std::array<T, 3>
         { return {1 - pt[2], pt[1], pt[0]}; };
-        stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> J(
-            stdex::extents<std::size_t, 3, 3>{},
+        mdex::mdarray<T, md::extents<std::size_t, 3, 3>> J(
+            md::extents<std::size_t, 3, 3>{},
             {0., 0., 1., 0., 1., 0., -1., 0., 0.});
         T detJ = 1.0;
-        stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> K(
-            stdex::extents<std::size_t, 3, 3>{},
+        mdex::mdarray<T, md::extents<std::size_t, 3, 3>> K(
+            md::extents<std::size_t, 3, 3>{},
             {0., 0., -1., 0., 1., 0., 1., 0., 0.});
         data.push_back(std::tuple(map, J, detJ, K));
       }
       { // scope
         auto map
             = [](auto pt) -> std::array<T, 3> { return {pt[2], pt[1], pt[0]}; };
-        stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> J(
-            stdex::extents<std::size_t, 3, 3>{},
+        mdex::mdarray<T, md::extents<std::size_t, 3, 3>> J(
+            md::extents<std::size_t, 3, 3>{},
             {0., 0., 1., 0., 1., 0., 1., 0., 0.});
         T detJ = -1.;
-        stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> K(
-            stdex::extents<std::size_t, 3, 3>{},
+        mdex::mdarray<T, md::extents<std::size_t, 3, 3>> K(
+            md::extents<std::size_t, 3, 3>{},
             {0., 0., 1., 0., 1., 0., 1., 0., 0.});
         data.push_back(std::tuple(map, J, detJ, K));
       }
@@ -294,12 +289,12 @@ mapinfo_t<T> get_mapinfo(cell::type cell_type)
       auto& data = mapinfo.try_emplace(cell::type::interval).first->second;
       auto map = [](auto pt) -> std::array<T, 3>
       { return {1 - pt[0], pt[1], pt[2]}; };
-      stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> J(
-          stdex::extents<std::size_t, 3, 3>{},
+      mdex::mdarray<T, md::extents<std::size_t, 3, 3>> J(
+          md::extents<std::size_t, 3, 3>{},
           {-1., 0., 0., 0., 1., 0., 0., 0., 1.});
       T detJ = -1.;
-      stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> K(
-          stdex::extents<std::size_t, 3, 3>{},
+      mdex::mdarray<T, md::extents<std::size_t, 3, 3>> K(
+          md::extents<std::size_t, 3, 3>{},
           {-1., 0., 0., 0., 1., 0., 0., 0., 1.});
       data.push_back(std::tuple(map, J, detJ, K));
     }
@@ -309,24 +304,24 @@ mapinfo_t<T> get_mapinfo(cell::type cell_type)
       {
         auto map = [](auto pt) -> std::array<T, 3>
         { return {1 - pt[1], pt[0], pt[2]}; };
-        stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> J(
-            stdex::extents<std::size_t, 3, 3>{},
+        mdex::mdarray<T, md::extents<std::size_t, 3, 3>> J(
+            md::extents<std::size_t, 3, 3>{},
             {0., 1., 0., -1., 0., 0., 0., 0., 1.});
         T detJ = 1.;
-        stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> K(
-            stdex::extents<std::size_t, 3, 3>{},
+        mdex::mdarray<T, md::extents<std::size_t, 3, 3>> K(
+            md::extents<std::size_t, 3, 3>{},
             {0., -1., 0., 1., 0., 0., 0., 0., 1.});
         data.push_back(std::tuple(map, J, detJ, K));
       }
       {
         auto map
             = [](auto pt) -> std::array<T, 3> { return {pt[1], pt[0], pt[2]}; };
-        stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> J(
-            stdex::extents<std::size_t, 3, 3>{},
+        mdex::mdarray<T, md::extents<std::size_t, 3, 3>> J(
+            md::extents<std::size_t, 3, 3>{},
             {0., 1., 0., 1., 0., 0., 0., 0., 1.});
         T detJ = -1.;
-        stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> K(
-            stdex::extents<std::size_t, 3, 3>{},
+        mdex::mdarray<T, md::extents<std::size_t, 3, 3>> K(
+            md::extents<std::size_t, 3, 3>{},
             {0., 1., 0., 1., 0., 0., 0., 0., 1.});
         data.push_back(std::tuple(map, J, detJ, K));
       }
@@ -337,24 +332,24 @@ mapinfo_t<T> get_mapinfo(cell::type cell_type)
       {
         auto map = [](auto pt) -> std::array<T, 3>
         { return {1 - pt[2] - pt[0], pt[1], pt[0]}; };
-        stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> J(
-            stdex::extents<std::size_t, 3, 3>{},
+        mdex::mdarray<T, md::extents<std::size_t, 3, 3>> J(
+            md::extents<std::size_t, 3, 3>{},
             {0., 0., 1., 0., 1., 0., -1., 0., -1.});
         T detJ = 1.;
-        stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> K(
-            stdex::extents<std::size_t, 3, 3>{},
+        mdex::mdarray<T, md::extents<std::size_t, 3, 3>> K(
+            md::extents<std::size_t, 3, 3>{},
             {-1., 0., -1., 0., 1., 0., 1., 0., 0.});
         data.push_back(std::tuple(map, J, detJ, K));
       }
       {
         auto map
             = [](auto pt) -> std::array<T, 3> { return {pt[2], pt[1], pt[0]}; };
-        stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> J(
-            stdex::extents<std::size_t, 3, 3>{},
+        mdex::mdarray<T, md::extents<std::size_t, 3, 3>> J(
+            md::extents<std::size_t, 3, 3>{},
             {0., 0., 1., 0., 1., 0., 1., 0., 0.});
         T detJ = -1.;
-        stdex::mdarray<T, stdex::extents<std::size_t, 3, 3>> K(
-            stdex::extents<std::size_t, 3, 3>{},
+        mdex::mdarray<T, md::extents<std::size_t, 3, 3>> K(
+            md::extents<std::size_t, 3, 3>{},
             {0., 0., 1., 0., 1., 0., 1., 0., 0.});
         data.push_back(std::tuple(map, J, detJ, K));
       }
@@ -505,20 +500,14 @@ template <std::floating_point T>
 std::map<cell::type, std::pair<std::vector<T>, std::array<std::size_t, 3>>>
 doftransforms::compute_entity_transformations(
     cell::type cell_type,
-    std::array<
-        std::vector<MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-            const T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>>,
-        4>
+    std::array<std::vector<md::mdspan<const T, md::dextents<std::size_t, 2>>>,
+               4>
         x,
-    std::array<
-        std::vector<MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-            const T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 4>>>,
-        4>
+    std::array<std::vector<md::mdspan<const T, md::dextents<std::size_t, 4>>>,
+               4>
         M,
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        const T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-        coeffs,
-    int degree, std::size_t vs, maps::type map_type, polyset::type ptype)
+    md::mdspan<const T, md::dextents<std::size_t, 2>> coeffs, int degree,
+    std::size_t vs, maps::type map_type, polyset::type ptype)
 {
   std::map<cell::type, std::pair<std::vector<T>, std::array<std::size_t, 3>>>
       out;
@@ -551,32 +540,22 @@ template std::map<cell::type,
                   std::pair<std::vector<float>, std::array<std::size_t, 3>>>
 doftransforms::compute_entity_transformations(
     cell::type,
-    std::array<std::vector<MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-                   const float,
-                   MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>>,
-               4>,
-    std::array<std::vector<MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-                   const float,
-                   MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 4>>>,
-               4>,
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        const float, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>,
-    int, std::size_t, maps::type, polyset::type);
+    std::array<
+        std::vector<md::mdspan<const float, md::dextents<std::size_t, 2>>>, 4>,
+    std::array<
+        std::vector<md::mdspan<const float, md::dextents<std::size_t, 4>>>, 4>,
+    md::mdspan<const float, md::dextents<std::size_t, 2>>, int, std::size_t,
+    maps::type, polyset::type);
 
 template std::map<cell::type,
                   std::pair<std::vector<double>, std::array<std::size_t, 3>>>
 doftransforms::compute_entity_transformations(
     cell::type,
-    std::array<std::vector<MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-                   const double,
-                   MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>>,
-               4>,
-    std::array<std::vector<MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-                   const double,
-                   MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 4>>>,
-               4>,
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        const double, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>,
-    int, std::size_t, maps::type, polyset::type);
+    std::array<
+        std::vector<md::mdspan<const double, md::dextents<std::size_t, 2>>>, 4>,
+    std::array<
+        std::vector<md::mdspan<const double, md::dextents<std::size_t, 4>>>, 4>,
+    md::mdspan<const double, md::dextents<std::size_t, 2>>, int, std::size_t,
+    maps::type, polyset::type);
 /// @endcond
 //-----------------------------------------------------------------------------

--- a/cpp/basix/dof-transformations.h
+++ b/cpp/basix/dof-transformations.h
@@ -40,19 +40,13 @@ template <std::floating_point T>
 std::map<cell::type, std::pair<std::vector<T>, std::array<std::size_t, 3>>>
 compute_entity_transformations(
     cell::type cell_type,
-    std::array<
-        std::vector<MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-            const T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>>,
-        4>
+    std::array<std::vector<md::mdspan<const T, md::dextents<std::size_t, 2>>>,
+               4>
         x,
-    std::array<
-        std::vector<MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-            const T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 4>>>,
-        4>
+    std::array<std::vector<md::mdspan<const T, md::dextents<std::size_t, 4>>>,
+               4>
         M,
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        const T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-        coeffs,
-    int degree, std::size_t vs, maps::type map_type, polyset::type ptype);
+    md::mdspan<const T, md::dextents<std::size_t, 2>> coeffs, int degree,
+    std::size_t vs, maps::type map_type, polyset::type ptype);
 
 } // namespace basix::doftransforms

--- a/cpp/basix/e-lagrange.cpp
+++ b/cpp/basix/e-lagrange.cpp
@@ -15,8 +15,7 @@
 #include <concepts>
 
 using namespace basix;
-namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
-namespace stdex = md::MDSPAN_IMPL_PROPOSED_NAMESPACE;
+namespace md = md::MDSPAN_IMPL_PROPOSED_NAMESPACE;
 
 namespace
 {

--- a/cpp/basix/e-regge.cpp
+++ b/cpp/basix/e-regge.cpp
@@ -13,8 +13,7 @@
 #include <cmath>
 
 using namespace basix;
-namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
-namespace stdex = md::MDSPAN_IMPL_PROPOSED_NAMESPACE;
+namespace md = md::MDSPAN_IMPL_PROPOSED_NAMESPACE;
 
 //-----------------------------------------------------------------------------
 template <std::floating_point T>
@@ -116,7 +115,7 @@ FiniteElement<T> element::create_regge(cell::type celltype, int degree,
         // Store up outer(t, t) for all tangents
         const std::vector<int>& vert_ids = topology[d][e];
         const std::size_t ntangents = d * (d + 1) / 2;
-        stdex::mdarray<T, md::dextents<std::size_t, 3>> vvt(
+        mdex::mdarray<T, md::dextents<std::size_t, 3>> vvt(
             ntangents, geometry.extent(1), geometry.extent(1));
         std::vector<T> edge(geometry.extent(1));
 

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -28,13 +28,11 @@
 #define str(X) str_macro(X)
 
 using namespace basix;
-namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
 
-namespace stdex = md::MDSPAN_IMPL_PROPOSED_NAMESPACE;
 template <typename T, std::size_t d>
 using mdspan_t = md::mdspan<T, md::dextents<std::size_t, d>>;
 template <typename T, std::size_t d>
-using mdarray_t = stdex::mdarray<T, md::dextents<std::size_t, d>>;
+using mdarray_t = mdex::mdarray<T, md::dextents<std::size_t, d>>;
 
 namespace
 {

--- a/cpp/basix/finite-element.h
+++ b/cpp/basix/finite-element.h
@@ -29,12 +29,11 @@ namespace basix
 namespace impl
 {
 template <typename T, std::size_t d>
-using mdspan_t = MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-    T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, d>>;
+using mdspan_t = md::mdspan<T, md::dextents<std::size_t, d>>;
 template <typename T, std::size_t d>
 using mdarray_t
-    = MDSPAN_IMPL_STANDARD_NAMESPACE::MDSPAN_IMPL_PROPOSED_NAMESPACE::mdarray<
-        T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, d>>;
+    = md::MDSPAN_IMPL_PROPOSED_NAMESPACE::mdarray<T,
+                                                  md::dextents<std::size_t, d>>;
 
 /// Create a container of cmdspan2_t objects from a container of
 /// mdarray2_t objects
@@ -137,8 +136,7 @@ template <std::floating_point F>
 class FiniteElement
 {
   template <typename T, std::size_t d>
-  using mdspan_t = MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-      T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, d>>;
+  using mdspan_t = md::mdspan<T, md::dextents<std::size_t, d>>;
 
 public:
   /// Scalar type.

--- a/cpp/basix/interpolation.cpp
+++ b/cpp/basix/interpolation.cpp
@@ -8,9 +8,7 @@
 #include <exception>
 
 using namespace basix;
-namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
 
-namespace stdex = md::MDSPAN_IMPL_PROPOSED_NAMESPACE;
 template <typename T, std::size_t D>
 using mdspan_t = md::mdspan<T, md::dextents<std::size_t, D>>;
 

--- a/cpp/basix/lattice.cpp
+++ b/cpp/basix/lattice.cpp
@@ -15,8 +15,6 @@
 #include <vector>
 
 using namespace basix;
-namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
-namespace stdex = md::MDSPAN_IMPL_PROPOSED_NAMESPACE;
 
 namespace
 {
@@ -167,7 +165,7 @@ std::vector<T> create_interval(std::size_t n, lattice::type lattice_type,
 }
 //-----------------------------------------------------------------------------
 template <std::floating_point T>
-stdex::mdarray<T, md::dextents<std::size_t, 2>>
+mdex::mdarray<T, md::dextents<std::size_t, 2>>
 tabulate_dlagrange(std::size_t n, std::span<const T> x)
 {
   std::vector<T> equi_pts(n + 1);
@@ -207,8 +205,8 @@ tabulate_dlagrange(std::size_t n, std::span<const T> x)
       tabulated(i, j) = tabulated_values(0, i, j);
 
   std::vector<T> c = math::solve<T>(dualmat, tabulated);
-  return stdex::mdarray<T, md::dextents<std::size_t, 2>>(tabulated.extents(),
-                                                         std::move(c));
+  return mdex::mdarray<T, md::dextents<std::size_t, 2>>(tabulated.extents(),
+                                                        std::move(c));
 }
 //-----------------------------------------------------------------------------
 template <std::floating_point T>
@@ -219,7 +217,7 @@ std::vector<T> warp_function(lattice::type lattice_type, int n,
   for (int i = 0; i < n + 1; ++i)
     pts[i] -= static_cast<T>(i) / static_cast<T>(n);
 
-  stdex::mdarray<T, md::dextents<std::size_t, 2>> v = tabulate_dlagrange(n, x);
+  mdex::mdarray<T, md::dextents<std::size_t, 2>> v = tabulate_dlagrange(n, x);
   std::vector<T> w(v.extent(1), 0);
   for (std::size_t i = 0; i < v.extent(0); ++i)
     for (std::size_t j = 0; j < v.extent(1); ++j)

--- a/cpp/basix/maps.h
+++ b/cpp/basix/maps.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "mdspan.hpp"
+#include "types.h"
 #include <algorithm>
 #include <stdexcept>
 #include <type_traits>
@@ -103,18 +104,14 @@ template <typename O, typename P, typename Q, typename R>
 void double_covariant_piola(O&& r, const P& U, const Q& J, double /*detJ*/,
                             const R& K)
 {
-  namespace stdex
-      = MDSPAN_IMPL_STANDARD_NAMESPACE::MDSPAN_IMPL_PROPOSED_NAMESPACE;
   using T = typename std::decay_t<O>::value_type;
   using Z = typename impl::scalar_value_type_t<T>;
   for (std::size_t p = 0; p < U.extent(0); ++p)
   {
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        const T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-        _U(U.data_handle() + p * U.extent(1), J.extent(1), J.extent(1));
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-        _r(r.data_handle() + p * r.extent(1), K.extent(1), K.extent(1));
+    md::mdspan<const T, md::dextents<std::size_t, 2>> _U(
+        U.data_handle() + p * U.extent(1), J.extent(1), J.extent(1));
+    md::mdspan<T, md::dextents<std::size_t, 2>> _r(
+        r.data_handle() + p * r.extent(1), K.extent(1), K.extent(1));
     // _r = K^T _U K
     for (std::size_t i = 0; i < _r.extent(0); ++i)
     {
@@ -135,18 +132,14 @@ template <typename O, typename P, typename Q, typename R>
 void double_contravariant_piola(O&& r, const P& U, const Q& J, double detJ,
                                 const R& /*K*/)
 {
-  namespace stdex
-      = MDSPAN_IMPL_STANDARD_NAMESPACE::MDSPAN_IMPL_PROPOSED_NAMESPACE;
   using T = typename std::decay_t<O>::value_type;
   using Z = typename impl::scalar_value_type_t<T>;
   for (std::size_t p = 0; p < U.extent(0); ++p)
   {
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        const T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-        _U(U.data_handle() + p * U.extent(1), J.extent(1), J.extent(1));
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-        _r(r.data_handle() + p * r.extent(1), J.extent(0), J.extent(0));
+    md::mdspan<const T, md::dextents<std::size_t, 2>> _U(
+        U.data_handle() + p * U.extent(1), J.extent(1), J.extent(1));
+    md::mdspan<T, md::dextents<std::size_t, 2>> _r(
+        r.data_handle() + p * r.extent(1), J.extent(0), J.extent(0));
 
     // _r = J U J^T
     for (std::size_t i = 0; i < _r.extent(0); ++i)

--- a/cpp/basix/math.h
+++ b/cpp/basix/math.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "mdspan.hpp"
+#include "types.h"
 #include <algorithm>
 #include <array>
 #include <cmath>
@@ -183,21 +184,13 @@ std::pair<std::vector<T>, std::vector<T>> eigh(std::span<const T> A,
 /// @param[in] B Right-hand side matrix/vector.
 /// @return A^{-1} B.
 template <std::floating_point T>
-std::vector<T>
-solve(MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-          const T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-          A,
-      MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-          const T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-          B)
+std::vector<T> solve(md::mdspan<const T, md::dextents<std::size_t, 2>> A,
+                     md::mdspan<const T, md::dextents<std::size_t, 2>> B)
 {
-  namespace stdex
-      = MDSPAN_IMPL_STANDARD_NAMESPACE::MDSPAN_IMPL_PROPOSED_NAMESPACE;
-
   // Copy A and B to column-major storage
-  stdex::mdarray<T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>,
-                 MDSPAN_IMPL_STANDARD_NAMESPACE::layout_left>
-      _A(A.extents()), _B(B.extents());
+  mdex::mdarray<T, md::dextents<std::size_t, 2>, md::layout_left> _A(
+      A.extents()),
+      _B(B.extents());
   for (std::size_t i = 0; i < A.extent(0); ++i)
     for (std::size_t j = 0; j < A.extent(1); ++j)
       _A(i, j) = A(i, j);
@@ -222,9 +215,7 @@ solve(MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
 
   // Copy result to row-major storage
   std::vector<T> rb(_B.extent(0) * _B.extent(1));
-  MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-      T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-      r(rb.data(), _B.extents());
+  md::mdspan<T, md::dextents<std::size_t, 2>> r(rb.data(), _B.extents());
   for (std::size_t i = 0; i < _B.extent(0); ++i)
     for (std::size_t j = 0; j < _B.extent(1); ++j)
       r(i, j) = _B(i, j);
@@ -236,17 +227,11 @@ solve(MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
 /// @param[in] A The matrix.
 /// @return A bool indicating if the matrix is singular.
 template <std::floating_point T>
-bool is_singular(
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        const T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-        A)
+bool is_singular(md::mdspan<const T, md::dextents<std::size_t, 2>> A)
 {
   // Copy to column major matrix
-  namespace stdex
-      = MDSPAN_IMPL_STANDARD_NAMESPACE::MDSPAN_IMPL_PROPOSED_NAMESPACE;
-  stdex::mdarray<T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>,
-                 MDSPAN_IMPL_STANDARD_NAMESPACE::layout_left>
-      _A(A.extents());
+  mdex::mdarray<T, md::dextents<std::size_t, 2>, md::layout_left> _A(
+      A.extents());
   for (std::size_t i = 0; i < A.extent(0); ++i)
     for (std::size_t j = 0; j < A.extent(1); ++j)
       _A(i, j) = A(i, j);
@@ -345,11 +330,11 @@ void dot(const U& A, const V& B, W&& C,
   else
   {
     static_assert(std::is_same_v<typename std::decay_t<U>::layout_type,
-                                 MDSPAN_IMPL_STANDARD_NAMESPACE::layout_right>);
+                                 md::layout_right>);
     static_assert(std::is_same_v<typename std::decay_t<V>::layout_type,
-                                 MDSPAN_IMPL_STANDARD_NAMESPACE::layout_right>);
+                                 md::layout_right>);
     static_assert(std::is_same_v<typename std::decay_t<W>::layout_type,
-                                 MDSPAN_IMPL_STANDARD_NAMESPACE::layout_right>);
+                                 md::layout_right>);
     static_assert(std::is_same_v<typename std::decay_t<V>::value_type, T>);
     static_assert(std::is_same_v<typename std::decay_t<W>::value_type, T>);
     impl::dot_blas<T>(
@@ -366,11 +351,7 @@ template <std::floating_point T>
 std::vector<T> eye(std::size_t n)
 {
   std::vector<T> I(n * n, 0);
-  namespace stdex
-      = MDSPAN_IMPL_STANDARD_NAMESPACE::MDSPAN_IMPL_PROPOSED_NAMESPACE;
-  MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-      T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-      Iview(I.data(), n, n);
+  md::mdspan<T, md::dextents<std::size_t, 2>> Iview(I.data(), n, n);
   for (std::size_t i = 0; i < n; ++i)
     Iview(i, i) = 1;
   return I;
@@ -381,11 +362,8 @@ std::vector<T> eye(std::size_t n)
 /// @param[in] start The row to start from. The rows before this should
 /// already be orthogonal.
 template <std::floating_point T>
-void orthogonalise(
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-        wcoeffs,
-    std::size_t start = 0)
+void orthogonalise(md::mdspan<T, md::dextents<std::size_t, 2>> wcoeffs,
+                   std::size_t start = 0)
 {
   for (std::size_t i = start; i < wcoeffs.extent(0); ++i)
   {

--- a/cpp/basix/moments.cpp
+++ b/cpp/basix/moments.cpp
@@ -7,17 +7,16 @@
 #include "finite-element.h"
 #include "math.h"
 #include "quadrature.h"
+#include "types.h"
 
 using namespace basix;
-namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
 
 namespace
 {
-namespace stdex = md::MDSPAN_IMPL_PROPOSED_NAMESPACE;
 template <typename T, std::size_t d>
 using mdspan_t = md::mdspan<T, md::dextents<std::size_t, d>>;
 template <typename T, std::size_t d>
-using mdarray_t = stdex::mdarray<T, md::dextents<std::size_t, d>>;
+using mdarray_t = mdex::mdarray<T, md::dextents<std::size_t, d>>;
 
 //----------------------------------------------------------------------------
 std::vector<int> axis_points(const cell::type celltype)

--- a/cpp/basix/polynomials.cpp
+++ b/cpp/basix/polynomials.cpp
@@ -11,13 +11,11 @@
 #include <vector>
 
 using namespace basix;
-namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
-namespace stdex = md::MDSPAN_IMPL_PROPOSED_NAMESPACE;
 
 namespace
 {
 template <typename T, std::size_t d>
-using mdarray_t = stdex::mdarray<T, md::dextents<std::size_t, d>>;
+using mdarray_t = mdex::mdarray<T, md::dextents<std::size_t, d>>;
 template <typename T, std::size_t d>
 using mdspan_t = md::mdspan<T, md::dextents<std::size_t, d>>;
 
@@ -111,11 +109,9 @@ tabulate_bernstein(cell::type celltype, int d, mdspan_t<const T, 2> x)
 
 //-----------------------------------------------------------------------------
 template <std::floating_point T>
-std::pair<std::vector<T>, std::array<std::size_t, 2>> polynomials::tabulate(
-    polynomials::type polytype, cell::type celltype, int d,
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        const T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-        x)
+std::pair<std::vector<T>, std::array<std::size_t, 2>>
+polynomials::tabulate(polynomials::type polytype, cell::type celltype, int d,
+                      md::mdspan<const T, md::dextents<std::size_t, 2>> x)
 {
   switch (polytype)
   {

--- a/cpp/basix/polynomials.h
+++ b/cpp/basix/polynomials.h
@@ -6,6 +6,7 @@
 
 #include "cell.h"
 #include "mdspan.hpp"
+#include "types.h"
 #include <array>
 #include <concepts>
 #include <utility>
@@ -32,9 +33,7 @@ enum class type
 template <std::floating_point T>
 std::pair<std::vector<T>, std::array<std::size_t, 2>>
 tabulate(polynomials::type polytype, cell::type celltype, int d,
-         MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-             const T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-             x);
+         md::mdspan<const T, md::dextents<std::size_t, 2>> x);
 
 /// @brief Dimension of a polynomial space.
 /// @param[in] polytype Polynomial type

--- a/cpp/basix/polyset.cpp
+++ b/cpp/basix/polyset.cpp
@@ -14,9 +14,6 @@
 using namespace basix;
 using namespace basix::indexing;
 
-namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
-namespace stdex = md::MDSPAN_IMPL_PROPOSED_NAMESPACE;
-
 namespace
 {
 //-----------------------------------------------------------------------------
@@ -2934,14 +2931,9 @@ void tabulate_polyset_prism_derivs(
 } // namespace
 //-----------------------------------------------------------------------------
 template <std::floating_point T>
-void polyset::tabulate(
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 3>>
-        P,
-    cell::type celltype, polyset::type ptype, int d, int n,
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        const T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-        x)
+void polyset::tabulate(md::mdspan<T, md::dextents<std::size_t, 3>> P,
+                       cell::type celltype, polyset::type ptype, int d, int n,
+                       md::mdspan<const T, md::dextents<std::size_t, 2>> x)
 {
   switch (ptype)
   {
@@ -3005,11 +2997,9 @@ void polyset::tabulate(
 }
 //-----------------------------------------------------------------------------
 template <std::floating_point T>
-std::pair<std::vector<T>, std::array<std::size_t, 3>> polyset::tabulate(
-    cell::type celltype, polyset::type ptype, int d, int n,
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        const T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-        x)
+std::pair<std::vector<T>, std::array<std::size_t, 3>>
+polyset::tabulate(cell::type celltype, polyset::type ptype, int d, int n,
+                  md::mdspan<const T, md::dextents<std::size_t, 2>> x)
 {
   std::array<std::size_t, 3> shape
       = {(std::size_t)polyset::nderivs(celltype, n),

--- a/cpp/basix/polyset.h
+++ b/cpp/basix/polyset.h
@@ -6,6 +6,7 @@
 
 #include "cell.h"
 #include "mdspan.hpp"
+#include "types.h"
 #include <array>
 #include <concepts>
 #include <utility>
@@ -179,9 +180,7 @@ enum class type
 template <std::floating_point T>
 std::pair<std::vector<T>, std::array<std::size_t, 3>>
 tabulate(cell::type celltype, polyset::type ptype, int d, int n,
-         MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-             const T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-             x);
+         md::mdspan<const T, md::dextents<std::size_t, 2>> x);
 
 /// @brief Tabulate the orthonormal polynomial basis, and derivatives,
 /// at points on the reference cell.
@@ -222,14 +221,9 @@ tabulate(cell::type celltype, polyset::type ptype, int d, int n,
 /// @param[in] x Points at which to evaluate the basis. The shape is
 /// `(number of points, geometric dimension)`.
 template <std::floating_point T>
-void tabulate(
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 3>>
-        P,
-    cell::type celltype, polyset::type ptype, int d, int n,
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        const T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-        x);
+void tabulate(md::mdspan<T, md::dextents<std::size_t, 3>> P,
+              cell::type celltype, polyset::type ptype, int d, int n,
+              md::mdspan<const T, md::dextents<std::size_t, 2>> x);
 
 /// @brief Dimension of a polynomial space
 /// @param[in] cell Cell type

--- a/cpp/basix/precompute.h
+++ b/cpp/basix/precompute.h
@@ -233,12 +233,9 @@ prepare_matrix(std::pair<std::vector<T>, std::array<std::size_t, 2>>& A)
 /// permutation
 /// @param[in] n The block size of the data
 template <typename T, typename E>
-void apply_matrix(
-    std::span<const std::size_t> v_size_t,
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        const T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-        M,
-    std::span<E> data, std::size_t offset = 0, std::size_t n = 1)
+void apply_matrix(std::span<const std::size_t> v_size_t,
+                  md::mdspan<const T, md::dextents<std::size_t, 2>> M,
+                  std::span<E> data, std::size_t offset = 0, std::size_t n = 1)
 {
   using U = typename impl::scalar_value_type_t<E>;
 
@@ -278,10 +275,8 @@ void apply_matrix(
 template <typename T, typename E>
 void apply_tranpose_matrix_right(
     std::span<const std::size_t> v_size_t,
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        const T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-        M,
-    std::span<E> data, std::size_t offset = 0, std::size_t n = 1)
+    md::mdspan<const T, md::dextents<std::size_t, 2>> M, std::span<E> data,
+    std::size_t offset = 0, std::size_t n = 1)
 {
   using U = typename impl::scalar_value_type_t<E>;
 

--- a/cpp/basix/quadrature.cpp
+++ b/cpp/basix/quadrature.cpp
@@ -14,13 +14,11 @@
 #include <vector>
 
 using namespace basix;
-namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
 
-namespace stdex = md::MDSPAN_IMPL_PROPOSED_NAMESPACE;
 template <typename T, std::size_t d>
 using mdspan_t = md::mdspan<T, md::dextents<std::size_t, d>>;
 template <typename T, std::size_t d>
-using mdarray_t = stdex::mdarray<T, md::dextents<std::size_t, d>>;
+using mdarray_t = mdex::mdarray<T, md::dextents<std::size_t, d>>;
 
 namespace
 {

--- a/cpp/basix/types.h
+++ b/cpp/basix/types.h
@@ -1,0 +1,16 @@
+// Copyright (C) 2025 Paul T. Kühner
+//
+// This file is part of DOLFINx (https://www.fenicsproject.org)
+//
+// SPDX-License-Identifier:    LGPL-3.0-or-later
+
+#include "mdspan.hpp"
+
+namespace basix
+{
+/// @private mdspan namespace
+namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
+
+/// @private mdarray namespace
+namespace mdex = MDSPAN_IMPL_STANDARD_NAMESPACE::MDSPAN_IMPL_PROPOSED_NAMESPACE;
+} // namespace basix

--- a/demo/cpp/demo_create_and_tabulate/main.cpp
+++ b/demo/cpp/demo_create_and_tabulate/main.cpp
@@ -8,13 +8,11 @@
 
 #include <basix/finite-element.h>
 #include <basix/mdspan.hpp>
+#include <basix/types.h>
 #include <iostream>
 
-namespace stdex
-    = MDSPAN_IMPL_STANDARD_NAMESPACE::MDSPAN_IMPL_PROPOSED_NAMESPACE;
 template <typename T, std::size_t d>
-using mdspan_t = MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-    T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, d>>;
+using mdspan_t = basix::md::mdspan<T, basix::md::dextents<std::size_t, d>>;
 
 using T = double;
 

--- a/demo/cpp/demo_dof_transformations/main.cpp
+++ b/demo/cpp/demo_dof_transformations/main.cpp
@@ -22,6 +22,7 @@
 
 #include <basix/finite-element.h>
 #include <basix/lattice.h>
+#include <basix/types.h>
 #include <iomanip>
 #include <iostream>
 #include <span>
@@ -182,9 +183,8 @@ int main(int argc, char* argv[])
 
     const auto [pdata, shape] = basix::lattice::create<T>(
         cell_type, 5, basix::lattice::type::equispaced, true);
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        const T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-        points(pdata.data(), shape);
+    basix::md::mdspan<const T, basix::md::dextents<std::size_t, 2>> points(
+        pdata.data(), shape);
     int num_points = points.extent(0);
 
     // If (for example) the direction of edge 2 in the physical cell

--- a/python/wrapper.cpp
+++ b/python/wrapper.cpp
@@ -34,8 +34,7 @@ using namespace nb::literals;
 using namespace basix;
 
 template <typename T, std::size_t d>
-using mdspan_t = MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-    T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, d>>;
+using mdspan_t = md::mdspan<T, md::dextents<std::size_t, d>>;
 
 namespace
 {


### PR DESCRIPTION
Addds the equivalent changes of https://github.com/FEniCS/dolfinx/pull/3642 and https://github.com/FEniCS/dolfinx/pull/3655 for the `mdpsan` functionalities to `basix`.

`Basix` also uses `mdarray`, which makes an additional namespace `mdex` necessary (due to `mdarray` being only part of the experimental namespace at this point).