### PR TITLE
Allow RPATH adjustment to be removed and various CMake fixes

### DIFF
--- a/.github/workflows/dolfinx-tests.yml
+++ b/.github/workflows/dolfinx-tests.yml
@@ -34,8 +34,9 @@ jobs:
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build-dir -S cpp/
           cmake --build build-dir/
           cmake --install build-dir/
+          # This tests non-RPATH based linking.
           ldconfig
-          python3 -m pip install --break-system-packages python/
+          python3 -m pip install -Ccmake.args=-DBASIX_SET_INSTALL_RPATH=OFF --break-system-packages python/
       - name: Install FEniCS Python components
         run: |
           python3 -m pip install --break-system-packages git+https://github.com/${{ env.ufl_repository }}.git@${{ env.ufl_ref }}

--- a/.github/workflows/dolfinx-tests.yml
+++ b/.github/workflows/dolfinx-tests.yml
@@ -33,7 +33,8 @@ jobs:
         run: |
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build-dir -S cpp/
           cmake --build build-dir/
-          cmake --install build-dir/ --prefix /usr/local
+          cmake --install build-dir/
+          ldconfig
           python3 -m pip install --break-system-packages python/
       - name: Install FEniCS Python components
         run: |
@@ -49,7 +50,7 @@ jobs:
         run: |
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -DBUILD_TESTING=true -B build -S dolfinx/cpp/
           cmake --build build
-          cmake --install build --prefix /usr/local
+          cmake --install build
       - name: Run DOLFINx C++ unit tests
         working-directory: build
         run: ctest -V --output-on-failure -R unittests

--- a/.github/workflows/dolfinx-tests.yml
+++ b/.github/workflows/dolfinx-tests.yml
@@ -36,7 +36,7 @@ jobs:
           cmake --install build-dir/
           # This tests non-RPATH based linking.
           ldconfig
-          python3 -m pip install -Ccmake.args=-DBASIX_SET_INSTALL_RPATH=OFF --break-system-packages python/
+          python3 -m pip -v install -Ccmake.args=-DBASIX_SET_INSTALL_RPATH=OFF --break-system-packages python/
       - name: Install FEniCS Python components
         run: |
           python3 -m pip install --break-system-packages git+https://github.com/${{ env.ufl_repository }}.git@${{ env.ufl_ref }}

--- a/.github/workflows/dolfinx-tests.yml
+++ b/.github/workflows/dolfinx-tests.yml
@@ -31,10 +31,10 @@ jobs:
         run: cat .github/workflows/fenicsx-refs.env >> $GITHUB_ENV
       - name: Install Basix
         run: |
-          cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build-dir -S ./cpp
-          cmake --build build-dir
-          cmake --install build-dir
-          python3 -m pip install --break-system-packages ./python
+          cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build-dir -S cpp/
+          cmake --build build-dir/
+          cmake --install build-dir/ --prefix /usr/local
+          python3 -m pip install --break-system-packages python/
       - name: Install FEniCS Python components
         run: |
           python3 -m pip install --break-system-packages git+https://github.com/${{ env.ufl_repository }}.git@${{ env.ufl_ref }}
@@ -49,7 +49,7 @@ jobs:
         run: |
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -DBUILD_TESTING=true -B build -S dolfinx/cpp/
           cmake --build build
-          cmake --install build
+          cmake --install build --prefix /usr/local
       - name: Run DOLFINx C++ unit tests
         working-directory: build
         run: ctest -V --output-on-failure -R unittests

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -148,7 +148,10 @@ jobs:
       - name: Install Python dependencies
         run: pip install nanobind scikit-build-core[pyproject]
       - name: Install Basix
-        run: pip install --no-build-isolation .
+        run: |
+          pip install scikit-build-core
+          python -m scikit_build_core.build requires | python -c "import sys, json; print(' '.join(json.load(sys.stdin)))" | xargs pip install
+          pip install --no-build-isolation .
       - name: Install mypy
         run: pip install mypy
       - name: Run mypy (module)
@@ -174,11 +177,14 @@ jobs:
           cd cpp
           cmake -DCMAKE_BUILD_TYPE=Developer -B build-dir -S . # Use make (not ninja)
           cmake --build build-dir
-          sudo cmake --install build-dir --prefix /usr/local
+          sudo cmake --install build-dir
+          sudo ldconfig # necessary for runtime linking of libbasix.so
       - name: Install Basix Python wrapper
         run: |
           cd python
-          pip install .[test]
+          pip install scikit-build-core
+          python -m scikit_build_core.build requires | python -c "import sys, json; print(' '.join(json.load(sys.stdin)))" | xargs pip install
+          pip install --no-build-isolation .[test]
       - name: Run units tests
         run: |
           pip install pytest-xdist # in ci extras, but most not needed.

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -134,7 +134,7 @@ jobs:
           git commit --allow-empty -m "Update Basix docs FEniCS/basix@${{ github.sha }}"
           git push
 
-  isolated-python-build:
+  no-isolation-python-build:
     name: Build Python using '--no-build-isolation'
     runs-on: ubuntu-latest
     steps:
@@ -158,8 +158,8 @@ jobs:
       # - name: Run mypy (demo)
       #   run: mypy demo/python
 
-  build-cmake:
-    name: Build using C++ and Python parts separately and run tests
+  build-separately:
+    name: Build C++ and Python parts separately and run tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -174,7 +174,7 @@ jobs:
           cd cpp
           cmake -DCMAKE_BUILD_TYPE=Developer -B build-dir -S . # Use make (not ninja)
           cmake --build build-dir
-          sudo cmake --install build-dir
+          sudo cmake --install build-dir --prefix /usr/local
       - name: Install Basix Python wrapper
         run: |
           cd python
@@ -189,7 +189,7 @@ jobs:
         run: pytest demo/cpp/test.py
 
   build-cpp-only:
-    name: Build C++ only and run demos
+    name: Build C++ part only and run demos
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -182,9 +182,7 @@ jobs:
       - name: Install Basix Python wrapper
         run: |
           cd python
-          pip install scikit-build-core
-          python -m scikit_build_core.build requires | python -c "import sys, json; print(' '.join(json.load(sys.stdin)))" | xargs pip install
-          pip install --no-build-isolation .[test]
+          pip install .[test]
       - name: Run units tests
         run: |
           pip install pytest-xdist # in ci extras, but most not needed.

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -178,7 +178,6 @@ jobs:
           cmake -DCMAKE_BUILD_TYPE=Developer -B build-dir -S . # Use make (not ninja)
           cmake --build build-dir
           sudo cmake --install build-dir
-          sudo ldconfig # necessary for runtime linking of libbasix.so
       - name: Install Basix Python wrapper
         run: |
           cd python

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -43,13 +43,6 @@ jobs:
 
       - uses: actions/checkout@v6
 
-      - name: Export GitHub Actions cache environment variables
-        uses: actions/github-script@v9
-        with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
@@ -58,7 +51,7 @@ jobs:
       - name: Set up CMake
         uses: lukka/get-cmake@latest
         with:
-          cmakeVersion: "~3.30.0"
+          cmakeVersion: "latest"
 
       - name: Install Basix (combined)
         run: |
@@ -100,7 +93,7 @@ jobs:
       - name: Set up CMake
         uses: lukka/get-cmake@latest
         with:
-          cmakeVersion: "~3.30.0"
+          cmakeVersion: "latest"
 
       - name: Install Basix (C++)
         run: |

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,7 +2,7 @@
 
 ## Standard
 
-Basix can be installed using
+Basix can be installed using:
 ```console
 pip install .
 ```
@@ -20,9 +20,11 @@ In the `cpp/` directory:
 cmake -DCMAKE_BUILD_TYPE=Release -B build-dir -S .
 cmake --build build-dir
 cmake --install build-dir
+sudo ldconfig # Often necessary if installing into system path
 ```
-Using the CMake build type `Release` is strongly recommended for
-performance.
+
+Using the CMake build type `Release` or `RelWithDebug` is strongly recommended
+for performance.
 
 
 ### Python interface
@@ -35,10 +37,10 @@ pip install .
 
 For a debug and editable build for development:
 ```console
-pip -v install --check-build-dependencies --config-settings=build-dir="build" --config-settings=cmake.build-type="Debug"  --config-settings=install.strip=false --no-build-isolation -e .
+pip -v install --check-build-dependencies --config-settings=build-dir="build" --config-settings=cmake.build-type="Development"  --config-settings=install.strip=false --no-build-isolation -e .
 ```
-When using the `--no-build-isolation` option all build and runtime
-dependencies must already be installed.
+When using the `--no-build-isolation` option all build dependencies must
+already be installed (see `python/pyproject.toml`).
 
 ## Running the unit tests
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -41,9 +41,8 @@ pip -v install --check-build-dependencies -Cbuild-dir="build" -Ccmake.build-type
 When using the `--no-build-isolation` option all build dependencies must
 already be installed (see `python/pyproject.toml`).
 
-When Basix C++ was installed into a non-standard prefix, passing
-`-Ccmake.args="-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON"` to pip ensures the
-extension module can locate its runtime dependencies.
+RPATH manipulation can be disabled by passing
+`-Ccmake.args=-DBASIX_SET_INSTALL_RPATH=FALSE`.
 
 ## Running the unit tests
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -37,10 +37,14 @@ pip install .
 
 For a debug and editable build for development:
 ```console
-pip -v install --check-build-dependencies --config-settings=build-dir="build" --config-settings=cmake.build-type="Development"  --config-settings=install.strip=false --no-build-isolation -e .
+pip -v install --check-build-dependencies -Cbuild-dir="build" -Ccmake.build-type="Development" -Ccmake.args="-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON" -Cinstall.strip=false --no-build-isolation -e .
 ```
 When using the `--no-build-isolation` option all build dependencies must
 already be installed (see `python/pyproject.toml`).
+
+When Basix C++ was installed into a non-standard prefix, passing
+`-Ccmake.args="-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON"` to pip ensures the
+extension module can locate its runtime dependencies.
 
 ## Running the unit tests
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -20,7 +20,6 @@ In the `cpp/` directory:
 cmake -DCMAKE_BUILD_TYPE=Release -B build-dir -S .
 cmake --build build-dir
 cmake --install build-dir
-sudo ldconfig # Often necessary if installing into system path
 ```
 
 Using the CMake build type `Release` or `RelWithDebug` is strongly recommended
@@ -37,7 +36,7 @@ pip install .
 
 For a debug and editable build for development:
 ```console
-pip -v install --check-build-dependencies -Cbuild-dir="build" -Ccmake.build-type="Development" -Ccmake.args="-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON" -Cinstall.strip=false --no-build-isolation -e .
+pip -v install --check-build-dependencies -Cbuild-dir="build" -Ccmake.build-type="Development" -Cinstall.strip=false --no-build-isolation -e .
 ```
 When using the `--no-build-isolation` option all build dependencies must
 already be installed (see `python/pyproject.toml`).

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -114,7 +114,7 @@ endif()
 
 target_include_directories(basix PUBLIC
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR};${CMAKE_CURRENT_SOURCE_DIR}>")
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR};${CMAKE_CURRENT_BINARY_DIR}>")
 
 target_compile_definitions(basix PUBLIC MDSPAN_USE_PAREN_OPERATOR=1)
 target_compile_definitions(basix PUBLIC MDSPAN_USE_BRACKET_OPERATOR=0)
@@ -188,7 +188,7 @@ endif()
 
 # Configure CMake helpers
 include(CMakePackageConfigHelpers)
-write_basic_package_version_file(BasixConfigVersion.cmake VERSION ${PACKAGE_VERSION}
+write_basic_package_version_file(BasixConfigVersion.cmake VERSION ${PROJECT_VERSION}
   COMPATIBILITY AnyNewerVersion)
 configure_package_config_file(BasixConfig.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/BasixConfig.cmake
   INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/basix)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,10 @@ testpaths = ["test"]
 [tool.scikit-build]
 wheel.packages = ["python/basix"]
 
+[tool.scikit-build.cmake.define]
+# Set to OFF to disable all install RPATH adjustments
+BASIX_SET_INSTALL_RPATH = "ON"
+
 [tool.cibuildwheel]
 build-frontend = { name = "build", args = [
     "-Cwheel.py-api=cp312",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,8 @@ testpaths = ["test"]
 wheel.packages = ["python/basix"]
 
 [tool.scikit-build.cmake.define]
-# Set to OFF to disable all install RPATH adjustments
-BASIX_SET_INSTALL_RPATH = "ON"
+# Set to FALSE to disable install RPATH adjustments
+BASIX_SET_INSTALL_RPATH = "TRUE"
 
 [tool.cibuildwheel]
 build-frontend = { name = "build", args = [

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,12 +1,12 @@
 cmake_minimum_required(VERSION 3.21)
 
-project(basix_nanobind VERSION LANGUAGES CXX)
+project(basix_nanobind LANGUAGES CXX)
 
 if(WIN32)
     # Windows requires all symbols to be manually exported.
     # This flag exports all symbols automatically, as in Unix.
     set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
-endif(WIN32)
+endif()
 
 # See https://gitlab.kitware.com/cmake/cmake/-/issues/16414
 if(TARGET basix)
@@ -37,7 +37,7 @@ if(NOT "${SKBUILD_SABI_VERSION}" STREQUAL "")
   set(NANOBIND_SABI "STABLE_ABI")
 endif()
 nanobind_add_module(_basixcpp NB_SUPPRESS_WARNINGS ${NANOBIND_SABI} wrapper.cpp)
-target_compile_definitions(_basixcpp PRIVATE cxx_std_20)
+target_compile_features(_basixcpp PRIVATE cxx_std_20)
 
 if(ENABLE_CLANG_TIDY)
   find_program(CLANG_TIDY NAMES clang-tidy REQUIRED)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -23,6 +23,8 @@ include(FeatureSummary)
 option(ENABLE_CLANG_TIDY "Run clang-tidy while building" OFF)
 add_feature_info(ENABLE_CLANG_TIDY ENABLE_CLANG_TIDY "Run clang-tidy while building")
 
+option(BASIX_SET_INSTALL_RPATH "Embed RPATH to installed C++ library." ON)
+
 feature_summary(WHAT ALL)
 
 # Detect the installed nanobind package and import it into CMake
@@ -93,20 +95,29 @@ target_compile_definitions(
 target_compile_definitions(_basixcpp PRIVATE MDSPAN_USE_PAREN_OPERATOR=1)
 target_compile_definitions(_basixcpp PRIVATE MDSPAN_USE_BRACKET_OPERATOR=0)
 
-# Add relative rpath so _basixcpp can find the bundled Basix::basix library
-# when the build is relocated
-if(BASIX_FULL_SKBUILD)
+if(BASIX_FULL_SKBUILD AND BASIX_SET_INSTALL_RPATH)
+  # If building bundled C++ and Python wrapper wheel `pip install .` add relative
+  # rpath so _basixcpp can find the bundled Basix::basix library when the wheel
+  # is relocated.
   if(APPLE)
     set_target_properties(_basixcpp PROPERTIES INSTALL_RPATH "@loader_path/lib")
   elseif(UNIX)
     set_target_properties(_basixcpp PROPERTIES INSTALL_RPATH "$ORIGIN/lib")
   endif()
+elif(BASIX_SET_INSTALL_RPATH)
+  # If building standalone Python wrapper `pip install python/` put absolute
+  # path to Basix C++ on RPATH - can help if Basix::basix is outside a system
+  # directory. This makes the build non-relocatable.
+  get_target_property(_location Basix::basix LOCATION)
+  get_filename_component(_basix_dir ${_location} DIRECTORY)
+  set_target_properties(_basixcpp PROPERTIES INSTALL_RPATH ${_basix_dir})
 endif()
 
 # and the nanobind typing stubs.
 if (WIN32)
-  # On Windows we cannot import basix._basixcpp without installing the package
-  # alongside its external dlls.
+  # On Windows we cannot import basix._basixcpp without bundling in all
+  # external dlls and relying on Windows library search order - effectively a
+  # 'static binary build'.
 
   # This *must* be called prior to nanobind_add_stub
   install(TARGETS _basixcpp LIBRARY DESTINATION basix)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.21)
 
 # nanobind uses aligned deallocators only present on macOS > 10.14
-if(APPLE)
+if(APPLE and NOT CMAKE_OSX_DEPLOYMENT_TARGET)
   set(CMAKE_OSX_DEPLOYMENT_TARGET "10.14")
 endif()
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -23,7 +23,8 @@ include(FeatureSummary)
 option(ENABLE_CLANG_TIDY "Run clang-tidy while building" OFF)
 add_feature_info(ENABLE_CLANG_TIDY ENABLE_CLANG_TIDY "Run clang-tidy while building")
 
-option(BASIX_SET_INSTALL_RPATH "Embed RPATH to installed C++ library." ON)
+option(BASIX_SET_INSTALL_RPATH "Set RPATH to location of installed C++ library" ON)
+add_feature_info(BASIX_SET_INSTALL_RPATH BASIX_SET_INSTALL_RPATH "Set RPATH to location of installed C++ library")
 
 feature_summary(WHAT ALL)
 
@@ -104,10 +105,10 @@ if(BASIX_FULL_SKBUILD AND BASIX_SET_INSTALL_RPATH)
   elseif(UNIX)
     set_target_properties(_basixcpp PROPERTIES INSTALL_RPATH "$ORIGIN/lib")
   endif()
-elif(BASIX_SET_INSTALL_RPATH)
+elseif(BASIX_SET_INSTALL_RPATH)
   # If building standalone Python wrapper `pip install python/` put absolute
-  # path to Basix C++ on RPATH - can help if Basix::basix is outside a system
-  # directory. This makes the build non-relocatable.
+  # path to Basix C++ library on rpath - can help linking if it is outside a
+  # system directory. The build is non-relocatable.
   get_target_property(_location Basix::basix LOCATION)
   get_filename_component(_basix_dir ${_location} DIRECTORY)
   set_target_properties(_basixcpp PROPERTIES INSTALL_RPATH ${_basix_dir})

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -23,8 +23,8 @@ include(FeatureSummary)
 option(ENABLE_CLANG_TIDY "Run clang-tidy while building" OFF)
 add_feature_info(ENABLE_CLANG_TIDY ENABLE_CLANG_TIDY "Run clang-tidy while building")
 
-option(BASIX_SET_INSTALL_RPATH "Set RPATH to location of installed C++ library" ON)
-add_feature_info(BASIX_SET_INSTALL_RPATH BASIX_SET_INSTALL_RPATH "Set RPATH to location of installed C++ library")
+option(BASIX_SET_INSTALL_RPATH "Set rpath of _basixcpp to location of installed C++ library" TRUE)
+add_feature_info(BASIX_SET_INSTALL_RPATH BASIX_SET_INSTALL_RPATH "Set rpath of _basixcpp to location of installed C++ library")
 
 feature_summary(WHAT ALL)
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,10 +1,5 @@
 cmake_minimum_required(VERSION 3.21)
 
-# nanobind uses aligned deallocators only present on macOS > 10.14
-if(APPLE and NOT CMAKE_OSX_DEPLOYMENT_TARGET)
-  set(CMAKE_OSX_DEPLOYMENT_TARGET "10.14")
-endif()
-
 project(basix_nanobind VERSION LANGUAGES CXX)
 
 if(WIN32)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -98,7 +98,7 @@ target_compile_definitions(
 target_compile_definitions(_basixcpp PRIVATE MDSPAN_USE_PAREN_OPERATOR=1)
 target_compile_definitions(_basixcpp PRIVATE MDSPAN_USE_BRACKET_OPERATOR=0)
 
-# Add relative rpath so _basixcpp can find the Basix::basix library
+# Add relative rpath so _basixcpp can find the bundled Basix::basix library
 # when the build is relocated
 if(BASIX_FULL_SKBUILD)
   if(APPLE)
@@ -106,10 +106,6 @@ if(BASIX_FULL_SKBUILD)
   elseif(UNIX)
     set_target_properties(_basixcpp PROPERTIES INSTALL_RPATH "$ORIGIN/lib")
   endif()
-else()
-  get_target_property(_location Basix::basix LOCATION)
-  get_filename_component(_basix_dir ${_location} DIRECTORY)
-  set_target_properties(_basixcpp PROPERTIES INSTALL_RPATH ${_basix_dir})
 endif()
 
 # and the nanobind typing stubs.

--- a/python/README.md
+++ b/python/README.md
@@ -1,8 +1,3 @@
-# Re-generating nanobind stubs
+# Basix Python
 
-To update the nanobind type stubs, after installing the Basix Python
-interface, run:
-```sh
-python -m nanobind.stubgen -m basix._basixcpp -M basix/py.typed -p pattern_stub.txt -o basix/_basixcpp.pyi
-```
-from the `python/` directory.
+Please see `../INSTALL.md` and `../README.md`.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -34,3 +34,7 @@ ignore_missing_imports = true
 
 [tool.scikit-build]
 wheel.packages = ["basix"]
+
+[tool.scikit-build.cmake.define]
+# Set to OFF to disable all install RPATH adjustments
+BASIX_SET_INSTALL_RPATH = "ON"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -36,5 +36,5 @@ ignore_missing_imports = true
 wheel.packages = ["basix"]
 
 [tool.scikit-build.cmake.define]
-# Set to OFF to disable all install RPATH adjustments
-BASIX_SET_INSTALL_RPATH = "ON"
+# Set to FALSE to disable all install RPATH adjustments
+BASIX_SET_INSTALL_RPATH = "TRUE"


### PR DESCRIPTION
RPATH adjustments can be disabled in Python interface using `-Ccmake.args=-DBASIX_SET_INSTALL_RPATH=False`. This is possibly useful for packages and users who prefer dynamic library discovery. Many other small fixes.