### PR TITLE
Move to native macOS wheel builds

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-14, macos-15, windows-2025]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-26, windows-2025]
 
     steps:
       - uses: actions/checkout@v6
@@ -48,7 +48,7 @@ jobs:
           ref: ${{ github.event.inputs.basix_ref }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.3.1
+        uses: pypa/cibuildwheel@v3.4.1
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-26, windows-2025]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-26, macos-26-intel, windows-2025]
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -46,8 +46,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04]
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        os: [ubuntu-22.04]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -46,8 +46,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        os: [ubuntu-24.04]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,8 @@ build-frontend = { name = "pip", args = [
 build = [
     "cp3{10,11,12,13}-manylinux_x86_64",
     "cp3{10,11,12,13}-manylinux_aarch64",
-    "cp3{10,11,12,13}-macosx_x86_64",
-    "cp3{10,11,12,13}-macosx_arm64",
+    "cp3{14}-macosx_x86_64",
+    "cp3{14}-macosx_arm64",
     "cp3{10,11,12,13}-win_amd64",
 ]
 test-command = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,8 @@ build-frontend = { name = "pip", args = [
 build = [
     "cp3{10,11,12,13}-manylinux_x86_64",
     "cp3{10,11,12,13}-manylinux_aarch64",
-    "cp3{14}-macosx_x86_64",
-    "cp3{14}-macosx_arm64",
+    "cp314-macosx_x86_64",
+    "cp314-macosx_arm64",
     "cp3{10,11,12,13}-win_amd64",
 ]
 test-command = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "fenics-basix"
 version = "0.11.0.dev0"
 description = "Basix Python interface"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 license = { file = "LICENSE" }
 authors = [
     { email = "fenics-steering-council@googlegroups.com" },
@@ -38,11 +38,11 @@ build-frontend = { name = "pip", args = [
     "--config-settings=wheel.py-api=cp312",
 ] }
 build = [
-    "cp3{10,11,12,13}-manylinux_x86_64",
-    "cp3{10,11,12,13}-manylinux_aarch64",
-    "cp314-macosx_x86_64",
-    "cp314-macosx_arm64",
-    "cp3{10,11,12,13}-win_amd64",
+    "cp3{11,12,13,14}-manylinux_x86_64",
+    "cp3{11,12,13,14}-manylinux_aarch64",
+    "cp3{11,12,13,14}-macosx_x86_64",
+    "cp3{11,12,13,14}-macosx_arm64",
+    "cp3{11,12,13,14}-win_amd64",
 ]
 test-command = [
     "cmake -G Ninja -DPython3_EXECUTABLE=$(which python) -B build-dir -S {project}/test/test_cmake",
@@ -64,7 +64,7 @@ build-frontend = { name = "pip", args = [
 test-command = ["python -m pytest -n auto --durations 20 {project}/test/"]
 
 [[tool.cibuildwheel.overrides]]
-select = "cp3{12,13}-win_amd64"
+select = "cp3{12,13,14}-win_amd64"
 repair-wheel-command = [
     "copy {wheel} {dest_dir}",
     "pipx run abi3audit --verbose --strict --report {wheel}",
@@ -77,7 +77,7 @@ archs = [
 before-build = "yum -y update && yum install -y epel-release && yum install -y openblas-devel ninja-build"
 
 [[tool.cibuildwheel.overrides]]
-select = "cp3{12,13}-manylinux*"
+select = "cp3{12,13,14}-manylinux*"
 repair-wheel-command = [
     "auditwheel repair -w {dest_dir} {wheel}",
     "pipx run abi3audit --verbose --strict --report {wheel}",
@@ -86,12 +86,11 @@ repair-wheel-command = [
 [tool.cibuildwheel.macos]
 environment = { "MACOSX_DEPLOYMENT_TARGET" = "10.14" }
 archs = [
-    "x86_64",
-    "arm64",
-] # Forces x86_64 build on arm64 runner using cross-compilation (and vice-versa).
+    "native",
+]
 
 [[tool.cibuildwheel.overrides]]
-select = "cp3{12,13}-macosx*"
+select = "cp3{12,13,14}-macosx*"
 repair-wheel-command = [
     "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}",
     "pipx run abi3audit --verbose --strict --report {wheel}",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,8 +52,6 @@ test-command = [
 ]
 test-requires = ["pytest-xdist"]
 test-extras = ["test"]
-# llvmlite (numba) not being built for x86_64 on macOS
-test-skip = "*-macosx_x86_64"
 
 [tool.cibuildwheel.windows]
 build-frontend = { name = "pip", args = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,6 @@ archs = [
     "x86_64",
     "arm64",
 ] # Forces x86_64 build on arm64 runner using cross-compilation (and vice-versa).
-before-build = "export HOMEBREW_AUTO_UPDATING=0 && brew update && brew install ninja"
 
 [[tool.cibuildwheel.overrides]]
 select = "cp3{12,13}-macosx*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,8 @@ test-command = [
 ]
 test-requires = ["pytest-xdist"]
 test-extras = ["test"]
+# llvmlite (numba) not being built for x86_64 on macOS
+test-skip = "*-macosx_x86_64"
 
 [tool.cibuildwheel.windows]
 build-frontend = { name = "pip", args = [


### PR DESCRIPTION
https://github.com/FEniCS/basix/pull/1011 discovered that building x86-64 wheels via Rosetta emulation on aarch64 runners leads to the nanobind stubgen process failing due to the x86-64 wheel not being loadable. I cannot recreate this locally - `arch -x86_64 pip install .` works perfectly. This means it is probably a `cibuildwheel` or runner configuration issue.

That said, `macos-14` runners will shortly be deprecated and GitHub provides aarch64 `macos-26` and x86-64 `macos-26-intel` runners which bypass this issue.

This PR:
- Bumps minimum Python to 3.11.
- Bumps builders to `macos-26` and `macos-26-intel` and builds/tests native wheels.

