### PR TITLE
Fix inaccuracies and improve clarity in C++ API documentation

### DIFF
--- a/cpp/basix/cell.h
+++ b/cpp/basix/cell.h
@@ -30,16 +30,16 @@ enum class type : int
 };
 
 /// Cell geometry
-/// @param celltype Cell Type
+/// @param celltype Cell type
 /// @return (0) Vertex point data of the cell and (1) the shape of the
 /// data array. The points are stored in row-major format and the shape
-/// is is (npoints, gdim)
+/// is (npoints, gdim)
 template <std::floating_point T>
 std::pair<std::vector<T>, std::array<std::size_t, 2>>
 geometry(cell::type celltype);
 
 /// Cell topology
-/// @param celltype Cell Type
+/// @param celltype Cell type
 /// @return List of topology (vertex indices) for each dimension (0..tdim)
 std::vector<std::vector<std::vector<int>>> topology(cell::type celltype);
 
@@ -51,13 +51,14 @@ std::vector<std::vector<std::vector<int>>> topology(cell::type celltype);
 /// the entities of dimension `connected_dim` and numbers
 /// `connected_entity_n0`, `connected_entity_n1`, ...
 ///
-/// @param celltype Cell Type
-/// @return List of topology (vertex indices) for each dimension (0..tdim)
+/// @param celltype Cell type
+/// @return Connectivity data indexed as `[dim][entity_n][connected_dim]`
+/// -> list of connected entity numbers, as described above.
 std::vector<std::vector<std::vector<std::vector<int>>>>
 sub_entity_connectivity(cell::type celltype);
 
 /// Sub-entity of a cell, given by topological dimension and index
-/// @param celltype The cell::type
+/// @param celltype Cell type
 /// @param dim Dimension of sub-entity
 /// @param index Local index of sub-entity
 /// @return Set of vertex points of the sub-entity. Shape is (npoints, gdim)
@@ -66,7 +67,7 @@ std::pair<std::vector<T>, std::array<std::size_t, 2>>
 sub_entity_geometry(cell::type celltype, int dim, int index);
 
 /// Number of sub-entities of a cell by topological dimension
-/// @param celltype The cell::type
+/// @param celltype Cell type
 /// @param dim Dimension of sub-entity
 /// @return The number of sub-entities of the given dimension
 int num_sub_entities(cell::type celltype, int dim);
@@ -77,20 +78,20 @@ int num_sub_entities(cell::type celltype, int dim);
 int topological_dimension(cell::type celltype);
 
 /// Get the cell type of a sub-entity of given dimension and index
-/// @param celltype Type of cell
+/// @param celltype Cell type
 /// @param dim Topological dimension of sub-entity
 /// @param index Index of sub-entity
 /// @return cell type of sub-entity
 cell::type sub_entity_type(cell::type celltype, int dim, int index);
 
 /// Get the volume of a reference cell
-/// @param cell_type Type of cell
+/// @param cell_type Cell type
 /// @return The volume of the cell
 template <std::floating_point T>
 T volume(cell::type cell_type);
 
 /// Get the (outward) normals to the facets of a reference cell
-/// @param cell_type Type of cell
+/// @param cell_type Cell type
 /// @return The outward normals. Shape is (nfacets, gdim)
 template <std::floating_point T>
 std::pair<std::vector<T>, std::array<std::size_t, 2>>
@@ -99,7 +100,7 @@ facet_outward_normals(cell::type cell_type);
 /// Get the normals to the facets of a reference cell oriented using the
 /// low-to-high ordering of the facet, scaled so that the length of the
 /// normal is the volume of the facet
-/// @param cell_type Type of cell
+/// @param cell_type Cell type
 /// @return The normals. Shape is (nfacets, gdim)
 template <std::floating_point T>
 std::pair<std::vector<T>, std::array<std::size_t, 2>>
@@ -107,7 +108,7 @@ scaled_facet_normals(cell::type cell_type);
 
 /// Get the normals to the facets of a reference cell oriented using the
 /// low-to-high ordering of the facet
-/// @param cell_type Type of cell
+/// @param cell_type Cell type
 /// @return The normals. Shape is (nfacets, gdim)
 template <std::floating_point T>
 std::pair<std::vector<T>, std::array<std::size_t, 2>>
@@ -115,40 +116,40 @@ facet_normals(cell::type cell_type);
 
 /// Get an array of bools indicating whether or not the facet normals are
 /// outward pointing
-/// @param cell_type Type of cell
+/// @param cell_type Cell type
 /// @return The orientations
 std::vector<bool> facet_orientations(cell::type cell_type);
 
 /// Get the reference volumes of the facets of a reference cell
-/// @param cell_type Type of cell
-/// @return The volumes of the references associated with each facet
+/// @param cell_type Cell type
+/// @return The reference volume of each facet
 template <std::floating_point T>
 std::vector<T> facet_reference_volumes(cell::type cell_type);
 
 /// Get the types of the subentities of a reference cell
-/// @param cell_type Type of cell
+/// @param cell_type Cell type
 /// @return The subentity types. Indices are (tdim, entity)
 std::vector<std::vector<cell::type>> subentity_types(cell::type cell_type);
 
 /// Get the jacobians of a set of entities of a reference cell
-/// @param cell_type Type of cell
+/// @param cell_type Cell type
 /// @param e_dim Dimension of entities
-/// @return The jacobians of the facets (flattened) and the shape (nfacets,
-/// tdim, tdim - 1).
+/// @return The jacobians of the entities of dimension `e_dim`
+/// (flattened) and the shape `(n_entities, tdim, e_dim)`.
 template <std::floating_point T>
 std::pair<std::vector<T>, std::array<std::size_t, 3>>
 entity_jacobians(cell::type cell_type, std::size_t e_dim);
 
 /// Get the jacobians of the facets of a reference cell
-/// @param cell_type Type of cell
+/// @param cell_type Cell type
 /// @return The jacobians of the facets (flattened) and the shape (nfacets,
 /// tdim, tdim - 1).
 template <std::floating_point T>
 std::pair<std::vector<T>, std::array<std::size_t, 3>>
 facet_jacobians(cell::type cell_type);
 
-/// Get the jacobians of the edegs of a reference cell
-/// @param cell_type Type of cell
+/// Get the jacobians of the edges of a reference cell
+/// @param cell_type Cell type
 /// @return The jacobians of the edges (flattened) and the shape (nedges, tdim,
 /// tdim-2).
 template <std::floating_point T>

--- a/cpp/basix/dof-transformations.h
+++ b/cpp/basix/dof-transformations.h
@@ -15,9 +15,9 @@
 #include <vector>
 
 ///
-/// @brief Functions to transform DOFs in high degree Lagrange spaces.
-/// The functions in this namespace calculate the permutations that can
-/// be used to rotate and reflect DOF points in Lagrange spaces.
+/// @brief Functions to compute the DOF transformations (rotations and
+/// reflections of entity DOFs) needed by a finite element under a
+/// change of entity orientation.
 namespace basix::doftransforms
 {
 /// @brief Compute the entity DOF transformations for an element.
@@ -29,8 +29,11 @@ namespace basix::doftransforms
 /// (tdim, entity index, dof, vs, point_index, derivative)
 /// @param[in] coeffs The coefficients that define the basis functions
 /// of the element in terms of the orthonormal basis. Shape is
-/// (dim(Legendre polynomials), dim(finite element polyset))
-/// @param[in] degree The degree of the element
+/// (number of basis functions of the element, dim(Legendre
+/// polynomials))
+/// @param[in] degree The embedded superdegree of the element (the
+/// lowest degree `n` such that the element's polynomial set is a
+/// subspace of a Lagrange element of degree `n`)
 /// @param[in] vs The value size of the element
 /// @param[in] map_type The map type used by the element
 /// @param[in] ptype The polyset type used by the element

--- a/cpp/basix/e-lagrange.h
+++ b/cpp/basix/e-lagrange.h
@@ -15,8 +15,10 @@ namespace basix::element
 /// @param[in] celltype The element cell type
 /// @param[in] degree The degree of the element
 /// @param[in] variant The variant of the element to be created
-/// @param[in] discontinuous True if the is discontinuous
-/// @param[in] dof_ordering DOF reordering
+/// @param[in] discontinuous Controls whether the element is continuous or
+/// discontinuous
+/// @param[in] dof_ordering A mapping from the reference DOF order to a
+/// new permuted order (empty for the default ordering)
 /// @return A finite element
 template <std::floating_point T>
 FiniteElement<T> create_lagrange(cell::type celltype, int degree,
@@ -27,7 +29,8 @@ FiniteElement<T> create_lagrange(cell::type celltype, int degree,
 /// @param[in] celltype The element cell type
 /// @param[in] degree The degree of the element
 /// @param[in] variant The variant of the element to be created
-/// @param[in] discontinuous True if the is discontinuous
+/// @param[in] discontinuous Controls whether the element is continuous or
+/// discontinuous
 /// @return A finite element
 template <std::floating_point T>
 FiniteElement<T> create_iso(cell::type celltype, int degree,

--- a/cpp/basix/e-serendipity.h
+++ b/cpp/basix/e-serendipity.h
@@ -34,8 +34,8 @@ FiniteElement<T> create_serendipity(cell::type celltype, int degree,
 /// @param[in] celltype The cell type
 /// @param[in] degree The degree of the element
 /// @param[in] variant The variant of the element to be created
-/// @param[in] discontinuous Controls whether the element is continuous or
-/// discontinuous
+/// @param[in] discontinuous Must be `true`; DPC elements are
+/// discontinuous only, and `false` causes a runtime error.
 /// @return A finite element
 template <std::floating_point T>
 FiniteElement<T> create_dpc(cell::type celltype, int degree,

--- a/cpp/basix/element-families.h
+++ b/cpp/basix/element-families.h
@@ -43,19 +43,20 @@ enum class dpc_variant
 /// Available element families
 enum class family
 {
-  custom = 0,
-  P = 1,
-  RT = 2,
-  N1E = 3,
-  BDM = 4,
-  N2E = 5,
-  CR = 6,
-  Regge = 7,
-  DPC = 8,
-  bubble = 9,
-  serendipity = 10,
-  HHJ = 11,
-  Hermite = 12,
-  iso = 13,
+  custom = 0,       /*!< Custom element, defined directly by its
+                       coefficients, interpolation points/matrices, etc. */
+  P = 1,            /*!< Lagrange */
+  RT = 2,           /*!< Raviart-Thomas */
+  N1E = 3,          /*!< Nedelec first kind */
+  BDM = 4,          /*!< Brezzi-Douglas-Marini */
+  N2E = 5,          /*!< Nedelec second kind */
+  CR = 6,           /*!< Crouzeix-Raviart */
+  Regge = 7,        /*!< Regge */
+  DPC = 8,          /*!< Discontinuous polynomial cubical */
+  bubble = 9,       /*!< Bubble */
+  serendipity = 10, /*!< Serendipity */
+  HHJ = 11,         /*!< Hellan-Herrmann-Johnson */
+  Hermite = 12,     /*!< Hermite */
+  iso = 13,         /*!< Iso (macro) element */
 };
 } // namespace basix::element

--- a/cpp/basix/finite-element.h
+++ b/cpp/basix/finite-element.h
@@ -288,8 +288,6 @@ public:
   /// @param[in] cell_type The cell type
   /// @param[in] poly_type The polyset type
   /// @param[in] degree The degree of the element
-  /// @param[in] interpolation_nderivs The number of derivatives that
-  /// need to be used during interpolation
   /// @param[in] value_shape The value shape of the element
   /// @param[in] wcoeffs Matrices for the kth value index containing the
   /// expansion coefficients defining a polynomial basis spanning the
@@ -299,6 +297,8 @@ public:
   /// index, point index, dim)
   /// @param[in] M The interpolation matrices. Indices are (tdim, entity
   /// index, dof, vs, point_index, derivative)
+  /// @param[in] interpolation_nderivs The number of derivatives that
+  /// need to be used during interpolation
   /// @param[in] map_type The type of map to be used to map values from
   /// the reference to a cell
   /// @param[in] sobolev_space The underlying Sobolev space for the
@@ -308,9 +308,9 @@ public:
   /// @param[in] embedded_subdegree The highest degree n such that
   /// a Lagrange (or vector Lagrange) element of degree n is a subspace
   /// of this element
-  /// @param[in] embedded_superdegree The highest degree n such that at least
-  /// one polynomial of degree n is included in this element's
-  /// polymonial set
+  /// @param[in] embedded_superdegree The lowest degree n such that
+  /// this element's polynomial set is a subspace of a Lagrange (or
+  /// vector Lagrange) element of degree n
   /// @param[in] lvariant The Lagrange variant of the element
   /// @param[in] dvariant The DPC variant of the element
   /// @param[in] dof_ordering DOF reordering: a mapping from the
@@ -378,7 +378,7 @@ public:
   /// @brief Compute basis values and derivatives at set of points.
   ///
   /// @note The version of tabulate() with the basis data as an out
-  /// argument should be preferred for repeated call where performance
+  /// argument should be preferred for repeated calls where performance
   /// is critical.
   ///
   /// @param[in] nd The order of derivatives, up to and including, to
@@ -394,7 +394,7 @@ public:
   /// appropriate derivative.
   /// - The second index is the point index
   /// - The third index is the basis function index
-  /// - The fourth index is the basis function component. Its has size
+  /// - The fourth index is the basis function component. It has size
   /// one for scalar basis functions.
   std::pair<std::vector<F>, std::array<std::size_t, 4>>
   tabulate(int nd, impl::mdspan_t<const F, 2> x) const;
@@ -402,7 +402,7 @@ public:
   /// @brief Compute basis values and derivatives at set of points.
   ///
   /// @note The version of tabulate() with the basis data as an out
-  /// argument should be preferred for repeated call where performance
+  /// argument should be preferred for repeated calls where performance
   /// is critical
   ///
   /// @param[in] nd The order of derivatives, up to and including, to
@@ -420,7 +420,7 @@ public:
   /// appropriate derivative.
   /// - The second index is the point index
   /// - The third index is the basis function index
-  /// - The fourth index is the basis function component. Its has size
+  /// - The fourth index is the basis function component. It has size
   /// one for scalar basis functions.
   std::pair<std::vector<F>, std::array<std::size_t, 4>>
   tabulate(int nd, std::span<const F> x,
@@ -446,7 +446,7 @@ public:
   /// find the appropriate derivative.
   /// - The second index is the point index
   /// - The third index is the basis function index
-  /// - The fourth index is the basis function component. Its has size
+  /// - The fourth index is the basis function component. It has size
   /// one for scalar basis functions.
   ///
   /// @todo Remove all internal dynamic memory allocation, pass scratch
@@ -477,7 +477,7 @@ public:
   /// appropriate derivative.
   /// - The second index is the point index
   /// - The third index is the basis function index
-  /// - The fourth index is the basis function component. Its has size
+  /// - The fourth index is the basis function component. It has size
   /// one for scalar basis functions.
   void tabulate(int nd, std::span<const F> x, std::array<std::size_t, 2> xshape,
                 std::span<F> basis) const;
@@ -494,9 +494,9 @@ public:
   /// @return Polynomial degree
   int degree() const { return _degree; }
 
-  /// @brief Lowest degree `n` such that the highest degree polynomial in this
-  /// element is contained in a Lagrange (or vector Lagrange) element of
-  /// degree `n`.
+  /// @brief Lowest degree `n` such that this element's polynomial set
+  /// is a subspace of a Lagrange (or vector Lagrange) element of degree
+  /// `n`.
   /// @return Polynomial degree
   int embedded_superdegree() const { return _embedded_superdegree; }
 
@@ -579,10 +579,14 @@ public:
                std::span<const F> detJ, impl::mdspan_t<const F, 3> K) const;
 
   /// @brief Map function values from a physical cell to the reference.
-  /// @param[in] u The function values on the cell
-  /// @param[in] J The Jacobian of the mapping
-  /// @param[in] detJ The determinant of the Jacobian of the mapping
-  /// @param[in] K The inverse of the Jacobian of the mapping
+  /// @param[in] u The function values on the cell. The indices are
+  /// `[Jacobian index, point index, components]`.
+  /// @param[in] J The Jacobian of the mapping. The indices are
+  /// `[Jacobian index, J_i, J_j]`.
+  /// @param[in] detJ The determinant of the Jacobian of the mapping. It
+  /// has length `J.shape(0)`.
+  /// @param[in] K The inverse of the Jacobian of the mapping. The
+  /// indices are `[Jacobian index, K_i, K_j]`.
   /// @return The function values on the reference. The indices are
   /// [Jacobian index, point index, components].
   std::pair<std::vector<F>, std::array<std::size_t, 3>>
@@ -757,7 +761,7 @@ public:
   ///                [1, 0]]
   /// ~~~~~~~~~~~~~~~~
   /// @return The base transformations for this element. The shape is
-  /// (ntranformations, ndofs, ndofs)
+  /// (ntransformations, ndofs, ndofs)
   std::pair<std::vector<F>, std::array<std::size_t, 3>>
   base_transformations() const;
 
@@ -1056,7 +1060,7 @@ public:
   /// elements, but not all.
   ///
   /// @param[in,out] u Data to transform. The shape is `(m, n)`, where
-  /// `m` is the number of dgerees-of-freedom and the storage is
+  /// `m` is the number of degrees-of-freedom and the storage is
   /// row-major.
   /// @param[in] n Number of columns in `data`.
   /// @param cell_info Permutation info for the cell
@@ -1069,7 +1073,7 @@ public:
   /// in-place.
   ///
   /// @param[in,out] u Data to transform. The shape is `(m, n)`, where
-  /// `m` is the number of dgerees-of-freedom an d the storage is
+  /// `m` is the number of degrees-of-freedom and the storage is
   /// row-major.
   /// @param[in] n Number of columns in `data`.
   /// @param[in] cell_info Permutation info for the cell,
@@ -1083,7 +1087,7 @@ public:
   /// in-place.
   ///
   /// @param[in,out] u Data to transform. The shape is `(m, n)`, where
-  /// `m` is the number of dgerees-of-freedom and the storage is
+  /// `m` is the number of degrees-of-freedom and the storage is
   /// row-major.
   /// @param[in] n Number of columns in `data`.
   /// @param[in] cell_info Permutation info for the cell.
@@ -1096,7 +1100,7 @@ public:
   /// in-place.
   ///
   /// @param[in,out] u Data to transform. The shape is `(m, n)`, where
-  /// `m` is the number of dgerees-of-freedom and the storage is
+  /// `m` is the number of degrees-of-freedom and the storage is
   /// row-major.
   /// @param[in] n Number of columns in `data`.
   /// @param[in] cell_info Permutation info for the cell.
@@ -1109,7 +1113,7 @@ public:
   /// Computes \f[ u^{T} \leftarrow u^{T} T^{T} \f] in-place.
   ///
   /// @param[in,out] u Data to transform. The shape is `(m, n)`, where
-  /// `m` is the number of dgerees-of-freedom and the storage is
+  /// `m` is the number of degrees-of-freedom and the storage is
   /// row-major.
   /// @param[in] n Number of columns in `data`.
   /// @param[in] cell_info Permutation info for the cell.
@@ -1121,7 +1125,7 @@ public:
   /// Computes \f[ u^{T} \leftarrow u^{T} T \f] in-place.
   ///
   /// @param[in,out] u Data to transform. The shape is `(m, n)`, where
-  /// `m` is the number of dgerees-of-freedom and the storage is
+  /// `m` is the number of degrees-of-freedom and the storage is
   /// row-major.
   /// @param[in] n Number of columns in `data`.
   /// @param[in] cell_info Permutation info for the cell.
@@ -1134,7 +1138,7 @@ public:
   /// Computes \f[ u^{T} \leftarrow u^{T} T^{-1} \f] in-place.
   ///
   /// @param[in,out] u Data to transform. The shape is `(m, n)`, where
-  /// `m` is the number of dgerees-of-freedom and the storage is
+  /// `m` is the number of degrees-of-freedom and the storage is
   /// row-major.
   /// @param[in] n Number of columns in `data`.
   /// @param cell_info Permutation info for the cell.
@@ -1147,7 +1151,7 @@ public:
   /// Computes \f[ u^{T} \leftarrow u^{T} T^{-T} \f] in-place.
   ///
   /// @param[in,out] u Data to transform. The shape is `(m, n)`, where
-  /// `m` is the number of dgerees-of-freedom and the storage is
+  /// `m` is the number of degrees-of-freedom and the storage is
   /// row-major.
   /// @param[in] n Number of columns in `data`.
   /// @param cell_info Permutation info for the cell.
@@ -1268,7 +1272,7 @@ public:
   /// element.
   ///
   /// @return Coefficient matrix. Shape is `(dim(finite element polyset),
-  /// dim(Lagrange polynomials))`.
+  /// dim(Legendre polynomials))`.
   const std::pair<std::vector<F>, std::array<std::size_t, 2>>& wcoeffs() const
   {
     return _wcoeffs;
@@ -1298,7 +1302,7 @@ public:
   /// \code{.pseudo}
   /// matrix = element.M()[d][e]
   /// pts = element.x()[d][e]
-  /// nderivs = element
+  /// nderivs = element.interpolation_nderivs()
   /// values = f.eval_derivs(nderivs, pts)
   /// result = ZEROS(matrix.shape(0))
   /// FOR i IN RANGE(matrix.shape(0)):
@@ -1330,7 +1334,11 @@ public:
 
   /// @brief Get the matrix of coefficients.
   ///
-  /// @return The coefficient matrix. Shape is `(ndofs, ndofs)`.
+  /// @return The coefficient matrix. Shape is `(ndofs, dim(Legendre
+  /// polynomials))`; it is only square (`ndofs == dim(Legendre
+  /// polynomials)`) for elements, such as Lagrange, whose polynomial
+  /// set spans the full space of Legendre polynomials up to the
+  /// element's degree.
   const std::pair<std::vector<F>, std::array<std::size_t, 2>>&
   coefficient_matrix() const
   {
@@ -1381,7 +1389,11 @@ public:
   /// @brief The number of derivatives needed when interpolating
   int interpolation_nderivs() const { return _interpolation_nderivs; }
 
-  /// @brief Get dof layout
+  /// @brief Get the mapping from the reference-element DOF ordering to
+  /// the custom DOF ordering supplied at construction (empty if none
+  /// was supplied).
+  /// @return Vector `v` such that reference DOF `i` is placed at
+  /// position `v[i]` in the custom ordering.
   const std::vector<int>& dof_ordering() const { return _dof_ordering; }
 
 private:
@@ -1582,8 +1594,9 @@ private:
 /// @param[in] embedded_subdegree The highest degree n such that a
 /// Lagrange (or vector Lagrange) element of degree n is a subspace of this
 /// element
-/// @param[in] embedded_superdegree The degree of a polynomial in this element's
-/// polyset
+/// @param[in] embedded_superdegree The lowest degree n such that this
+/// element's polynomial set is a subspace of a Lagrange (or vector
+/// Lagrange) element of degree n
 /// @param[in] poly_type The type of polyset to use for this element
 /// @return A custom finite element
 template <std::floating_point T>

--- a/cpp/basix/lattice.h
+++ b/cpp/basix/lattice.h
@@ -15,8 +15,8 @@ namespace basix::lattice
 {
 /// @brief The type of point spacing to be used in a lattice.
 ///
-/// @note type::chebyshev_plus_endpoints() and type::gl_plus_endpoints() are
-/// only intended for internal use only.
+/// @note type::chebyshev_plus_endpoints and type::gl_plus_endpoints are
+/// intended for internal use only.
 enum class type
 {
   equispaced = 0, /*!< Equally spaced points */

--- a/cpp/basix/maps.h
+++ b/cpp/basix/maps.h
@@ -47,11 +47,12 @@ enum class type
 };
 
 /// @brief L2 Piola map.
+///
+/// This map does not use the Jacobian or its inverse.
+///
 /// @param[out] r The mapped (physical-cell) values.
 /// @param[in] U The reference-cell values to map.
-/// @param[in] J Unused by this map.
 /// @param[in] detJ Determinant of the Jacobian of the map.
-/// @param[in] K Unused by this map.
 template <typename O, typename P, typename Q, typename R>
 void l2_piola(O&& r, const P& U, const Q& /*J*/, double detJ, const R& /*K*/)
 {
@@ -63,10 +64,11 @@ void l2_piola(O&& r, const P& U, const Q& /*J*/, double detJ, const R& /*K*/)
 }
 
 /// @brief Covariant Piola map.
+///
+/// This map does not use the Jacobian or its determinant.
+///
 /// @param[out] r The mapped (physical-cell) values.
 /// @param[in] U The reference-cell values to map.
-/// @param[in] J Unused by this map.
-/// @param[in] detJ Unused by this map.
 /// @param[in] K Inverse of the Jacobian of the map.
 template <typename O, typename P, typename Q, typename R>
 void covariant_piola(O&& r, const P& U, const Q& /*J*/, double /*detJ*/,
@@ -88,11 +90,13 @@ void covariant_piola(O&& r, const P& U, const Q& /*J*/, double /*detJ*/,
 }
 
 /// @brief Contravariant Piola map.
+///
+/// This map does not use the inverse of the Jacobian.
+///
 /// @param[out] r The mapped (physical-cell) values.
 /// @param[in] U The reference-cell values to map.
 /// @param[in] J Jacobian of the map.
 /// @param[in] detJ Determinant of the Jacobian of the map.
-/// @param[in] K Unused by this map.
 template <typename O, typename P, typename Q, typename R>
 void contravariant_piola(O&& r, const P& U, const Q& J, double detJ,
                          const R& /*K*/)
@@ -115,10 +119,11 @@ void contravariant_piola(O&& r, const P& U, const Q& J, double detJ,
 }
 
 /// @brief Double covariant Piola map.
+///
+/// This map does not use the Jacobian or its determinant.
+///
 /// @param[out] r The mapped (physical-cell) values.
 /// @param[in] U The reference-cell values to map.
-/// @param[in] J Unused by this map.
-/// @param[in] detJ Unused by this map.
 /// @param[in] K Inverse of the Jacobian of the map.
 template <typename O, typename P, typename Q, typename R>
 void double_covariant_piola(O&& r, const P& U, const Q& /*J*/, double /*detJ*/,
@@ -148,11 +153,13 @@ void double_covariant_piola(O&& r, const P& U, const Q& /*J*/, double /*detJ*/,
 }
 
 /// @brief Double contravariant Piola map.
+///
+/// This map does not use the inverse of the Jacobian.
+///
 /// @param[out] r The mapped (physical-cell) values.
 /// @param[in] U The reference-cell values to map.
 /// @param[in] J Jacobian of the map.
 /// @param[in] detJ Determinant of the Jacobian of the map.
-/// @param[in] K Unused by this map.
 template <typename O, typename P, typename Q, typename R>
 void double_contravariant_piola(O&& r, const P& U, const Q& J, double detJ,
                                 const R& /*K*/)

--- a/cpp/basix/maps.h
+++ b/cpp/basix/maps.h
@@ -46,7 +46,12 @@ enum class type
   doubleContravariantPiola = 5,
 };
 
-/// @brief L2 Piola map
+/// @brief L2 Piola map.
+/// @param[out] r The mapped (physical-cell) values.
+/// @param[in] U The reference-cell values to map.
+/// @param[in] J Unused by this map.
+/// @param[in] detJ Determinant of the Jacobian of the map.
+/// @param[in] K Unused by this map.
 template <typename O, typename P, typename Q, typename R>
 void l2_piola(O&& r, const P& U, const Q& /*J*/, double detJ, const R& /*K*/)
 {
@@ -57,7 +62,12 @@ void l2_piola(O&& r, const P& U, const Q& /*J*/, double detJ, const R& /*K*/)
       r(i, j) = U(i, j) / detJ;
 }
 
-/// @brief  Covariant Piola map
+/// @brief Covariant Piola map.
+/// @param[out] r The mapped (physical-cell) values.
+/// @param[in] U The reference-cell values to map.
+/// @param[in] J Unused by this map.
+/// @param[in] detJ Unused by this map.
+/// @param[in] K Inverse of the Jacobian of the map.
 template <typename O, typename P, typename Q, typename R>
 void covariant_piola(O&& r, const P& U, const Q& /*J*/, double /*detJ*/,
                      const R& K)
@@ -77,7 +87,12 @@ void covariant_piola(O&& r, const P& U, const Q& /*J*/, double /*detJ*/,
   }
 }
 
-/// @brief Contravariant Piola map
+/// @brief Contravariant Piola map.
+/// @param[out] r The mapped (physical-cell) values.
+/// @param[in] U The reference-cell values to map.
+/// @param[in] J Jacobian of the map.
+/// @param[in] detJ Determinant of the Jacobian of the map.
+/// @param[in] K Unused by this map.
 template <typename O, typename P, typename Q, typename R>
 void contravariant_piola(O&& r, const P& U, const Q& J, double detJ,
                          const R& /*K*/)
@@ -99,7 +114,12 @@ void contravariant_piola(O&& r, const P& U, const Q& J, double detJ,
                  [detJ](auto ri) { return ri / static_cast<Z>(detJ); });
 }
 
-/// @brief Double covariant Piola map
+/// @brief Double covariant Piola map.
+/// @param[out] r The mapped (physical-cell) values.
+/// @param[in] U The reference-cell values to map.
+/// @param[in] J Unused by this map.
+/// @param[in] detJ Unused by this map.
+/// @param[in] K Inverse of the Jacobian of the map.
 template <typename O, typename P, typename Q, typename R>
 void double_covariant_piola(O&& r, const P& U, const Q& /*J*/, double /*detJ*/,
                             const R& K)
@@ -127,7 +147,12 @@ void double_covariant_piola(O&& r, const P& U, const Q& /*J*/, double /*detJ*/,
   }
 }
 
-/// @brief Double contravariant Piola map
+/// @brief Double contravariant Piola map.
+/// @param[out] r The mapped (physical-cell) values.
+/// @param[in] U The reference-cell values to map.
+/// @param[in] J Jacobian of the map.
+/// @param[in] detJ Determinant of the Jacobian of the map.
+/// @param[in] K Unused by this map.
 template <typename O, typename P, typename Q, typename R>
 void double_contravariant_piola(O&& r, const P& U, const Q& J, double detJ,
                                 const R& /*K*/)

--- a/cpp/basix/math.h
+++ b/cpp/basix/math.h
@@ -53,9 +53,13 @@ namespace impl
 {
 /// @brief Compute C = alpha A * B  + beta C using BLAS (GEMM).
 /// @param[in] A Input matrix.
+/// @param[in] Ashape Shape of `A`.
 /// @param[in] B Input matrix.
-/// @param[in] alpha
-/// @param[in] beta
+/// @param[in] Bshape Shape of `B`.
+/// @param[in,out] C Output matrix, size `Ashape[0] * Bshape[1]`. Read
+/// when `beta != 0`.
+/// @param[in] alpha Scalar multiplying `A * B`.
+/// @param[in] beta Scalar multiplying the existing contents of `C`.
 template <std::floating_point T>
 void dot_blas(std::span<const T> A, std::array<std::size_t, 2> Ashape,
               std::span<const T> B, std::array<std::size_t, 2> Bshape,
@@ -88,7 +92,7 @@ void dot_blas(std::span<const T> A, std::array<std::size_t, 2> Ashape,
 
 } // namespace impl
 
-/// @brief Compute the outer product of vectors u and v.
+/// @brief Compute the outer product of vectors `u` and `v`.
 /// @param u The first vector.
 /// @param v The second vector.
 /// @return The outer product. The type will be the same as `u`.
@@ -104,8 +108,8 @@ outer(const U& u, const V& v)
 }
 
 /// @brief Compute the cross product u x v.
-/// @param u The first vector. It must has size 3.
-/// @param v The second vector. It must has size 3.
+/// @param u The first vector. It must have size 3.
+/// @param v The second vector. It must have size 3.
 /// @return The cross product `u x v`. The type will be the same as `u`.
 template <typename U, typename V>
 std::array<typename U::value_type, 3> cross(const U& u, const V& v)
@@ -117,11 +121,11 @@ std::array<typename U::value_type, 3> cross(const U& u, const V& v)
 }
 
 /// @brief Compute the eigenvalues and eigenvectors of a square
-/// Hermitian matrix A.
+/// symmetric matrix A.
 /// @param[in] A Input matrix, row-major storage.
 /// @param[in] n Number of rows.
 /// @return Eigenvalues (0) and eigenvectors (1). The eigenvector array
-/// uses column-major storage, which each column being an eigenvector.
+/// uses column-major storage, with each column being an eigenvector.
 /// @pre The matrix `A` must be symmetric.
 template <std::floating_point T>
 std::pair<std::vector<T>, std::vector<T>> eigh(std::span<const T> A,
@@ -298,10 +302,10 @@ transpose_lu(std::pair<std::vector<T>, std::array<std::size_t, 2>>& A)
 /// @brief Compute C = alpha A * B + beta C
 /// @param[in] A Input matrix
 /// @param[in] B Input matrix
-/// @param[out] C Output matrix. Must be sized correctly before calling
-/// this function.
-/// @param[in] alpha
-/// @param[in] beta
+/// @param[in,out] C Matrix to accumulate into (read when `beta != 0`).
+/// Must be sized correctly before calling this function.
+/// @param[in] alpha Scalar multiplying `A * B`.
+/// @param[in] beta Scalar multiplying the existing contents of `C`.
 template <typename U, typename V, typename W>
 void dot(const U& A, const V& B, W&& C,
          typename std::decay_t<U>::value_type alpha = 1,
@@ -357,10 +361,10 @@ std::vector<T> eye(std::size_t n)
   return I;
 }
 
-/// @brief Orthogonalise the rows of a matrix (in place).
-/// @param[in] wcoeffs The matrix.
+/// @brief Orthonormalise the rows of a matrix (in place).
+/// @param[in,out] wcoeffs The matrix, orthonormalised on exit.
 /// @param[in] start The row to start from. The rows before this should
-/// already be orthogonal.
+/// already be orthonormal.
 template <std::floating_point T>
 void orthogonalise(md::mdspan<T, md::dextents<std::size_t, 2>> wcoeffs,
                    std::size_t start = 0)

--- a/cpp/basix/moments.h
+++ b/cpp/basix/moments.h
@@ -38,10 +38,11 @@ namespace moments
 /// define
 /// @param value_size The value size of the space being defined
 /// @param q_deg The quadrature degree used for the integrals
-/// @return (interpolation points, interpolation matrix). The indices of
-/// the interpolation points are (number of entities, npoints, gdim).
-/// The indices on the interpolation matrix are (number of entities,
-/// ndofs, value_size, npoints, derivative)
+/// @return (interpolation points, interpolation shape, interpolation
+/// matrix, interpolation shape). The indices of the interpolation
+/// points are (number of entities, npoints, gdim). The indices on the
+/// interpolation matrix are (number of entities, ndofs, value_size,
+/// npoints, derivative)
 template <std::floating_point T>
 std::tuple<std::vector<std::vector<T>>, std::array<std::size_t, 2>,
            std::vector<std::vector<T>>, std::array<std::size_t, 4>>
@@ -57,8 +58,8 @@ make_integral_moments(const FiniteElement<T>& moment_space, cell::type celltype,
 /// triangle and the moment space is a P1 space on an edge, this will
 /// perform two integrals for each of the 3 edges of the triangle.
 ///
-/// @todo Clarify what happens value size of the moment space is less
-/// than `value_size`.
+/// @todo Clarify what happens when the value size of the moment space
+/// is less than `value_size`.
 ///
 /// @param V The space to compute the integral moments against
 /// @param celltype The cell type of the cell on which the space is
@@ -67,7 +68,7 @@ make_integral_moments(const FiniteElement<T>& moment_space, cell::type celltype,
 /// define
 /// @param value_size The value size of the space being defined
 /// @param q_deg The quadrature degree used for the integrals
-/// @return (interpolation points, interpolation shape,  interpolation
+/// @return (interpolation points, interpolation shape, interpolation
 /// matrix, interpolation shape). The indices of the interpolation
 /// points are (number of entities, npoints, gdim). The indices on the
 /// interpolation matrix are (number of entities, ndofs, value_size,
@@ -90,10 +91,9 @@ make_dot_integral_moments(const FiniteElement<T>& V, cell::type celltype,
 /// being defined
 /// @param ptype The polyset type of the element this moment is being used to
 /// define
-/// @param value_size The value size of the space being defined the
-/// space
+/// @param value_size The value size of the space being defined
 /// @param q_deg The quadrature degree used for the integrals
-/// @return (interpolation points, interpolation shape,  interpolation
+/// @return (interpolation points, interpolation shape, interpolation
 /// matrix, interpolation shape). The indices of the interpolation
 /// points are (number of entities, npoints, gdim). The indices on the
 /// interpolation matrix are (number of entities, ndofs, value_size,
@@ -118,7 +118,7 @@ make_tangent_integral_moments(const FiniteElement<T>& V, cell::type celltype,
 /// define
 /// @param[in] value_size The value size of the space being defined
 /// @param[in] q_deg The quadrature degree used for the integrals
-/// @return (interpolation points, interpolation shape,  interpolation
+/// @return (interpolation points, interpolation shape, interpolation
 /// matrix, interpolation shape). The indices of the interpolation
 /// points are (number of entities, npoints, gdim). The indices on the
 /// interpolation matrix are (number of entities, ndofs, value_size,

--- a/cpp/basix/polynomials.h
+++ b/cpp/basix/polynomials.h
@@ -34,8 +34,8 @@ enum class type
 /// @param[in] d Polynomial degree
 /// @param[in] x Points at which to evaluate the basis. The shape is
 /// (number of points, geometric dimension).
-/// @return Polynomial sets, for each derivative, tabulated at points.
-/// The shape is `(basis index, number of points)`.
+/// @return Polynomial values tabulated at points. The shape is
+/// `(basis index, number of points)`.
 template <std::floating_point T>
 std::pair<std::vector<T>, std::array<std::size_t, 2>>
 tabulate(polynomials::type polytype, cell::type celltype, int d,
@@ -45,7 +45,7 @@ tabulate(polynomials::type polytype, cell::type celltype, int d,
 /// @param[in] polytype Polynomial type
 /// @param[in] cell Cell type
 /// @param[in] d Polynomial degree
-/// @return The number terms in the basis spanning a space of
+/// @return The number of terms in the basis spanning a space of
 /// polynomial degree `d`.
 int dim(polynomials::type polytype, cell::type cell, int d);
 

--- a/cpp/basix/polyset.h
+++ b/cpp/basix/polyset.h
@@ -132,7 +132,7 @@
 namespace basix::polyset
 {
 
-/// @brief Cell type
+/// @brief Polyset (polynomial set) type.
 enum class type
 {
   standard = 0,
@@ -240,8 +240,8 @@ int dim(cell::type cell, polyset::type ptype, int d);
 /// @return Number of derivatives
 int nderivs(cell::type cell, int d);
 
-/// @brief Get the polyset types that is a superset of two types on the
-/// given cell.
+/// @brief Get the polyset type that is a superset of two given types
+/// on the given cell.
 /// @param[in] cell Cell type
 /// @param[in] type1 First polyset type
 /// @param[in] type2 Second polyset type

--- a/cpp/basix/precompute.h
+++ b/cpp/basix/precompute.h
@@ -143,6 +143,12 @@ void apply_permutation(std::span<const std::size_t> perm, std::span<E> data,
 }
 
 /// @brief Permutation of mapped data.
+/// @param[in] perm A permutation in precomputed form (as returned by
+/// prepare_permutation()).
+/// @param[in,out] data The data to apply the permutation to.
+/// @param[in] emap Map from the permutation's local entity numbering to
+/// the position of that entity's block in `data`.
+/// @param[in] n The block size of the data.
 template <typename E>
 void apply_permutation_mapped(std::span<const std::size_t> perm,
                               std::span<E> data, std::span<const int> emap,
@@ -157,10 +163,21 @@ void apply_permutation_mapped(std::span<const std::size_t> perm,
 ///
 /// Applies \f$v = u P^{T}\f$.
 ///
+/// Unlike apply_permutation(), where the `n` values of a block are
+/// interleaved (block `b` occupies `data[n*(offset+i)+b]` for `i` in
+/// the permutation), here each of the `n` blocks is contiguous: block
+/// `b` occupies `data[data_size*b+offset+i]` for `i` in the
+/// permutation.
+///
 /// @note This function is designed to be called at runtime, so its
 /// performance is critical.
 ///
-/// See apply_permutation().
+/// @param[in] perm A permutation in precomputed form (as returned by
+/// prepare_permutation()).
+/// @param[in,out] data The data to apply the permutation to.
+/// @param[in] offset The position in each block to start applying the
+/// permutation.
+/// @param[in] n The number of blocks in the data.
 template <typename E>
 void apply_inv_permutation_right(std::span<const std::size_t> perm,
                                  std::span<E> data, std::size_t offset = 0,
@@ -189,11 +206,10 @@ void apply_inv_permutation_right(std::span<const std::size_t> perm,
 /// For an example of how the permutation in this form is applied, see
 /// apply_matrix().
 ///
-/// @param[in,out] A The matrix data.
-/// @return The three parts of a precomputed representation of the
-/// matrix. These are (as described above):
-/// - A permutation (precomputed as in prepare_permutation());
-/// - the vector @f$D@f$;
+/// @param[in,out] A The matrix data. On exit, holds the LU factors of
+/// @f$A^t@f$ in place.
+/// @return The permutation @f$P@f$ (in prepared form, as produced by
+/// prepare_permutation()) satisfying @f$PA^t=LU@f$.
 template <std::floating_point T>
 std::vector<std::size_t>
 prepare_matrix(std::pair<std::vector<T>, std::array<std::size_t, 2>>& A)
@@ -219,15 +235,15 @@ prepare_matrix(std::pair<std::vector<T>, std::array<std::size_t, 2>>& A)
 ///         data[i] += mat[i, j] * data[j]
 /// \endcode
 ///
-/// If `n` is set, this will apply the permutation to every block. The
-/// `offset` is set, this will start applying the permutation at the
-/// `offset`th block.
+/// If `n` is set, the permutation is applied to every block. If
+/// `offset` is set, application starts at the `offset`-th block.
 ///
 /// @note This function is designed to be called at runtime, so its
 /// performance is critical.
 ///
 /// @param[in] v_size_t A permutation, as computed by prepare_matrix().
-/// @param[in] M The vector created by prepare_matrix().
+/// @param[in] M The matrix data left in `A` after the call to
+/// prepare_matrix().
 /// @param[in,out] data The data to apply the permutation to
 /// @param[in] offset The position in the data to start applying the
 /// permutation
@@ -308,10 +324,21 @@ void apply_matrix(std::span<const std::size_t> v_size_t,
 ///
 /// Computes \f$v^{T} = M u^{T}\f$ (or equivalently \f$v = u M^{T}\f$).
 ///
+/// Uses the same block-contiguous data layout as
+/// apply_inv_permutation_right() (rather than the interleaved layout
+/// used by apply_matrix()): block `b` occupies
+/// `data[data_size*b+offset+i]`.
+///
 /// @note This function is designed to be called at runtime, so its
 /// performance is critical.
 ///
-/// See apply_matrix().
+/// @param[in] v_size_t A permutation, as computed by prepare_matrix().
+/// @param[in] M The matrix data left in `A` after the call to
+/// prepare_matrix().
+/// @param[in,out] data The data to apply the permutation to.
+/// @param[in] offset The position in each block to start applying the
+/// permutation.
+/// @param[in] n The number of blocks in the data.
 template <typename T, typename E>
 void apply_tranpose_matrix_right(
     std::span<const std::size_t> v_size_t,

--- a/cpp/basix/quadrature.h
+++ b/cpp/basix/quadrature.h
@@ -28,7 +28,7 @@ enum class type
 
 /// @brief Get the Gauss-Jacobi rule for the interval for integrating
 /// f(x) * (1-x)^a on the interval [0, 1].
-/// @tparam The floating point type.
+/// @tparam T The floating point type.
 /// @param[in] a The exponent a.
 /// @param[in] m The number of points.
 /// @return Points and weights of a Gauss-Jacobi rule.
@@ -42,8 +42,9 @@ std::array<std::vector<T>, 2> gauss_jacobi_rule(T a, int m);
 /// @param[in] polytype Polyset type.
 /// @param[in] m Maximum degree of polynomial that this quadrature rule
 /// will integrate exactly.
-/// @return List of points and list of weights. The number of points
-/// arrays has shape `(num points, gdim)`.
+/// @return Points and weights. The points are flattened row-major with
+/// shape `(num_points, gdim)`; the weights array has length
+/// `num_points`.
 template <std::floating_point T>
 std::array<std::vector<T>, 2> make_quadrature(const quadrature::type rule,
                                               cell::type celltype,


### PR DESCRIPTION
## Summary
- Fixes Doxygen comments across `cpp/basix/` that contradicted the implementation: mismatched parameter order/shapes, stale or copy-pasted `@return` text, incorrect `[in]`/`[out]` tags, an inverted shape description, and a namespace brief that was too narrow (`doftransforms` is used by every element family, not just high-degree Lagrange).
- Adds missing `@param` documentation to the Piola map functions in `maps.h` and several helpers in `precompute.h`, and documents the `element::family` enum values.
- Fixes assorted typos and grammar issues (`dgerees-of-freedom`, `ntranformations`, `Its has size`, etc.) and resolves a few internal wording inconsistencies (e.g. `embedded_superdegree`, "Cell type" mislabelling `polyset::type`).
- Comment-only change: no declarations, types, or default values were modified.

## Test plan
- [x] Verified every finding against the corresponding `.cpp` implementation (call sites, actual return shapes/layouts) before fixing, not just the header text.
- [x] `git diff` confirms only `///`/`/*!< ... */` comment lines changed (one exception: added trailing enum-value comments in `element-families.h`, values unchanged).
- [x] Full CMake configure + build of the C++ library succeeds with no errors.