### PR TITLE
Ruff fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ ignore_missing_imports = true
 [tool.ruff]
 line-length = 100
 indent-width = 4
-extend-exclude = ["_basixcpp.pyi", "./joss", "make_html.py"]
+extend-exclude = ["./joss"]
 
 [tool.ruff.format]
 docstring-code-format = true

--- a/python/basix/__init__.py
+++ b/python/basix/__init__.py
@@ -12,8 +12,10 @@ functionality can be used via this Python interface.
 # Template placeholder for injecting Windows dll directories in CI
 # WINDOWSDLL
 
-from basix._basixcpp import MapType
+from importlib.metadata import metadata
+
 from basix import cell, finite_element, lattice, polynomials, quadrature, sobolev_spaces
+from basix._basixcpp import MapType
 from basix.cell import CellType, geometry, topology
 from basix.finite_element import (
     DPCVariant,
@@ -32,17 +34,9 @@ from basix.quadrature import QuadratureType, make_quadrature
 from basix.sobolev_spaces import SobolevSpace
 from basix.utils import index
 
-from importlib.metadata import metadata
-
 __version__ = metadata("fenics-basix")["Version"]
 
 __all__ = [
-    "cell",
-    "finite_element",
-    "lattice",
-    "polynomials",
-    "quadrature",
-    "sobolev_spaces",
     "CellType",
     "DPCVariant",
     "ElementFamily",
@@ -55,16 +49,22 @@ __all__ = [
     "QuadratureType",
     "SobolevSpace",
     "__version__",
-    "create_lattice",
-    "geometry",
-    "index",
-    "polyset_restriction",
-    "polyset_superset",
-    "tabulate_polynomials",
-    "topology",
+    "cell",
+    "compute_interpolation_operator",
     "create_custom_element",
     "create_element",
+    "create_lattice",
     "create_tp_element",
+    "finite_element",
+    "geometry",
+    "index",
+    "lattice",
     "make_quadrature",
-    "compute_interpolation_operator",
+    "polynomials",
+    "polyset_restriction",
+    "polyset_superset",
+    "quadrature",
+    "sobolev_spaces",
+    "tabulate_polynomials",
+    "topology",
 ]

--- a/python/basix/cell.py
+++ b/python/basix/cell.py
@@ -9,29 +9,29 @@ import numpy as np
 import numpy.typing as npt
 
 from basix._basixcpp import CellType
-from basix._basixcpp import cell_facet_jacobians as _fj
 from basix._basixcpp import cell_edge_jacobians as _ej
+from basix._basixcpp import cell_facet_jacobians as _fj
 from basix._basixcpp import cell_facet_normals as _fn
 from basix._basixcpp import cell_facet_orientations as _fo
 from basix._basixcpp import cell_facet_outward_normals as _fon
 from basix._basixcpp import cell_facet_reference_volumes as _frv
 from basix._basixcpp import cell_volume as _v
 from basix._basixcpp import geometry as _geometry
-from basix._basixcpp import subentity_types as _sut
 from basix._basixcpp import sub_entity_connectivity as _sec
 from basix._basixcpp import sub_entity_type as _set
+from basix._basixcpp import subentity_types as _sut
 from basix._basixcpp import topology as _topology
 
 __all__ = [
-    "sub_entity_connectivity",
-    "subentity_types",
-    "volume",
     "edge_jacobians",
     "facet_jacobians",
     "facet_normals",
     "facet_orientations",
     "facet_outward_normals",
     "facet_reference_volumes",
+    "sub_entity_connectivity",
+    "subentity_types",
+    "volume",
 ]
 
 

--- a/python/basix/finite_element.py
+++ b/python/basix/finite_element.py
@@ -5,12 +5,16 @@
 # SPDX-License-Identifier:    MIT
 """Functions for creating finite elements."""
 
+from typing import TYPE_CHECKING
 from warnings import warn
 
 import numpy as np
 import numpy.typing as npt
 
-from basix._basixcpp import DPCVariant, ElementFamily, LagrangeVariant, MapType
+if TYPE_CHECKING:
+    from basix import MapType
+
+from basix._basixcpp import DPCVariant, ElementFamily, LagrangeVariant
 from basix._basixcpp import FiniteElement_float32 as _FiniteElement_float32
 from basix._basixcpp import FiniteElement_float64 as _FiniteElement_float64
 from basix._basixcpp import (
@@ -495,7 +499,7 @@ class FiniteElement:
         return self._e.interpolation_is_identity
 
     @property
-    def map_type(self) -> MapType:
+    def map_type(self) -> "MapType":
         """Map type for this element."""
         return self._e.map_type
 
@@ -632,7 +636,7 @@ def create_custom_element(
     x: list[list[npt.NDArray[np.floating]]],
     M: list[list[npt.NDArray[np.floating]]],
     interpolation_nderivs: int,
-    map_type: MapType,
+    map_type: "MapType",
     sobolev_space: SobolevSpace,
     discontinuous: bool,
     embedded_subdegree: int,

--- a/python/basix/finite_element.py
+++ b/python/basix/finite_element.py
@@ -5,12 +5,12 @@
 # SPDX-License-Identifier:    MIT
 """Functions for creating finite elements."""
 
-import typing
 from warnings import warn
 
 import numpy as np
 import numpy.typing as npt
 
+from basix import MapType
 from basix._basixcpp import DPCVariant, ElementFamily, LagrangeVariant
 from basix._basixcpp import FiniteElement_float32 as _FiniteElement_float32
 from basix._basixcpp import FiniteElement_float64 as _FiniteElement_float64
@@ -22,32 +22,31 @@ from basix._basixcpp import (
 )
 from basix._basixcpp import create_element as _create_element
 from basix._basixcpp import create_tp_element as _create_tp_element
-from basix._basixcpp import tp_dof_ordering as _tp_dof_ordering
 from basix._basixcpp import lex_dof_ordering as _lex_dof_ordering
+from basix._basixcpp import tp_dof_ordering as _tp_dof_ordering
 from basix._basixcpp import tp_factors as _tp_factors
-from basix.cell import CellType, geometry, topology, facet_outward_normals
-from basix import MapType
+from basix.cell import CellType, facet_outward_normals, geometry, topology
 from basix.polynomials import PolysetType
 from basix.sobolev_spaces import SobolevSpace
 
 __all__ = [
     "FiniteElement",
-    "create_element",
     "create_custom_element",
+    "create_element",
     "create_tp_element",
     "lex_dof_ordering",
     "string_to_family",
-    "tp_factors",
     "tp_dof_ordering",
+    "tp_factors",
 ]
 
 
 class FiniteElement:
     """Finite element class."""
 
-    _e: typing.Union[_FiniteElement_float32, _FiniteElement_float64]
+    _e: _FiniteElement_float32 | _FiniteElement_float64
 
-    def __init__(self, e: typing.Union[_FiniteElement_float32, _FiniteElement_float64]):
+    def __init__(self, e: _FiniteElement_float32 | _FiniteElement_float64):
         """Initialise a finite element wrapper.
 
         Note:
@@ -317,7 +316,7 @@ class FiniteElement:
         indices: npt.NDArray,
         cell_or_entity_info: int,
         entity_type: CellType,
-        entity_index: typing.Optional[int] = None,
+        entity_index: int | None = None,
     ) -> npt.NDArray:
         """Permute DOF indices on the closure of a sub-entity.
 
@@ -344,7 +343,7 @@ class FiniteElement:
         indices: npt.NDArray,
         cell_or_entity_info: int,
         entity_type: CellType,
-        entity_index: typing.Optional[int] = None,
+        entity_index: int | None = None,
     ) -> npt.NDArray:
         """Apply inverse permutation to DOF indices on the closure of a sub-entity.
 
@@ -592,7 +591,7 @@ def create_element(
     lagrange_variant: LagrangeVariant = LagrangeVariant.unset,
     dpc_variant: DPCVariant = DPCVariant.unset,
     discontinuous: bool = False,
-    dof_ordering: typing.Optional[list[int]] = None,
+    dof_ordering: list[int] | None = None,
     dtype: npt.DTypeLike | None = np.float64,
 ) -> FiniteElement:
     """Create a finite element.
@@ -776,9 +775,9 @@ def tp_factors(
     lagrange_variant: LagrangeVariant = LagrangeVariant.unset,
     dpc_variant: DPCVariant = DPCVariant.unset,
     discontinuous: bool = False,
-    dof_ordering: typing.Optional[list[int]] = None,
+    dof_ordering: list[int] | None = None,
     dtype: npt.DTypeLike = np.float64,
-) -> typing.Optional[list[list[FiniteElement]]]:
+) -> list[list[FiniteElement]] | None:
     """Elements in the tensor product factorisation of an element.
 
     If the element has no factorisation, raises a RuntimeError.
@@ -823,7 +822,7 @@ def tp_dof_ordering(
     lagrange_variant: LagrangeVariant = LagrangeVariant.unset,
     dpc_variant: DPCVariant = DPCVariant.unset,
     discontinuous: bool = False,
-) -> typing.Optional[list[int]]:
+) -> list[int] | None:
     """Tensor product DOF ordering for an element.
 
     This DOF ordering can be passed into create_element to create the

--- a/python/basix/finite_element.py
+++ b/python/basix/finite_element.py
@@ -10,8 +10,7 @@ from warnings import warn
 import numpy as np
 import numpy.typing as npt
 
-from basix import MapType
-from basix._basixcpp import DPCVariant, ElementFamily, LagrangeVariant
+from basix._basixcpp import DPCVariant, ElementFamily, LagrangeVariant, MapType
 from basix._basixcpp import FiniteElement_float32 as _FiniteElement_float32
 from basix._basixcpp import FiniteElement_float64 as _FiniteElement_float64
 from basix._basixcpp import (

--- a/python/basix/numba_helpers.py
+++ b/python/basix/numba_helpers.py
@@ -16,21 +16,21 @@ import numpy.typing as npt
 
 __all__ = [
     "T_apply",
-    "T_apply_interval",
-    "T_apply_triangle",
-    "T_apply_quadrilateral",
-    "T_apply_tetrahedron",
     "T_apply_hexahedron",
+    "T_apply_interval",
     "T_apply_prism",
     "T_apply_pyramid",
+    "T_apply_quadrilateral",
+    "T_apply_tetrahedron",
+    "T_apply_triangle",
     "Tt_apply_right",
-    "Tt_apply_right_interval",
-    "Tt_apply_right_triangle",
-    "Tt_apply_right_quadrilateral",
-    "Tt_apply_right_tetrahedron",
     "Tt_apply_right_hexahedron",
+    "Tt_apply_right_interval",
     "Tt_apply_right_prism",
     "Tt_apply_right_pyramid",
+    "Tt_apply_right_quadrilateral",
+    "Tt_apply_right_tetrahedron",
+    "Tt_apply_right_triangle",
 ]
 
 

--- a/python/basix/polynomials.py
+++ b/python/basix/polynomials.py
@@ -10,16 +10,20 @@ from typing import TypeVar
 import numpy as np
 import numpy.typing as npt
 
-from basix._basixcpp import PolynomialType, PolysetType
+from basix._basixcpp import (
+    PolynomialType,
+    PolysetType,
+    tabulate_polynomial_set_float32,
+    tabulate_polynomial_set_float64,
+)
 from basix._basixcpp import polynomials_dim as _pd
 from basix._basixcpp import restriction as _restriction
 from basix._basixcpp import superset as _superset
-from basix._basixcpp import tabulate_polynomial_set_float32, tabulate_polynomial_set_float64
 from basix._basixcpp import tabulate_polynomials as _tabulate_polynomials
 from basix.cell import CellType
 from basix.utils import index
 
-__all__ = ["reshape_coefficients", "dim", "tabulate_polynomial_set"]
+__all__ = ["dim", "reshape_coefficients", "tabulate_polynomial_set"]
 
 
 T = TypeVar("T", np.float32, np.float64)

--- a/python/basix/quadrature.py
+++ b/python/basix/quadrature.py
@@ -6,7 +6,7 @@
 """Functions to manipulate quadrature types."""
 
 import numpy as _np  # noqa: ICN001
-import numpy.typing as _npt
+import numpy.typing as _npt  # noqa: ICN001
 
 from basix._basixcpp import QuadratureType
 from basix._basixcpp import gauss_jacobi_rule as _gjr
@@ -64,8 +64,9 @@ def gauss_jacobi_rule(
     alpha: _np.floating,
     npoints: int,
 ) -> tuple[_npt.ArrayLike, _npt.ArrayLike]:
-    """Create a Gauss-Jacobi quadrature rule for integrating f(x)*(1-x)**alpha
-    on the interval [0, 1].
+    """Create a Gauss-Jacobi quadrature rule for integrating f(x)*(1-x)**alpha.
+
+    Rule is defined on the interval [0, 1].
 
     Args:
         alpha: The exponent alpha

--- a/python/basix/quadrature.py
+++ b/python/basix/quadrature.py
@@ -5,16 +5,16 @@
 # SPDX-License-Identifier:    MIT
 """Functions to manipulate quadrature types."""
 
-import numpy as _np
+import numpy as _np  # noqa: ICN001
 import numpy.typing as _npt
 
 from basix._basixcpp import QuadratureType
-from basix._basixcpp import make_quadrature as _mq
 from basix._basixcpp import gauss_jacobi_rule as _gjr
+from basix._basixcpp import make_quadrature as _mq
 from basix.cell import CellType
 from basix.polynomials import PolysetType
 
-__all__ = ["string_to_type", "make_quadrature"]
+__all__ = ["make_quadrature", "string_to_type"]
 
 
 def string_to_type(rule: str) -> QuadratureType:

--- a/python/basix/ufl.py
+++ b/python/basix/ufl.py
@@ -13,6 +13,8 @@ from warnings import warn as _warn
 
 import numpy as np
 import numpy.typing as _npt
+
+import basix as _basix
 import ufl as _ufl
 from ufl.finiteelement import AbstractFiniteElement as _AbstractFiniteElement
 from ufl.pullback import AbstractPullback as _AbstractPullback
@@ -21,16 +23,14 @@ from ufl.pullback import MixedPullback as _MixedPullback
 from ufl.pullback import SymmetricPullback as _SymmetricPullback
 from ufl.pullback import UndefinedPullback as _UndefinedPullback
 
-import basix as _basix
-
 __all__ = [
+    "blocked_element",
+    "custom_element",
     "element",
     "enriched_element",
-    "custom_element",
     "mixed_element",
     "quadrature_element",
     "real_element",
-    "blocked_element",
     "wrap_element",
 ]
 
@@ -122,7 +122,7 @@ class _ElementBase(_AbstractFiniteElement):
         """Return a hash."""
         return hash("basix" + self._repr)
 
-    def basix_hash(self) -> _typing.Optional[int]:
+    def basix_hash(self) -> int | None:
         """Hash of the Basix element (if this is a standard Basix element).
 
         Returns:
@@ -274,17 +274,17 @@ class _ElementBase(_AbstractFiniteElement):
 
     @property
     @_abstractmethod
-    def element_family(self) -> _typing.Union[_basix.ElementFamily, None]:
+    def element_family(self) -> _basix.ElementFamily | None:
         """Basix element family used to initialise the element."""
 
     @property
     @_abstractmethod
-    def lagrange_variant(self) -> _typing.Union[_basix.LagrangeVariant, None]:
+    def lagrange_variant(self) -> _basix.LagrangeVariant | None:
         """Basix Lagrange variant used to initialise the element."""
 
     @property
     @_abstractmethod
-    def dpc_variant(self) -> _typing.Union[_basix.DPCVariant, None]:
+    def dpc_variant(self) -> _basix.DPCVariant | None:
         """Basix DPC variant used to initialise the element."""
 
     @property
@@ -450,7 +450,7 @@ class _BasixElement(_ElementBase):
     def __hash__(self) -> int:
         return super().__hash__()
 
-    def basix_hash(self) -> _typing.Optional[int]:
+    def basix_hash(self) -> int | None:
         return self._element.hash()
 
     def tabulate(self, nderivs: int, points: _npt.NDArray[np.floating]) -> _npt.ArrayLike:
@@ -508,15 +508,15 @@ class _BasixElement(_ElementBase):
         return self._element.family.name
 
     @property
-    def element_family(self) -> _typing.Union[_basix.ElementFamily, None]:
+    def element_family(self) -> _basix.ElementFamily | None:
         return self._element.family
 
     @property
-    def lagrange_variant(self) -> _typing.Union[_basix.LagrangeVariant, None]:
+    def lagrange_variant(self) -> _basix.LagrangeVariant | None:
         return self._element.lagrange_variant
 
     @property
-    def dpc_variant(self) -> _typing.Union[_basix.DPCVariant, None]:
+    def dpc_variant(self) -> _basix.DPCVariant | None:
         return self._element.dpc_variant
 
     @property
@@ -669,15 +669,15 @@ class _ComponentElement(_ElementBase):
         raise NotImplementedError()
 
     @property
-    def element_family(self) -> _typing.Union[_basix.ElementFamily, None]:
+    def element_family(self) -> _basix.ElementFamily | None:
         return self._element.element_family
 
     @property
-    def lagrange_variant(self) -> _typing.Union[_basix.LagrangeVariant, None]:
+    def lagrange_variant(self) -> _basix.LagrangeVariant | None:
         return self._element.lagrange_variant
 
     @property
-    def dpc_variant(self) -> _typing.Union[_basix.DPCVariant, None]:
+    def dpc_variant(self) -> _basix.DPCVariant | None:
         return self._element.dpc_variant
 
     @property
@@ -884,15 +884,15 @@ class _MixedElement(_ElementBase):
         return self._sub_elements[0].reference_geometry
 
     @property
-    def lagrange_variant(self) -> _typing.Union[_basix.LagrangeVariant, None]:
+    def lagrange_variant(self) -> _basix.LagrangeVariant | None:
         return None
 
     @property
-    def dpc_variant(self) -> _typing.Union[_basix.DPCVariant, None]:
+    def dpc_variant(self) -> _basix.DPCVariant | None:
         return None
 
     @property
-    def element_family(self) -> _typing.Union[_basix.ElementFamily, None]:
+    def element_family(self) -> _basix.ElementFamily | None:
         return None
 
     @property
@@ -958,7 +958,7 @@ class _BlockedElement(_ElementBase):
         self,
         sub_element: _ElementBase,
         shape: tuple[int, ...],
-        symmetry: _typing.Optional[bool] = None,
+        symmetry: bool | None = None,
     ):
         """Initialise the element."""
         if sub_element.reference_value_size != 1:
@@ -1021,7 +1021,7 @@ class _BlockedElement(_ElementBase):
     def __hash__(self) -> int:
         return super().__hash__()
 
-    def basix_hash(self) -> _typing.Optional[int]:
+    def basix_hash(self) -> int | None:
         return self._sub_element.basix_hash()
 
     @property
@@ -1133,15 +1133,15 @@ class _BlockedElement(_ElementBase):
         return self._sub_element.reference_geometry
 
     @property
-    def lagrange_variant(self) -> _typing.Union[_basix.LagrangeVariant, None]:
+    def lagrange_variant(self) -> _basix.LagrangeVariant | None:
         return self._sub_element.lagrange_variant
 
     @property
-    def dpc_variant(self) -> _typing.Union[_basix.DPCVariant, None]:
+    def dpc_variant(self) -> _basix.DPCVariant | None:
         return self._sub_element.dpc_variant
 
     @property
-    def element_family(self) -> _typing.Union[_basix.ElementFamily, None]:
+    def element_family(self) -> _basix.ElementFamily | None:
         return self._sub_element.element_family
 
     @property
@@ -1239,8 +1239,8 @@ class _QuadratureElement(_ElementBase):
         points: _npt.NDArray[np.floating],
         weights: _npt.NDArray[np.floating],
         pullback: _AbstractPullback,
-        degree: _typing.Optional[int] = None,
-        dtype: _typing.Optional[_npt.DTypeLike] = np.float64,
+        degree: int | None = None,
+        dtype: _npt.DTypeLike | None = np.float64,
     ):
         """Initialise the element."""
         self._points = points.astype(dtype)
@@ -1344,15 +1344,15 @@ class _QuadratureElement(_ElementBase):
         return "quadrature"
 
     @property
-    def lagrange_variant(self) -> _typing.Union[_basix.LagrangeVariant, None]:
+    def lagrange_variant(self) -> _basix.LagrangeVariant | None:
         return None
 
     @property
-    def dpc_variant(self) -> _typing.Union[_basix.DPCVariant, None]:
+    def dpc_variant(self) -> _basix.DPCVariant | None:
         return None
 
     @property
-    def element_family(self) -> _typing.Union[_basix.ElementFamily, None]:
+    def element_family(self) -> _basix.ElementFamily | None:
         return None
 
     @property
@@ -1484,15 +1484,15 @@ class _RealElement(_ElementBase):
         return "real"
 
     @property
-    def lagrange_variant(self) -> _typing.Union[_basix.LagrangeVariant, None]:
+    def lagrange_variant(self) -> _basix.LagrangeVariant | None:
         return None
 
     @property
-    def dpc_variant(self) -> _typing.Union[_basix.DPCVariant, None]:
+    def dpc_variant(self) -> _basix.DPCVariant | None:
         return None
 
     @property
-    def element_family(self) -> _typing.Union[_basix.ElementFamily, None]:
+    def element_family(self) -> _basix.ElementFamily | None:
         return None
 
     @property
@@ -1564,16 +1564,16 @@ def _compute_signature(element: _basix.finite_element.FiniteElement) -> str:
 
 
 def element(
-    family: _typing.Union[_basix.ElementFamily, str],
-    cell: _typing.Union[_basix.CellType, str],
+    family: _basix.ElementFamily | str,
+    cell: _basix.CellType | str,
     degree: int,
     lagrange_variant: _basix.LagrangeVariant = _basix.LagrangeVariant.unset,
     dpc_variant: _basix.DPCVariant = _basix.DPCVariant.unset,
     discontinuous: bool = False,
-    shape: _typing.Optional[tuple[int, ...]] = None,
-    symmetry: _typing.Optional[bool] = None,
-    dof_ordering: _typing.Optional[list[int]] = None,
-    dtype: _typing.Optional[_npt.DTypeLike] = None,
+    shape: tuple[int, ...] | None = None,
+    symmetry: bool | None = None,
+    dof_ordering: list[int] | None = None,
+    dtype: _npt.DTypeLike | None = None,
 ) -> _ElementBase:
     """Create a UFL compatible element using Basix.
 
@@ -1657,7 +1657,7 @@ def element(
 
 def enriched_element(
     elements: list[_ElementBase],
-    map_type: _typing.Optional[_basix.MapType] = None,
+    map_type: _basix.MapType | None = None,
 ) -> _ElementBase:
     """Create an UFL compatible enriched element from a list of elements.
 
@@ -1752,7 +1752,7 @@ def enriched_element(
 
 def custom_element(
     cell_type: _basix.CellType,
-    reference_value_shape: _typing.Union[list[int], tuple[int, ...]],
+    reference_value_shape: list[int] | tuple[int, ...],
     wcoeffs: _npt.NDArray[np.floating],
     x: list[list[_npt.NDArray[np.floating]]],
     M: list[list[_npt.NDArray[np.floating]]],
@@ -1763,7 +1763,7 @@ def custom_element(
     embedded_subdegree: int,
     embedded_superdegree: int,
     polyset_type: _basix.PolysetType = _basix.PolysetType.standard,
-    dtype: _typing.Optional[_npt.DTypeLike] = None,
+    dtype: _npt.DTypeLike | None = None,
 ) -> _ElementBase:
     """Create a UFL compatible custom Basix element.
 
@@ -1827,15 +1827,15 @@ def mixed_element(elements: list[_ElementBase]) -> _ElementBase:
 
 
 def quadrature_element(
-    cell: _typing.Union[str, _basix.CellType],
+    cell: str | _basix.CellType,
     value_shape: tuple[int, ...] = (),
-    scheme: _typing.Optional[str] = None,
-    degree: _typing.Optional[int] = None,
-    points: _typing.Optional[_npt.NDArray[np.floating]] = None,
-    weights: _typing.Optional[_npt.NDArray[np.floating]] = None,
+    scheme: str | None = None,
+    degree: int | None = None,
+    points: _npt.NDArray[np.floating] | None = None,
+    weights: _npt.NDArray[np.floating] | None = None,
     pullback: _AbstractPullback = _ufl.identity_pullback,
-    symmetry: _typing.Optional[bool] = None,
-    dtype: _typing.Optional[_npt.DTypeLike] = None,
+    symmetry: bool | None = None,
+    dtype: _npt.DTypeLike | None = None,
 ) -> _ElementBase:
     """Create a quadrature element.
 
@@ -1883,10 +1883,10 @@ def quadrature_element(
 
 
 def real_element(
-    cell: _typing.Union[_basix.CellType, str],
+    cell: _basix.CellType | str,
     value_shape: tuple[int, ...] = (),
-    symmetry: _typing.Optional[bool] = None,
-    dtype: _typing.Optional[_npt.DTypeLike] = None,
+    symmetry: bool | None = None,
+    dtype: _npt.DTypeLike | None = None,
 ) -> _ElementBase:
     """Create a real element.
 
@@ -1912,7 +1912,7 @@ def real_element(
 def blocked_element(
     sub_element: _ElementBase,
     shape: tuple[int, ...],
-    symmetry: _typing.Optional[bool] = None,
+    symmetry: bool | None = None,
 ) -> _ElementBase:
     """Create a UFL compatible blocked element.
 

--- a/python/basix/ufl.py
+++ b/python/basix/ufl.py
@@ -12,7 +12,7 @@ from abc import abstractmethod as _abstractmethod
 from warnings import warn as _warn
 
 import numpy as np
-import numpy.typing as _npt
+import numpy.typing as _npt  # noqa: ICN001
 
 import basix as _basix
 import ufl as _ufl
@@ -1893,6 +1893,8 @@ def real_element(
     Args:
         cell: Cell to create the element on.
         value_shape: Value shape of the element.
+        symmetry: Is symmetric?
+        dtype: dtype of scalar value represented by real element.
 
     Returns:
         A 'real' finite element.

--- a/python/basix/utils.py
+++ b/python/basix/utils.py
@@ -5,12 +5,10 @@
 # SPDX-License-Identifier:    MIT
 """Utility funcitons."""
 
-import typing
-
 from basix._basixcpp import index as _index
 
 
-def index(p: int, q: typing.Optional[int] = None, r: typing.Optional[int] = None) -> int:
+def index(p: int, q: int | None = None, r: int | None = None) -> int:
     """Compute the indexing in a 1D, 2D or 3D simplex.
 
     Args:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -24,9 +24,9 @@ documentation = "https://docs.fenicsproject.org"
 [project.optional-dependencies]
 docs = ["markdown", "pylit3", "pyyaml", "sphinx", "pydata-sphinx-theme"]
 lint = ["ruff"]
-optional = ["numba", "fenics-ufl>=2026.1.0,<2026.2.0"]
+optional = ["numba", "fenics-ufl@git+https://github.com/fenics/ufl"]
 test = ["pytest", "sympy", "scipy", "matplotlib", "fenics-basix[optional]"]
-test-no-numba = ["pytest", "sympy", "scipy", "matplotlib", "fenics-ufl>=2026.1.0,<2026.2.0"]
+test-no-numba = ["pytest", "sympy", "scipy", "matplotlib", "fenics-ufl@git+https://github.com/fenics/ufl"]
 ci = ["mypy", "pytest-xdist", "fenics-basix[docs,lint,test,optional]"]
 
 [tool.mypy]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -16,20 +16,21 @@ authors = [
 ]
 dependencies = ["numpy>=2"]
 
+[project.urls]
+homepage = "https://fenicsproject.org"
+repository = "https://github.com/fenics/basix.git"
+documentation = "https://docs.fenicsproject.org"
+
 [project.optional-dependencies]
-docs = ["markdown", "pylit3", "pyyaml", "sphinx", "sphinx_rtd_theme"]
+docs = ["markdown", "pylit3", "pyyaml", "sphinx", "pydata-sphinx-theme"]
 lint = ["ruff"]
-optional = ["numba", "fenics-ufl@git+https://github.com/fenics/ufl"]
+optional = ["numba", "fenics-ufl>=2026.1.0,<2026.2.0"]
 test = ["pytest", "sympy", "scipy", "matplotlib", "fenics-basix[optional]"]
+test-no-numba = ["pytest", "sympy", "scipy", "matplotlib", "fenics-ufl>=2026.1.0,<2026.2.0"]
 ci = ["mypy", "pytest-xdist", "fenics-basix[docs,lint,test,optional]"]
 
 [tool.mypy]
 ignore_missing_imports = true
-
-[tool.ruff]
-line-length = 100
-indent-width = 4
-extend-exclude = ["_basixcpp.pyi"]
 
 [tool.scikit-build]
 wheel.packages = ["basix"]


### PR DESCRIPTION
Seems like the ruff configuration in `python/pyproject.toml` was blocking the (superior) one in `pyproject.toml`. This PR makes the necessary ruff-related fixes (most were automated).

Will be ported onto `release` and I will remake the `v0.11.0` tag.