### PR TITLE
Module level pytest skip for numba

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-26, macos-26-intel, windows-2025]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-26, macos-26-intel, windows-11-arm, windows-2025]
 
     steps:
       - uses: actions/checkout@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,8 @@ testpaths = ["test"]
 wheel.packages = ["python/basix"]
 
 [tool.cibuildwheel]
-build-frontend = { name = "pip", args = [
-    "--config-settings=wheel.py-api=cp312",
+build-frontend = { name = "build", args = [
+    "-Cwheel.py-api=cp312",
 ] }
 build = [
     "cp3{11,12,13,14}-manylinux_x86_64",
@@ -63,25 +63,11 @@ build-frontend = { name = "pip", args = [
 ] }
 test-command = ["python -m pytest -n auto --durations 20 {project}/test/"]
 
-[[tool.cibuildwheel.overrides]]
-select = "cp3{12,13,14}-win_*"
-repair-wheel-command = [
-    "copy {wheel} {dest_dir}",
-    "pipx run abi3audit --verbose --strict --report {wheel}",
-]
-
 [tool.cibuildwheel.linux]
 archs = [
     "native"
 ]
 before-build = "yum -y update && yum install -y epel-release && yum install -y openblas-devel ninja-build"
-
-[[tool.cibuildwheel.overrides]]
-select = "cp3{12,13,14}-manylinux*"
-repair-wheel-command = [
-    "auditwheel repair -w {dest_dir} {wheel}",
-    "pipx run abi3audit --verbose --strict --report {wheel}",
-]
 
 [tool.cibuildwheel.macos]
 environment = { "MACOSX_DEPLOYMENT_TARGET" = "10.14" }
@@ -89,16 +75,7 @@ archs = [
     "native",
 ]
 
-[[tool.cibuildwheel.overrides]]
-select = "cp3{12,13,14}-macosx*"
-repair-wheel-command = [
-    "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}",
-    "pipx run abi3audit --verbose --strict --report {wheel}",
-]
-
-# llvmlite (numba) is not built for x86_64 on macOS or arm64 on Windows,
-# so fall back to a numba-free test extras set; test_numba.py module-skips
-# itself.
+# llvmlite (numba) is not built for x86_64 on macOS or arm64 on Windows.
 [[tool.cibuildwheel.overrides]]
 select = ["*-macosx_x86_64", "*-win_arm64"]
 test-extras = ["test-no-numba"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ build = [
     "cp3{11,12,13,14}-macosx_x86_64",
     "cp3{11,12,13,14}-macosx_arm64",
     "cp3{11,12,13,14}-win_amd64",
+    "cp3{11,12,13,14}-win_arm64",
 ]
 test-command = [
     "cmake -G Ninja -DPython3_EXECUTABLE=$(which python) -B build-dir -S {project}/test/test_cmake",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ test-command = [
 ]
 test-requires = ["pytest-xdist"]
 test-extras = ["test"]
-# llvmlite (numba) not being built for x86_64 on macOS
+# llvmlite (numba) not being built for these platforms
 test-skip = "*-macosx_x86_64 *-win_arm64"
 
 [tool.cibuildwheel.windows]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ docs = ["markdown", "pylit3", "pyyaml", "sphinx", "sphinx_rtd_theme"]
 lint = ["ruff"]
 optional = ["numba", "fenics-ufl@git+https://github.com/fenics/ufl"]
 test = ["pytest", "sympy", "scipy", "matplotlib", "fenics-basix[optional]"]
+test-no-numba = ["pytest", "sympy", "scipy", "matplotlib", "fenics-ufl@git+https://github.com/fenics/ufl"]
 ci = ["mypy", "pytest-xdist", "fenics-basix[docs,lint,test,optional]"]
 
 [tool.pytest.ini_options]
@@ -43,6 +44,7 @@ build = [
     "cp3{11,12,13,14}-macosx_x86_64",
     "cp3{11,12,13,14}-macosx_arm64",
     "cp3{11,12,13,14}-win_amd64",
+    "cp3{11,12,13,14}-win_arm64",
 ]
 test-command = [
     "cmake -G Ninja -DPython3_EXECUTABLE=$(which python) -B build-dir -S {project}/test/test_cmake",
@@ -52,8 +54,6 @@ test-command = [
 ]
 test-requires = ["pytest-xdist"]
 test-extras = ["test"]
-# llvmlite (numba) not being built for x86_64 on macOS
-test-skip = "*-macosx_x86_64"
 
 [tool.cibuildwheel.windows]
 build-frontend = { name = "pip", args = [
@@ -64,7 +64,7 @@ build-frontend = { name = "pip", args = [
 test-command = ["python -m pytest -n auto --durations 20 {project}/test/"]
 
 [[tool.cibuildwheel.overrides]]
-select = "cp3{12,13,14}-win_amd64"
+select = "cp3{12,13,14}-win_*"
 repair-wheel-command = [
     "copy {wheel} {dest_dir}",
     "pipx run abi3audit --verbose --strict --report {wheel}",
@@ -95,6 +95,13 @@ repair-wheel-command = [
     "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}",
     "pipx run abi3audit --verbose --strict --report {wheel}",
 ]
+
+# llvmlite (numba) is not built for x86_64 on macOS or arm64 on Windows,
+# so fall back to a numba-free test extras set; test_numba.py module-skips
+# itself.
+[[tool.cibuildwheel.overrides]]
+select = ["*-macosx_x86_64", "*-win_arm64"]
+test-extras = ["test-no-numba"]
 
 [tool.mypy]
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,10 +56,10 @@ test-requires = ["pytest-xdist"]
 test-extras = ["test"]
 
 [tool.cibuildwheel.windows]
-build-frontend = { name = "pip", args = [
-    "--config-settings=wheel.py-api=cp312",
-    "--config-settings=cmake.args=-DINSTALL_RUNTIME_DEPENDENCIES=ON",
-    "--config-settings=cmake.args=-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake",
+build-frontend = { name = "build", args = [
+    "-Cwheel.py-api=cp312",
+    "-Ccmake.args=-DINSTALL_RUNTIME_DEPENDENCIES=ON",
+    "-Ccmake.args=-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake",
 ] }
 test-command = ["python -m pytest -n auto --durations 20 {project}/test/"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ test-command = [
 test-requires = ["pytest-xdist"]
 test-extras = ["test"]
 # llvmlite (numba) not being built for x86_64 on macOS
-test-skip = "*-macosx_x86_64"
+test-skip = "*-macosx_x86_64 *-win_arm64"
 
 [tool.cibuildwheel.windows]
 build-frontend = { name = "pip", args = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
     { email = "fenics-steering-council@googlegroups.com" },
     { name = "FEniCS Steering Council" },
 ]
-dependencies = ["numpy>=1.21"]
+dependencies = ["numpy>=2"]
 
 [project.urls]
 homepage = "https://fenicsproject.org"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ build-frontend = { name = "pip", args = [
 test-command = ["python -m pytest -n auto --durations 20 {project}/test/"]
 
 [[tool.cibuildwheel.overrides]]
-select = "cp3{12,13,14}-win_amd64"
+select = "cp3{12,13,14}-win*"
 repair-wheel-command = [
     "copy {wheel} {dest_dir}",
     "pipx run abi3audit --verbose --strict --report {wheel}",

--- a/test/test_numba.py
+++ b/test/test_numba.py
@@ -12,10 +12,10 @@ from basix import CellType
 
 pytest.importorskip("numba")
 
-from numba.core import types  # noqa: E402
-from numba.typed import Dict  # noqa: E402
+from numba.core import types
+from numba.typed import Dict
 
-from basix import numba_helpers  # noqa: E402
+from basix import numba_helpers
 
 
 @pytest.mark.parametrize(

--- a/test/test_numba.py
+++ b/test/test_numba.py
@@ -10,6 +10,13 @@ import pytest
 import basix
 from basix import CellType
 
+pytest.importorskip("numba")
+
+from numba.core import types  # noqa: E402
+from numba.typed import Dict  # noqa: E402
+
+from basix import numba_helpers  # noqa: E402
+
 
 @pytest.mark.parametrize(
     "cell",
@@ -30,15 +37,6 @@ from basix import CellType
 )
 @pytest.mark.parametrize("block_size", [1, 2, 4])
 def test_dof_transformations(cell, element, degree, element_args, block_size):
-    try:
-        import numba  # noqa: F401
-    except ImportError:
-        pytest.skip("Numba must be installed to run this test.")
-
-    from numba.core import types
-    from numba.typed import Dict
-
-    from basix import numba_helpers
 
     transform_functions = {
         CellType.triangle: numba_helpers.T_apply_triangle,
@@ -96,16 +94,6 @@ def test_dof_transformations(cell, element, degree, element_args, block_size):
 )
 @pytest.mark.parametrize("block_size", [1, 2, 4])
 def test_dof_transformations_to_transpose(cell, element, degree, block_size, element_args):
-    try:
-        import numba  # noqa: F401
-    except ImportError:
-        pytest.skip("Numba must be installed to run this test.")
-
-    from numba.core import types
-    from numba.typed import Dict
-
-    from basix import numba_helpers
-
     transform_functions = {
         CellType.triangle: numba_helpers.Tt_apply_right_triangle,
         CellType.quadrilateral: numba_helpers.Tt_apply_right_quadrilateral,


### PR DESCRIPTION
If it doesn't need to use numba, it can be elsewhere.

This will allow the majority of tests to run on platforms without numba/llvmlite wheels, for example, x86-64 macOS and ARM Windows. Wheel build tests for non-numba platforms are re-enabled.

I also removed manual calls to `abi3audit` - `cibuildwheel` does this automatically now.
