### PR TITLE
Add test that blocked quadrature elements have sub elements

### DIFF
--- a/test/test_ufl_wrapper.py
+++ b/test/test_ufl_wrapper.py
@@ -289,3 +289,13 @@ def test_dof_ordering():
 
     for i, j in enumerate([1, 2, 0]):
         assert np.allclose(table[:, i], table2[:, j])
+
+
+@pytest.mark.parametrize("e", [
+    basix.ufl.element(basix.ElementFamily.P, basix.CellType.triangle, 1, shape=(4, )),
+    basix.ufl.element(basix.ElementFamily.P, basix.CellType.triangle, 1, shape=(2, 2)),
+    basix.ufl.quadrature_element(basix.CellType.triangle, (4, ), degree=2),
+    basix.ufl.quadrature_element(basix.CellType.triangle, (2, 2), degree=2),
+])
+def test_blocked_elements(e):
+    assert len(e.sub_elements) == 4

--- a/test/test_ufl_wrapper.py
+++ b/test/test_ufl_wrapper.py
@@ -291,11 +291,14 @@ def test_dof_ordering():
         assert np.allclose(table[:, i], table2[:, j])
 
 
-@pytest.mark.parametrize("e", [
-    basix.ufl.element(basix.ElementFamily.P, basix.CellType.triangle, 1, shape=(4, )),
-    basix.ufl.element(basix.ElementFamily.P, basix.CellType.triangle, 1, shape=(2, 2)),
-    basix.ufl.quadrature_element(basix.CellType.triangle, (4, ), degree=2),
-    basix.ufl.quadrature_element(basix.CellType.triangle, (2, 2), degree=2),
-])
+@pytest.mark.parametrize(
+    "e",
+    [
+        basix.ufl.element(basix.ElementFamily.P, basix.CellType.triangle, 1, shape=(4,)),
+        basix.ufl.element(basix.ElementFamily.P, basix.CellType.triangle, 1, shape=(2, 2)),
+        basix.ufl.quadrature_element(basix.CellType.triangle, (4,), degree=2),
+        basix.ufl.quadrature_element(basix.CellType.triangle, (2, 2), degree=2),
+    ],
+)
 def test_blocked_elements(e):
     assert len(e.sub_elements) == 4


### PR DESCRIPTION
Looks like #896 was fixed at some point. This PR adds a test to confirm that #896 is resolved.

Close #896.