### PR TITLE
Fix: remove PETSc stub for tmp. typing fix

### DIFF
--- a/.github/workflows/dolfinx-tests.yml
+++ b/.github/workflows/dolfinx-tests.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           path: ./dolfinx
           repository: FEniCS/dolfinx
-          ref: main
+          ref: schnellerhase/mypy-non-venv
       - name: Get DOLFINx
         if: github.event_name == 'workflow_dispatch'
         uses: actions/checkout@v6

--- a/.github/workflows/dolfinx-tests.yml
+++ b/.github/workflows/dolfinx-tests.yml
@@ -83,6 +83,8 @@ jobs:
           python3 -m pip install scikit-build-core
           python3 -m scikit_build_core.build requires | python3 -c "import sys, json; print(' '.join(json.load(sys.stdin)))" | xargs pip install
           python3 -m pip -v install --break-system-packages --check-build-dependencies --no-build-isolation dolfinx/python/
+      - name: Workaround (dolfinx typing limitation)
+        run: rm /dolfinx-env/lib64/python3.12/site-packages/petsc4py/PETSc.pyi
       - name: Run mypy checks
         run: |
           python3 -m pip install --break-system-packages mypy

--- a/.github/workflows/dolfinx-tests.yml
+++ b/.github/workflows/dolfinx-tests.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           path: ./dolfinx
           repository: FEniCS/dolfinx
-          ref: schnellerhase/mypy-non-venv
+          ref: main
       - name: Get DOLFINx
         if: github.event_name == 'workflow_dispatch'
         uses: actions/checkout@v6


### PR DESCRIPTION
Pulls in workaround from https://github.com/fenics-dolfiny/dolfiny/commit/a33092ca17ca752258fd5ad195638b6158938813 for dolfinx not having caught up with new PETSc stubs.

(The underlying issue why this is not a problem in doflinx is that this runs the mypy check without venv on a full blown PETSc aware install - dolfinx is currently missing this)

Ref https://github.com/FEniCS/dolfinx/issues/4059#issuecomment-4287461055.

Depends on https://github.com/FEniCS/dolfinx/pull/4216.

(To make PETSc aware typing checks work here, we need https://github.com/FEniCS/dolfinx/pull/4095) 