### PR TITLE
Revert ubuntu-latest for pythonapp

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Documentation as it currently is can only build on ubuntu 22.04
Yet another reason to go over to sphinx and standardized documentation.