### PR TITLE
Pin scipy in dolfinx tests CI run

### DIFF
--- a/.github/workflows/dolfinx-tests.yml
+++ b/.github/workflows/dolfinx-tests.yml
@@ -37,6 +37,10 @@ jobs:
       OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
 
     steps:
+      # Remove once pin in dolfinx gets removed
+      - name: Pin scipy
+        run: pip install scipy==1.15.3
+
       - uses: actions/checkout@v4
       - name: Install Basix
         run: |


### PR DESCRIPTION
A bit hacky, but resolves the pinning issue with scipy for the dolfinx CI, see https://github.com/FEniCS/dolfinx/pull/3761