### PR TITLE
Clang tidy support

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,6 @@
-Checks: "-*,performance*"
 WarningsAsErrors: "*"
 UseColor: true
 HeaderFilterRegex: '^(*mdspan\.hpp$).*'
+Checks: >
+  -*,
+  performance*

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
-Checks: ""
+Checks: "-*,performance*"
 WarningsAsErrors: "*"
 UseColor: true
 HeaderFilterRegex: '^(*mdspan\.hpp$).*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,4 @@
+Checks: ""
+WarningsAsErrors: "*"
+UseColor: true
+HeaderFilterRegex: '^(*mdspan\.hpp$).*'

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -31,6 +31,7 @@ jobs:
         run: |
           cmake -G Ninja -B build -DENABLE_CLANG_TIDY=ON .
           cmake --build build/
+          cmake --install build/
       - name: Run clang-tidy (Python)
         working-directory: python
         run: >

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -26,6 +26,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install clang-tidy ninja-build libopenblas-dev liblapack-dev
+          pip install nanobind scikit-build-core[pyproject]
       - name: Run clang-tidy (C++)
         working-directory: cpp
         run: |

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,0 +1,33 @@
+name: clang-tidy
+
+on:
+  push:
+    branches:
+      - "**"
+    tags:
+      - "v*"
+  pull_request:
+    branches:
+      - main
+  merge_group:
+    branches:
+      - main
+  workflow_dispatch:
+  # Weekly build on Mondays at 8 am
+  schedule:
+    - cron: "0 8 * * 1"
+
+jobs:
+  clang-tidy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install clang-tidy ninja-build libopenblas-dev liblapack-dev
+      - name: Run clang-tidy (C++)
+        working-directory: cpp
+        run: |
+          cmake -G Ninja -B build -DENABLE_CLANG_TIDY=ON .
+          cmake --build build/

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -31,3 +31,10 @@ jobs:
         run: |
           cmake -G Ninja -B build -DENABLE_CLANG_TIDY=ON .
           cmake --build build/
+      - name: Run clang-tidy (Python)
+        working-directory: python
+        run: >
+          pip install .
+            --no-build-isolation
+            --verbose
+            --config-settings=cmake.define.ENABLE_CLANG_TIDY=ON

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           cmake -G Ninja -B build -DENABLE_CLANG_TIDY=ON .
           cmake --build build/
-          cmake --install build/
+          sudo cmake --install build/
       - name: Run clang-tidy (Python)
         working-directory: python
         run: >

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -36,6 +36,6 @@ jobs:
         working-directory: python
         run: >
           pip install .
-            --no-build-isolation
-            --verbose
-            --config-settings=cmake.define.ENABLE_CLANG_TIDY=ON
+          --no-build-isolation
+          --verbose
+          --config-settings=cmake.define.ENABLE_CLANG_TIDY=ON

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -25,6 +25,9 @@ add_feature_info(BUILD_SHARED_LIBS BUILD_SHARED_LIBS "Build Basix with shared li
 option(INSTALL_RUNTIME_DEPENDENCIES "Include runtime dependencies in install (Windows-only)" OFF)
 add_feature_info(INSTALL_RUNTIME_DEPENDENCIES INSTALL_RUNTIME_DEPENDENCIES "Include runtime dependencies in install (Windows-only)")
 
+option(ENABLE_CLANG_TIDY "Run clang-tidy while building" OFF)
+add_feature_info(ENABLE_CLANG_TIDY ENABLE_CLANG_TIDY "Run clang-tidy while building")
+
 find_package(BLAS REQUIRED)
 find_package(LAPACK REQUIRED)
 
@@ -103,6 +106,12 @@ target_sources(basix PRIVATE
 # Configure the library
 set_target_properties(basix PROPERTIES PUBLIC_HEADER basix/finite-element.h)
 set_target_properties(basix PROPERTIES PRIVATE_HEADER "${HEADERS_basix}")
+
+if(ENABLE_CLANG_TIDY)
+  find_program(CLANG_TIDY NAMES clang-tidy REQUIRED)
+  set_target_properties(basix PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY};--config-file=${CMAKE_CURRENT_SOURCE_DIR}/../.clang-tidy")
+endif()
+
 target_include_directories(basix PUBLIC
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR};${CMAKE_CURRENT_SOURCE_DIR}>")

--- a/cpp/basix/cell.cpp
+++ b/cpp/basix/cell.cpp
@@ -538,6 +538,7 @@ std::vector<T> cell::facet_reference_volumes(cell::type cell_type)
   int tdim = topological_dimension(cell_type);
   std::vector<cell::type> facet_types = subentity_types(cell_type)[tdim - 1];
   std::vector<T> out;
+  out.reserve(facet_types.size());
   for (auto& facet_type : facet_types)
     out.push_back(cell::volume<T>(facet_type));
   return out;
@@ -633,7 +634,7 @@ cell::entity_jacobians(cell::type cell_type, std::size_t e_dim)
         J(e, k, j) = x(entity[1 + j], k) - x(entity[0], k);
   }
 
-  return {std::move(jacobians), std::move(shape)};
+  return {std::move(jacobians), shape};
 }
 //-----------------------------------------------------------------------------
 template <std::floating_point T>

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -346,7 +346,7 @@ std::vector<std::vector<FiniteElement<T>>>
 basix::tp_factors(element::family family, cell::type cell, int degree,
                   element::lagrange_variant lvariant,
                   element::dpc_variant dvariant, bool discontinuous,
-                  std::vector<int> dof_ordering)
+                  const std::vector<int>& dof_ordering)
 {
   std::vector<int> tp_dofs = tp_dof_ordering(family, cell, degree, lvariant,
                                              dvariant, discontinuous);
@@ -388,10 +388,10 @@ basix::tp_factors(element::family family, cell::type cell, int degree,
 //-----------------------------------------------------------------------------
 template std::vector<std::vector<basix::FiniteElement<float>>>
 basix::tp_factors(element::family, cell::type, int, element::lagrange_variant,
-                  element::dpc_variant, bool, std::vector<int>);
+                  element::dpc_variant, bool, const std::vector<int>&);
 template std::vector<std::vector<basix::FiniteElement<double>>>
 basix::tp_factors(element::family, cell::type, int, element::lagrange_variant,
-                  element::dpc_variant, bool, std::vector<int>);
+                  element::dpc_variant, bool, const std::vector<int>&);
 //-----------------------------------------------------------------------------
 std::vector<int> basix::tp_dof_ordering(element::family family, cell::type cell,
                                         int degree, element::lagrange_variant,

--- a/cpp/basix/finite-element.h
+++ b/cpp/basix/finite-element.h
@@ -1645,7 +1645,7 @@ template <std::floating_point T>
 std::vector<std::vector<FiniteElement<T>>>
 tp_factors(element::family family, cell::type cell, int degree,
            element::lagrange_variant lvariant, element::dpc_variant dvariant,
-           bool discontinuous, std::vector<int> dof_ordering);
+           bool discontinuous, const std::vector<int>& dof_ordering);
 
 /// Create an element with Tensor Product dof ordering
 /// @param[in] family The element family

--- a/cpp/basix/interpolation.cpp
+++ b/cpp/basix/interpolation.cpp
@@ -56,7 +56,7 @@ basix::compute_interpolation_operator(const FiniteElement<T>& element_from,
             for (std::size_t l = 0; l < npts; ++l)
               out(i + j * vs_from, k) += i_m(j, l) * tab(0, l, k, i);
 
-      return {std::move(outb), std::move(shape)};
+      return {std::move(outb), shape};
     }
     else if (vs_from == 1)
     {
@@ -70,7 +70,7 @@ basix::compute_interpolation_operator(const FiniteElement<T>& element_from,
             for (std::size_t l = 0; l < npts; ++l)
               out(k, i + j * vs_to) += i_m(k, i * npts + l) * tab(0, l, j, 0);
 
-      return {std::move(outb), std::move(shape)};
+      return {std::move(outb), shape};
     }
     else
     {
@@ -89,7 +89,7 @@ basix::compute_interpolation_operator(const FiniteElement<T>& element_from,
           for (std::size_t l = 0; l < npts; ++l)
             out(i, j) += i_m(i, k * npts + l) * tab(0, l, j, k);
 
-    return {std::move(outb), std::move(shape)};
+    return {std::move(outb), shape};
   }
 }
 //----------------------------------------------------------------------------

--- a/cpp/basix/lattice.cpp
+++ b/cpp/basix/lattice.cpp
@@ -251,7 +251,7 @@ create_quad(std::size_t n, lattice::type lattice_type, bool exterior)
       }
     }
 
-    return {std::move(xb), std::move(shape)};
+    return {std::move(xb), shape};
   }
 }
 //-----------------------------------------------------------------------------
@@ -286,7 +286,7 @@ create_hex(int n, lattice::type lattice_type, bool exterior)
       }
     }
 
-    return {std::move(xb), std::move(shape)};
+    return {std::move(xb), shape};
   }
 }
 //-----------------------------------------------------------------------------
@@ -314,7 +314,7 @@ create_tri_equispaced(std::size_t n, bool exterior)
     }
   }
 
-  return {std::move(_p), std::move(shape)};
+  return {std::move(_p), shape};
 }
 //-----------------------------------------------------------------------------
 
@@ -357,7 +357,7 @@ create_tri_warped(std::size_t n, lattice::type lattice_type, bool exterior)
     }
   }
 
-  return {std::move(_p), std::move(shape)};
+  return {std::move(_p), shape};
 }
 //-----------------------------------------------------------------------------
 template <std::floating_point T>
@@ -417,7 +417,7 @@ create_tri_isaac(std::size_t n, lattice::type lattice_type, bool exterior)
     }
   }
 
-  return {std::move(_p), std::move(shape)};
+  return {std::move(_p), shape};
 }
 //-----------------------------------------------------------------------------
 
@@ -453,7 +453,7 @@ create_tri_centroid(std::size_t n, lattice::type lattice_type, bool exterior)
     }
   }
 
-  return {std::move(_p), std::move(shape)};
+  return {std::move(_p), shape};
 }
 //-----------------------------------------------------------------------------
 template <std::floating_point T>
@@ -520,7 +520,7 @@ create_tet_equispaced(std::size_t n, bool exterior)
     }
   }
 
-  return {std::move(xb), std::move(shape)};
+  return {std::move(xb), shape};
 }
 //-----------------------------------------------------------------------------
 
@@ -554,7 +554,7 @@ create_tet_isaac(std::size_t n, lattice::type lattice_type, bool exterior)
     }
   }
 
-  return {std::move(xb), std::move(shape)};
+  return {std::move(xb), shape};
 }
 //-----------------------------------------------------------------------------
 template <std::floating_point T>
@@ -608,7 +608,7 @@ create_tet_warped(std::size_t n, lattice::type lattice_type, bool exterior)
     }
   }
 
-  return {std::move(xb), std::move(shape)};
+  return {std::move(xb), shape};
 }
 //-----------------------------------------------------------------------------
 
@@ -650,7 +650,7 @@ create_tet_centroid(std::size_t n, lattice::type lattice_type, bool exterior)
     }
   }
 
-  return {std::move(xb), std::move(shape)};
+  return {std::move(xb), shape};
 }
 //-----------------------------------------------------------------------------
 template <std::floating_point T>
@@ -726,7 +726,7 @@ create_prism(std::size_t n, lattice::type lattice_type, bool exterior,
       }
     }
 
-    return {std::move(xb), std::move(shape)};
+    return {std::move(xb), shape};
   }
 }
 //-----------------------------------------------------------------------------
@@ -758,7 +758,7 @@ create_pyramid_equispaced(int n, bool exterior)
     }
   }
 
-  return {std::move(xb), std::move(shape)};
+  return {std::move(xb), shape};
 }
 //-----------------------------------------------------------------------------
 template <std::floating_point T>

--- a/cpp/basix/polynomials.cpp
+++ b/cpp/basix/polynomials.cpp
@@ -102,7 +102,7 @@ tabulate_bernstein(cell::type celltype, int d, mdspan_t<const T, 2> x)
     ++n;
   }
 
-  return {std::move(values_b), std::move(shape)};
+  return {std::move(values_b), shape};
 }
 //-----------------------------------------------------------------------------
 } // namespace

--- a/cpp/basix/polyset.cpp
+++ b/cpp/basix/polyset.cpp
@@ -3007,7 +3007,7 @@ polyset::tabulate(cell::type celltype, polyset::type ptype, int d, int n,
   std::vector<T> P(shape[0] * shape[1] * shape[2]);
   md::mdspan<T, md::dextents<std::size_t, 3>> _P(P.data(), shape);
   polyset::tabulate(_P, celltype, ptype, d, n, x);
-  return {std::move(P), std::move(shape)};
+  return {std::move(P), shape};
 }
 //-----------------------------------------------------------------------------
 /// @cond

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -22,6 +22,14 @@ endif()
 
 find_package(Python COMPONENTS Interpreter Development.Module REQUIRED)
 
+# Options
+include(FeatureSummary)
+
+option(ENABLE_CLANG_TIDY "Run clang-tidy while building" OFF)
+add_feature_info(ENABLE_CLANG_TIDY ENABLE_CLANG_TIDY "Run clang-tidy while building")
+
+feature_summary(WHAT ALL)
+
 # Detect the installed nanobind package and import it into CMake
 execute_process(
   COMMAND "${Python_EXECUTABLE}" -c "import nanobind; print(nanobind.cmake_dir())"
@@ -32,6 +40,12 @@ find_package(nanobind CONFIG REQUIRED)
 # Create the binding library
 nanobind_add_module(_basixcpp NB_SUPPRESS_WARNINGS wrapper.cpp)
 target_compile_definitions(_basixcpp PRIVATE cxx_std_20)
+
+if(ENABLE_CLANG_TIDY)
+  find_program(CLANG_TIDY NAMES clang-tidy REQUIRED)
+  set_target_properties(_basixcpp PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY};--config-file=${CMAKE_CURRENT_SOURCE_DIR}/../.clang-tidy")
+endif()
+
 target_link_libraries(_basixcpp PRIVATE Basix::basix)
 
 # Add strict compiler flags

--- a/python/wrapper.cpp
+++ b/python/wrapper.cpp
@@ -84,7 +84,7 @@ auto as_nbarrayp(std::pair<V, std::array<std::size_t, U>>&& x)
 }
 
 template <typename T>
-void declare_float(nb::module_& m, std::string type)
+void declare_float(nb::module_& m, const std::string& type)
 {
   std::string name = "FiniteElement_" + type;
   nb::class_<FiniteElement<T>>(m, name.c_str())
@@ -99,7 +99,7 @@ void declare_float(nb::module_& m, std::string type)
       .def("hash", &FiniteElement<T>::hash)
       .def("permute_subentity_closure",
            [](const FiniteElement<T>& self,
-              nb::ndarray<std::int32_t, nb::ndim<1>, nb::c_contig> d,
+              const nb::ndarray<std::int32_t, nb::ndim<1>, nb::c_contig>& d,
               std::uint32_t entity_info, cell::type entity_type)
            {
              std::span<std::int32_t> _d(d.data(), d.shape(0));
@@ -107,7 +107,7 @@ void declare_float(nb::module_& m, std::string type)
            })
       .def("permute_subentity_closure",
            [](const FiniteElement<T>& self,
-              nb::ndarray<std::int32_t, nb::ndim<1>, nb::c_contig> d,
+              const nb::ndarray<std::int32_t, nb::ndim<1>, nb::c_contig>& d,
               std::uint32_t cell_info, cell::type entity_type, int entity_index)
            {
              std::span<std::int32_t> _d(d.data(), d.shape(0));
@@ -115,7 +115,7 @@ void declare_float(nb::module_& m, std::string type)
            })
       .def("permute_subentity_closure_inv",
            [](const FiniteElement<T>& self,
-              nb::ndarray<std::int32_t, nb::ndim<1>, nb::c_contig> d,
+              const nb::ndarray<std::int32_t, nb::ndim<1>, nb::c_contig>& d,
               std::uint32_t entity_info, cell::type entity_type)
            {
              std::span<std::int32_t> _d(d.data(), d.shape(0));
@@ -123,7 +123,7 @@ void declare_float(nb::module_& m, std::string type)
            })
       .def("permute_subentity_closure_inv",
            [](const FiniteElement<T>& self,
-              nb::ndarray<std::int32_t, nb::ndim<1>, nb::c_contig> d,
+              const nb::ndarray<std::int32_t, nb::ndim<1>, nb::c_contig>& d,
               std::uint32_t cell_info, cell::type entity_type, int entity_index)
            {
              std::span<std::int32_t> _d(d.data(), d.shape(0));
@@ -470,7 +470,7 @@ NB_MODULE(_basixcpp, m)
 
   m.def("tabulate_polynomials",
         [](polynomials::type polytype, cell::type celltype, int d,
-           nb::ndarray<const double, nb::ndim<2>, nb::c_contig> x)
+           const nb::ndarray<const double, nb::ndim<2>, nb::c_contig>& x)
         {
           mdspan_t<const double, 2> _x(x.data(), x.shape(0), x.shape(1));
           return as_nbarrayp(polynomials::tabulate(polytype, celltype, d, _x));
@@ -639,7 +639,7 @@ NB_MODULE(_basixcpp, m)
         [](element::family family_name, cell::type cell, int degree,
            element::lagrange_variant lagrange_variant,
            element::dpc_variant dpc_variant, bool discontinuous,
-           std::vector<int> dof_ordering, char dtype)
+           const std::vector<int>& dof_ordering, char dtype)
             -> std::variant<std::vector<std::vector<FiniteElement<float>>>,
                             std::vector<std::vector<FiniteElement<double>>>>
         {


### PR DESCRIPTION
Introduces `clang-tidy` support for the `cpp/` build on the `performance*` clang-tidy checks to showcase its capabilities.

If accepted, this can be equivalently incorporated into the `python/` build.

The checks (configured in the `.clang-tidy`) can be further extended or fine tuned, most interesting (besides the activated `performance*`)  are probably `modernize*`, `cppcoreguidelines*` and/or `bugprone*` for the FEniCS project - see https://clang.llvm.org/extra/clang-tidy/checks/list.html