### PR TITLE
Fix: cross-compile of wheels

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -113,42 +113,19 @@ else()
 endif()
 
 # and the nanobind typing stubs.
-if (WIN32)
-  # On Windows we cannot import basix._basixcpp without installing the package
-  # alongside its external dlls.
+# We cannot rely on import without installing the package for cross compilation of wheels.
 
-  # This *must* be called prior to nanobind_add_stub
-  install(TARGETS _basixcpp LIBRARY DESTINATION basix)
-  # nanobind automatically installs into ${CMAKE_INSTALL_PREFIX} in
-  # INSTALL_TIME mode.
-  # DEPENDS is redundant in INSTALL_TIME mode - _basixcpp must be installed.
-  nanobind_add_stub(
-    _basixcpp_stub
-    MODULE basix._basixcpp
-    INSTALL_TIME
-    MARKER_FILE basix/py.typed
-    VERBOSE
-    OUTPUT
-      basix/_basixcpp.pyi
-  )
-else()
-  # On UNIX-like systems we can import the cpp compiled module before
-  # installing and rely on dynamic linking at import time.
-  nanobind_add_stub(
-    _basixcpp_stub
-    MODULE _basixcpp
-    PYTHON_PATH $<TARGET_FILE_DIR:_basixcpp>
-    DEPENDS _basixcpp
-    MARKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/basix/py.typed
-    VERBOSE
-    OUTPUT
-      _basixcpp.pyi
-  )
-
-  install(TARGETS _basixcpp LIBRARY DESTINATION basix)
-  install(FILES
-    ${CMAKE_CURRENT_SOURCE_DIR}/basix/py.typed
-    ${CMAKE_CURRENT_BINARY_DIR}/_basixcpp.pyi
-    DESTINATION basix
-  )
-endif()
+# This *must* be called prior to nanobind_add_stub
+install(TARGETS _basixcpp LIBRARY DESTINATION basix)
+# nanobind automatically installs into ${CMAKE_INSTALL_PREFIX} in
+# INSTALL_TIME mode.
+# DEPENDS is redundant in INSTALL_TIME mode - _basixcpp must be installed.
+nanobind_add_stub(
+  _basixcpp_stub
+  MODULE basix._basixcpp
+  INSTALL_TIME
+  MARKER_FILE basix/py.typed
+  VERBOSE
+  OUTPUT
+    basix/_basixcpp.pyi
+)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -114,11 +114,9 @@ endif()
 
 # and the nanobind typing stubs.
 # We cannot rely on import without installing the package for cross compilation of wheels.
-
 # This *must* be called prior to nanobind_add_stub
 install(TARGETS _basixcpp LIBRARY DESTINATION basix)
-# nanobind automatically installs into ${CMAKE_INSTALL_PREFIX} in
-# INSTALL_TIME mode.
+
 # DEPENDS is redundant in INSTALL_TIME mode - _basixcpp must be installed.
 nanobind_add_stub(
   _basixcpp_stub
@@ -127,5 +125,5 @@ nanobind_add_stub(
   MARKER_FILE basix/py.typed
   VERBOSE
   OUTPUT
-    basix/_basixcpp.pyi
+    ${CMAKE_INSTALL_PREFIX}/basix/_basixcpp.pyi
 )

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -113,11 +113,9 @@ else()
 endif()
 
 # and the nanobind typing stubs.
-# We cannot rely on import without installing the package for cross compilation of wheels.
-# This *must* be called prior to nanobind_add_stub
 install(TARGETS _basixcpp LIBRARY DESTINATION basix)
 
-# DEPENDS is redundant in INSTALL_TIME mode - _basixcpp must be installed.
+# Note: install time mode required for wheel cross compilation.
 nanobind_add_stub(
   _basixcpp_stub
   MODULE basix._basixcpp


### PR DESCRIPTION
Build-wheels is broken on `main` - https://github.com/FEniCS/basix/actions/runs/25927919086. The problem is cross-compilation of the nanobind stubs (in build time mode) - the python architecture of the `nanobind stubgen` invocation and the target wheel architecture do not necessarily align. In this case `nanobind` will fail in install time mode.

Changes to all stubs being generated at install time.

Tested `build-wheels` at https://github.com/FEniCS/basix/actions/runs/25930015175.

Ref https://github.com/FEniCS/basix/pull/992.