### PR TITLE
Remove version in CMake

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -5,7 +5,7 @@ if(APPLE)
   set(CMAKE_OSX_DEPLOYMENT_TARGET "10.14")
 endif()
 
-project(basix_nanobind VERSION "0.9.0.0" LANGUAGES CXX)
+project(basix_nanobind VERSION LANGUAGES CXX)
 
 if(WIN32)
     # Windows requires all symbols to be manually exported.


### PR DESCRIPTION
DOLFINx has managed without this for ages with no ill effects. One less thing to forget to update.