### PR TITLE
Extend typing checks to demos

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -164,8 +164,8 @@ jobs:
         run: mypy -p basix
       - name: Run mypy (test)
         run: mypy test
-      # - name: Run mypy (demo)
-      #   run: mypy demo/python
+      - name: Run mypy (demo)
+        run: mypy demo/python
 
   build-separately:
     name: Build C++ and Python parts separately and run tests

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -42,6 +42,7 @@ jobs:
           pip install mypy numpy
           pip install git+https://github.com/${{ env.ufl_repository }}.git@${{ env.ufl_ref }}
           mypy python/basix
+          mypy demo/python
       - name: Gersemi check
         run: |
           pip install gersemi

--- a/demo/python/demo_custom_element.py
+++ b/demo/python/demo_custom_element.py
@@ -8,6 +8,7 @@
 # First, we import Basix and Numpy.
 
 import numpy as np
+from numpy import typing as npt
 
 import basix
 from basix import CellType, LatticeType, MapType, PolynomialType, PolysetType, SobolevSpace
@@ -121,7 +122,7 @@ for _ in range(4):
 # The shape of each matrix is (number of DOFs, value size, number of
 # points, number of derivatives).
 
-M = [[], [], [], []]
+M: list[list[npt.NDArray[np.floating]]] = [[], [], [], []]
 for _ in range(4):
     M[0].append(np.array([[[[1.0]]]]))
 M[2].append(np.array([[[[1.0]]]]))

--- a/demo/python/demo_custom_element.py
+++ b/demo/python/demo_custom_element.py
@@ -157,7 +157,7 @@ for _ in range(4):
 
 element = basix.create_custom_element(
     CellType.quadrilateral,
-    [],
+    (),
     wcoeffs,
     x,
     M,
@@ -261,7 +261,7 @@ M[2].append(np.zeros((0, 2, 0, 1)))
 
 element = basix.create_custom_element(
     CellType.triangle,
-    [2],
+    (2,),
     wcoeffs,
     x,
     M,

--- a/demo/python/demo_custom_element.py
+++ b/demo/python/demo_custom_element.py
@@ -79,9 +79,9 @@ wcoeffs[3, 4] = 1
 
 pts, wts = basix.make_quadrature(CellType.quadrilateral, 4)
 poly = basix.tabulate_polynomials(PolynomialType.legendre, CellType.quadrilateral, 2, pts)
-x = pts[:, 0]
+_x = pts[:, 0]
 y = pts[:, 1]
-f = x * (1 - x) * y * (1 - y)
+f = _x * (1 - _x) * y * (1 - y)
 for i in range(9):
     wcoeffs[4, i] = sum(f * poly[i, :] * wts)
 
@@ -101,7 +101,7 @@ for i in range(9):
 #
 # The shape of each of the point lists is (number of points, dimension).
 
-x = [[], [], [], []]
+x: list[list[npt.NDArray[np.floating]]] = [[], [], [], []]
 x[0].append(np.array([[0.0, 0.0]]))
 x[0].append(np.array([[1.0, 0.0]]))
 x[0].append(np.array([[0.0, 1.0]]))
@@ -216,10 +216,10 @@ wcoeffs[1, 3] = 1
 
 pts, wts = basix.make_quadrature(CellType.triangle, 2)
 poly = basix.tabulate_polynomials(PolynomialType.legendre, CellType.triangle, 1, pts)
-x = pts[:, 0]
+_x = pts[:, 0]
 y = pts[:, 1]
 for i in range(3):
-    wcoeffs[2, i] = sum(x * poly[i, :] * wts)
+    wcoeffs[2, i] = sum(_x * poly[i, :] * wts)
     wcoeffs[2, 3 + i] = sum(y * poly[i, :] * wts)
 
 # Interpolation

--- a/demo/python/demo_custom_element.py
+++ b/demo/python/demo_custom_element.py
@@ -101,7 +101,7 @@ for i in range(9):
 #
 # The shape of each of the point lists is (number of points, dimension).
 
-x: list[list[npt.NDArray[np.floating]]] = [[], [], [], []]
+x: list[list[npt.NDArray[np.float64]]] = [[], [], [], []]
 x[0].append(np.array([[0.0, 0.0]]))
 x[0].append(np.array([[1.0, 0.0]]))
 x[0].append(np.array([[0.0, 1.0]]))
@@ -122,7 +122,7 @@ for _ in range(4):
 # The shape of each matrix is (number of DOFs, value size, number of
 # points, number of derivatives).
 
-M: list[list[npt.NDArray[np.floating]]] = [[], [], [], []]
+M: list[list[npt.NDArray[np.float64]]] = [[], [], [], []]
 for _ in range(4):
     M[0].append(np.array([[[[1.0]]]]))
 M[2].append(np.array([[[[1.0]]]]))

--- a/demo/python/demo_custom_element_conforming_cr.py
+++ b/demo/python/demo_custom_element_conforming_cr.py
@@ -51,7 +51,7 @@ def create_ccr_triangle(degree):
 
         return basix.create_custom_element(
             CellType.triangle,
-            [],
+            (),
             wcoeffs,
             x,
             M,
@@ -105,7 +105,7 @@ def create_ccr_triangle(degree):
 
     return basix.create_custom_element(
         CellType.triangle,
-        [],
+        (),
         wcoeffs,
         x,
         M,

--- a/python/basix/finite_element.py
+++ b/python/basix/finite_element.py
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier:    MIT
 """Functions for creating finite elements."""
 
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING, Generic, Sequence, TypeVar
 from warnings import warn
 
 import numpy as np
@@ -43,8 +43,10 @@ __all__ = [
     "tp_factors",
 ]
 
+T = TypeVar("T", np.float32, np.float64)
 
-class FiniteElement:
+
+class FiniteElement(Generic[T]):
     """Finite element class."""
 
     _e: _FiniteElement_float32 | _FiniteElement_float64
@@ -57,7 +59,7 @@ class FiniteElement:
         """
         self._e = e
 
-    def tabulate(self, n: int, x: npt.NDArray[np.floating]) -> npt.NDArray[np.floating]:
+    def tabulate(self, n: int, x: npt.NDArray[T]) -> npt.NDArray[T]:
         """Compute basis values and derivatives at set of points.
 
         Note:
@@ -89,7 +91,7 @@ class FiniteElement:
             * The third index is the basis function index one for scalar
                 basis functions.
         """
-        return self._e.tabulate(n, x)
+        return self._e.tabulate(n, x)  # type: ignore
 
     def __eq__(self, other) -> bool:
         """Test element for equality."""
@@ -106,7 +108,7 @@ class FiniteElement:
         """Hash."""
         return self.hash()
 
-    def push_forward(self, U, J, detJ, K) -> npt.ArrayLike:
+    def push_forward(self, U, J, detJ, K) -> npt.NDArray[T]:
         """Map function values from the reference to a physical cell.
 
         This function can perform the mapping for multiple points,
@@ -126,11 +128,11 @@ class FiniteElement:
             The function values on the cell. The indices are ``(Jacobian
             index, point index, components)``.
         """
-        return self._e.push_forward(U, J, detJ, K)
+        return self._e.push_forward(U, J, detJ, K)  # type: ignore
 
     def pull_back(
         self, u: npt.NDArray, J: npt.NDArray, detJ: npt.NDArray, K: npt.NDArray
-    ) -> npt.ArrayLike:
+    ) -> npt.NDArray[T]:
         """Map function values from a physical cell to the reference.
 
         Args:
@@ -143,7 +145,7 @@ class FiniteElement:
             The function values on the reference. The indices are
             ``(Jacobian index, point index, components``).
         """
-        return self._e.pull_back(u, J, detJ, K)
+        return self._e.pull_back(u, J, detJ, K)  # type: ignore
 
     def T_apply(self, data, block_size, cell_info) -> None:
         """Apply DOF transformations to some data in-place.
@@ -188,7 +190,7 @@ class FiniteElement:
         """
         self._e.Tt_inv_apply(data, block_size, cell_info)
 
-    def base_transformations(self) -> npt.ArrayLike:
+    def base_transformations(self) -> npt.NDArray[T]:
         r"""Get the base transformations.
 
         The base transformations represent the effect of rotating or
@@ -284,7 +286,7 @@ class FiniteElement:
             The base transformations for this element. The shape is
             ``(ntranformations, ndofs, ndofs)``.
         """
-        return self._e.base_transformations()
+        return self._e.base_transformations()  # type: ignore
 
     def entity_transformations(self) -> dict:
         """Entity dof transformation matrices.
@@ -320,7 +322,7 @@ class FiniteElement:
         cell_or_entity_info: int,
         entity_type: CellType,
         entity_index: int | None = None,
-    ) -> npt.NDArray:
+    ) -> npt.NDArray[T]:
         """Permute DOF indices on the closure of a sub-entity.
 
         Args:
@@ -347,7 +349,7 @@ class FiniteElement:
         cell_or_entity_info: int,
         entity_type: CellType,
         entity_index: int | None = None,
-    ) -> npt.NDArray:
+    ) -> npt.NDArray[T]:
         """Apply inverse permutation to DOF indices on the closure of a sub-entity.
 
         Args:
@@ -509,62 +511,62 @@ class FiniteElement:
         return self._e.sobolev_space
 
     @property
-    def points(self) -> npt.ArrayLike:
+    def points(self) -> npt.NDArray[T]:
         """Interpolation points.
 
         Coordinates on the reference element where a function need to be
         evaluated in order to interpolate it in the finite element
         space. Shape is ``(num_points, tdim)``.
         """
-        return self._e.points
+        return self._e.points  # type: ignore
 
     @property
-    def interpolation_matrix(self) -> npt.ArrayLike:
+    def interpolation_matrix(self) -> npt.NDArray[T]:
         """Interpolation points.
 
         Coordinates on the reference element where a function need to be
         evaluated in order to interpolate it in the finite element
         space.
         """
-        return self._e.interpolation_matrix
+        return self._e.interpolation_matrix  # type: ignore
 
     @property
-    def dual_matrix(self) -> npt.ArrayLike:
+    def dual_matrix(self) -> npt.NDArray[T]:
         """Matrix $BD^{T}$.
 
         See C++ documentation.
         """
-        return self._e.dual_matrix
+        return self._e.dual_matrix  # type: ignore
 
     @property
-    def coefficient_matrix(self) -> npt.ArrayLike:
+    def coefficient_matrix(self) -> npt.NDArray[T]:
         """Matrix of coefficients."""
-        return self._e.coefficient_matrix
+        return self._e.coefficient_matrix  # type: ignore
 
     @property
-    def wcoeffs(self) -> npt.ArrayLike:
+    def wcoeffs(self) -> npt.NDArray[T]:
         """Coefficients that define the polynomial set in terms of the orthonormal polynomials.
 
         See C++ documentation for details.
         """
-        return self._e.wcoeffs
+        return self._e.wcoeffs  # type: ignore
 
     @property
-    def M(self) -> list[list[npt.NDArray]]:
+    def M(self) -> list[list[npt.NDArray[T]]]:
         """Interpolation matrices for each sub-entity.
 
         See C++ documentation for details.
         """
-        return self._e.M
+        return self._e.M  # type: ignore
 
     @property
-    def x(self) -> list[list[npt.NDArray]]:
+    def x(self) -> list[list[npt.NDArray[T]]]:
         """Interpolation points for each sub-entity.
 
         The indices of this data are ``(tdim, entity index, point index,
         dim)``.
         """
-        return self._e.x
+        return self._e.x  # type: ignore
 
     @property
     def has_tensor_product_factorisation(self) -> bool:

--- a/python/basix/finite_element.py
+++ b/python/basix/finite_element.py
@@ -634,9 +634,9 @@ def create_element(
 def create_custom_element(
     cell_type: CellType,
     value_shape: Sequence[int],
-    wcoeffs: npt.NDArray[np.floating],
-    x: list[list[npt.NDArray[np.floating]]],
-    M: list[list[npt.NDArray[np.floating]]],
+    wcoeffs: npt.NDArray[T],
+    x: list[list[npt.NDArray[T]]],
+    M: list[list[npt.NDArray[T]]],
     interpolation_nderivs: int,
     map_type: "MapType",
     sobolev_space: SobolevSpace,
@@ -645,7 +645,7 @@ def create_custom_element(
     embedded_superdegree: int,
     poly_type: PolysetType,
     dtype: npt.DTypeLike | None = np.float64,
-) -> FiniteElement:
+) -> FiniteElement[T]:
     """Create a custom finite element.
 
     Args:
@@ -720,9 +720,9 @@ def create_custom_element(
         _create_custom_element(
             cell_type,
             tuple(value_shape),
-            wcoeffs,
-            x,
-            M,
+            wcoeffs,  # type: ignore
+            x,  # type: ignore
+            M,  # type: ignore
             interpolation_nderivs,
             map_type,
             sobolev_space,

--- a/python/basix/finite_element.py
+++ b/python/basix/finite_element.py
@@ -6,7 +6,7 @@
 """Functions for creating finite elements."""
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Generic, TypeVar, Self
+from typing import TYPE_CHECKING, Generic, Self, TypeVar
 from warnings import warn
 
 import numpy as np

--- a/python/basix/finite_element.py
+++ b/python/basix/finite_element.py
@@ -5,7 +5,8 @@
 # SPDX-License-Identifier:    MIT
 """Functions for creating finite elements."""
 
-from typing import TYPE_CHECKING, Generic, Sequence, TypeVar
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Generic, TypeVar
 from warnings import warn
 
 import numpy as np

--- a/python/basix/finite_element.py
+++ b/python/basix/finite_element.py
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier:    MIT
 """Functions for creating finite elements."""
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Sequence
 from warnings import warn
 
 import numpy as np
@@ -57,7 +57,7 @@ class FiniteElement:
         """
         self._e = e
 
-    def tabulate(self, n: int, x: npt.NDArray) -> npt.ArrayLike:
+    def tabulate(self, n: int, x: npt.NDArray[np.floating]) -> npt.NDArray[np.floating]:
         """Compute basis values and derivatives at set of points.
 
         Note:
@@ -631,7 +631,7 @@ def create_element(
 
 def create_custom_element(
     cell_type: CellType,
-    value_shape: tuple[int, ...],
+    value_shape: Sequence[int],
     wcoeffs: npt.NDArray[np.floating],
     x: list[list[npt.NDArray[np.floating]]],
     M: list[list[npt.NDArray[np.floating]]],
@@ -717,7 +717,7 @@ def create_custom_element(
     return FiniteElement(
         _create_custom_element(
             cell_type,
-            value_shape,
+            tuple(value_shape),
             wcoeffs,
             x,
             M,

--- a/python/basix/lattice.py
+++ b/python/basix/lattice.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier:    MIT
 """Functions to manipulate lattice types."""
 
+import numpy as np
 import numpy.typing as npt
 
 from basix._basixcpp import LatticeSimplexMethod, LatticeType
@@ -20,7 +21,7 @@ def create_lattice(
     ltype: LatticeType,
     exterior: bool,
     method: LatticeSimplexMethod = LatticeSimplexMethod.none,
-) -> npt.ArrayLike:
+) -> npt.NDArray[np.float64]:
     """Create a lattice of points on a reference cell.
 
     Args:

--- a/python/basix/polynomials.py
+++ b/python/basix/polynomials.py
@@ -160,8 +160,8 @@ def dim(ptype: PolynomialType, celltype: CellType, degree: int) -> int:
 
 
 def tabulate_polynomials(
-    ptype: PolynomialType, celltype: CellType, degree: int, pts: npt.NDArray
-) -> npt.ArrayLike:
+    ptype: PolynomialType, celltype: CellType, degree: int, pts: npt.NDArray[np.float64]
+) -> npt.NDArray[np.float64]:
     """Tabulate a set of polynomials on a reference cell.
 
     Args:

--- a/python/basix/quadrature.py
+++ b/python/basix/quadrature.py
@@ -43,7 +43,7 @@ def make_quadrature(
     degree: int,
     rule: QuadratureType = QuadratureType.default,
     polyset_type: PolysetType = PolysetType.standard,
-) -> tuple[_npt.ArrayLike, _npt.ArrayLike]:
+) -> tuple[_npt.NDArray[_np.float64], _npt.NDArray[_np.float64]]:
     """Create a quadrature rule.
 
     Args:

--- a/test/test_custom_element.py
+++ b/test/test_custom_element.py
@@ -31,7 +31,7 @@ def test_lagrange_custom_triangle_degree1():
     lagrange = basix.create_element(basix.ElementFamily.P, CellType.triangle, 1)
     element = basix.create_custom_element(
         CellType.triangle,
-        [],
+        (),
         wcoeffs,
         x,
         M,
@@ -65,7 +65,7 @@ def test_lagrange_custom_triangle_degree1_l2piola():
     lagrange = basix.create_element(basix.ElementFamily.P, CellType.triangle, 1)
     element = basix.create_custom_element(
         CellType.triangle,
-        [],
+        (),
         wcoeffs,
         x,
         M,
@@ -108,7 +108,7 @@ def test_lagrange_custom_triangle_degree4():
     )
     element = basix.create_custom_element(
         CellType.triangle,
-        [],
+        (),
         wcoeffs,
         x,
         M,
@@ -157,7 +157,7 @@ def test_lagrange_custom_quadrilateral_degree1():
     lagrange = basix.create_element(basix.ElementFamily.P, CellType.quadrilateral, 1)
     element = basix.create_custom_element(
         CellType.quadrilateral,
-        [],
+        (),
         wcoeffs,
         x,
         M,
@@ -212,7 +212,7 @@ def test_raviart_thomas_triangle_degree1():
 
     element = basix.create_custom_element(
         CellType.triangle,
-        [2],
+        (2,),
         wcoeffs,
         x,
         M,
@@ -562,7 +562,7 @@ def test_point_outside_cell_gives_warning(dim, component):
     with pytest.warns(UserWarning):
         basix.create_custom_element(
             CellType.tetrahedron,
-            [],
+            (),
             wcoeffs,
             x,
             M,

--- a/test/test_elements.py
+++ b/test/test_elements.py
@@ -207,7 +207,7 @@ def test_hash():
     ]
     e5 = basix.create_custom_element(
         basix.CellType.triangle,
-        [],
+        (),
         wcoeffs,
         x,
         M,

--- a/test/test_equality.py
+++ b/test/test_equality.py
@@ -61,7 +61,7 @@ def cr_custom():
 
     return basix.create_custom_element(
         basix.CellType.triangle,
-        [],
+        (),
         wcoeffs,
         x,
         M,


### PR DESCRIPTION
Basix is now fully `mypy` covered. Introduces minimal typing generics to `FiniteElement` to pass checks, this should be extended on in the future. 

- Fixes https://github.com/FEniCS/basix/issues/993.
- Fixes https://github.com/FEniCS/basix/issues/1010.