### PR TITLE
Add Windows 11 ARM wheel build

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-26, macos-26-intel, windows-2025]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-26, macos-26-intel, windows-11-arm, windows-2025]
 
     steps:
       - uses: actions/checkout@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ build = [
     "cp3{11,12,13,14}-macosx_x86_64",
     "cp3{11,12,13,14}-macosx_arm64",
     "cp3{11,12,13,14}-win_amd64",
+    "cp3{11,12,13,14}-win_arm64",
 ]
 test-command = [
     "cmake -G Ninja -DPython3_EXECUTABLE=$(which python) -B build-dir -S {project}/test/test_cmake",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ test-command = [
 ]
 test-requires = ["pytest-xdist"]
 test-extras = ["test"]
-# llvmlite (numba) not being built for x86_64 on macOS
+# llvmlite (numba) not being built for these platforms
 test-skip = "*-macosx_x86_64 *-win_arm64"
 
 [tool.cibuildwheel.windows]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ test-command = [
 test-requires = ["pytest-xdist"]
 test-extras = ["test"]
 # llvmlite (numba) not being built for x86_64 on macOS
-test-skip = "*-macosx_x86_64"
+test-skip = "*-macosx_x86_64 *-win_arm64"
 
 [tool.cibuildwheel.windows]
 build-frontend = { name = "pip", args = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
     { email = "fenics-steering-council@googlegroups.com" },
     { name = "FEniCS Steering Council" },
 ]
-dependencies = ["numpy>=1.21"]
+dependencies = ["numpy>=2"]
 
 [project.urls]
 homepage = "https://fenicsproject.org"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ build-frontend = { name = "pip", args = [
 test-command = ["python -m pytest -n auto --durations 20 {project}/test/"]
 
 [[tool.cibuildwheel.overrides]]
-select = "cp3{12,13,14}-win_amd64"
+select = "cp3{12,13,14}-win*"
 repair-wheel-command = [
     "copy {wheel} {dest_dir}",
     "pipx run abi3audit --verbose --strict --report {wheel}",


### PR DESCRIPTION
Also pins `numpy>=2` rather than the now ancient and untested `numpy>=1.21`.