### PR TITLE
Roll out fenicsx-refs.env system to CI workflows

### DIFF
--- a/.github/workflows/dolfinx-tests.yml
+++ b/.github/workflows/dolfinx-tests.yml
@@ -11,19 +11,6 @@ on:
     branches:
       - main
   workflow_dispatch:
-    inputs:
-      dolfinx_branch:
-        description: "DOLFINx branch or tag"
-        default: "main"
-        type: string
-      ffcx_branch:
-        description: "FFCx branch or tag"
-        default: "main"
-        type: string
-      ufl_branch:
-        description: "UFL branch or tag"
-        default: "main"
-        type: string
 
 jobs:
   build:
@@ -40,6 +27,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+      - name: Load environment variables
+        run: cat .github/workflows/fenicsx-refs.env >> $GITHUB_ENV
       - name: Install Basix
         run: |
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build-dir -S ./cpp
@@ -47,29 +36,15 @@ jobs:
           cmake --install build-dir
           python3 -m pip install --break-system-packages ./python
       - name: Install FEniCS Python components
-        if: github.event_name != 'workflow_dispatch'
         run: |
-          python3 -m pip install --break-system-packages git+https://github.com/FEniCS/ufl.git
-          python3 -m pip install --break-system-packages git+https://github.com/FEniCS/ffcx.git
-      - name: Install FEniCS Python components
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          python3 -m pip install --break-system-packages git+https://github.com/FEniCS/ufl.git@${{ github.event.inputs.ufl_branch }}
-          python3 -m pip install --break-system-packages git+https://github.com/FEniCS/ffcx.git@${{ github.event.inputs.ffcx_branch }}
+          python3 -m pip install --break-system-packages git+https://github.com/${{ env.ufl_repository }}.git@${{ env.ufl_ref }}
+          python3 -m pip install --break-system-packages git+https://github.com/${{ env.ffcx_repository }}.git@${{ env.ffcx_ref }}
       - name: Get DOLFINx
-        if: github.event_name != 'workflow_dispatch'
         uses: actions/checkout@v6
         with:
           path: ./dolfinx
-          repository: FEniCS/dolfinx
-          ref: main
-      - name: Get DOLFINx
-        if: github.event_name == 'workflow_dispatch'
-        uses: actions/checkout@v6
-        with:
-          path: ./dolfinx
-          repository: FEniCS/dolfinx
-          ref: ${{ github.event.inputs.dolfinx_branch }}
+          repository: ${{ env.dolfinx_repository }}
+          ref: ${{ env.dolfinx_ref }}
       - name: Install DOLFINx (C++)
         run: |
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -DBUILD_TESTING=true -B build -S dolfinx/cpp/

--- a/.github/workflows/fenicsx-refs.env
+++ b/.github/workflows/fenicsx-refs.env
@@ -1,0 +1,6 @@
+ufl_repository=FEniCS/ufl
+ufl_ref=main
+ffcx_repository=FEniCS/ffcx
+ffcx_ref=main
+dolfinx_repository=FEniCS/dolfinx
+dolfinx_ref=main

--- a/.github/workflows/ffcx-tests.yml
+++ b/.github/workflows/ffcx-tests.yml
@@ -13,15 +13,6 @@ on:
     branches:
       - main
   workflow_dispatch:
-    inputs:
-      ffcx_branch:
-        description: "FFCx branch or tag"
-        default: "main"
-        type: string
-      ufl_branch:
-        description: "UFL branch or tag"
-        default: "main"
-        type: string
 
 jobs:
   build:
@@ -29,34 +20,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - name: Load environment variables
+        run: cat .github/workflows/fenicsx-refs.env >> $GITHUB_ENV
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
           python-version: '3.13'
       - name: Install dependencies
         run: sudo apt-get install -y libopenblas-dev liblapack-dev graphviz libgraphviz-dev ninja-build
-      - name: Install UFL (default branch)
-        if: github.event_name != 'workflow_dispatch'
-        run: pip install git+https://github.com/FEniCS/ufl.git
-      - name: Install UFL (specified branch)
-        if: github.event_name == 'workflow_dispatch'
-        run: pip install git+https://github.com/FEniCS/ufl.git@${{ github.event.inputs.ufl_branch }}
+      - name: Install UFL
+        run: pip install git+https://github.com/${{ env.ufl_repository }}.git@${{ env.ufl_ref }}
       - name: Install Basix
         run: pip -v install .[ci]
-      - name: Get FFCx source (default branch)
-        if: github.event_name != 'workflow_dispatch'
+      - name: Get FFCx source
         uses: actions/checkout@v6
         with:
           path: ./ffcx
-          repository: FEniCS/ffcx
-          ref: main
-      - name: Get FFCx source (specified branch)
-        if: github.event_name == 'workflow_dispatch'
-        uses: actions/checkout@v6
-        with:
-          path: ./ffcx
-          repository: FEniCS/ffcx
-          ref: ${{ github.event.inputs.ffcx_branch }}
+          repository: ${{ env.ffcx_repository }}
+          ref: ${{ env.ffcx_ref }}
       - name: Install FFCx
         run: pip install ./ffcx[ci]
       - name: Run FFCx tests

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -30,6 +30,8 @@ jobs:
         with:
           python-version: "3.13"
       - uses: actions/checkout@v6
+      - name: Load environment variables
+        run: cat .github/workflows/fenicsx-refs.env >> $GITHUB_ENV
       - name: Ruff check
         run: |
           pip install ruff
@@ -38,7 +40,7 @@ jobs:
       - name: MyPy check
         run: |
           pip install mypy numpy
-          pip install git+https://github.com/FEniCS/ufl.git
+          pip install git+https://github.com/${{ env.ufl_repository }}.git@${{ env.ufl_ref }}
           mypy python/basix
 
   build:
@@ -50,6 +52,8 @@ jobs:
         python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v6
+      - name: Load environment variables
+        run: cat .github/workflows/fenicsx-refs.env >> $GITHUB_ENV
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
@@ -58,8 +62,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y doxygen graphviz libopenblas-dev liblapack-dev ninja-build
-      - name: Install UFL branch
-        run: pip -v install git+https://github.com/FEniCS/ufl.git
+      - name: Install UFL
+        run: pip -v install git+https://github.com/${{ env.ufl_repository }}.git@${{ env.ufl_ref }}
       - name: Install Basix
         run: pip -v install -Ccmake.build-type="Developer" .[ci]
       - name: Run units tests


### PR DESCRIPTION
The current system with many hard-coded refs makes releases very difficult. This rolls out the `fenicsx-refs.env` system across the workflows.