### PR TITLE
Fix MSVC narrowing-conversion warnings (C4244, C4267)

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -234,6 +234,10 @@ install(
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Development
 )
 if(INSTALL_RUNTIME_DEPENDENCIES AND WIN32)
+  # Regexes below accept either separator, so CMP0207 normalisation is a no-op.
+  if(POLICY CMP0207)
+    cmake_policy(SET CMP0207 NEW)
+  endif()
   # https://discourse.cmake.org/t/migration-experiences-comparison-runtime-dependency-set-vs-fixup-bundle-bundleutilities
   install(
     RUNTIME_DEPENDENCY_SET dependencies DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/cpp/basix/cell.cpp
+++ b/cpp/basix/cell.cpp
@@ -460,7 +460,7 @@ cell::facet_normals(cell::type cell_type)
   switch (tdim)
   {
   case 1:
-    std::ranges::fill(normal, 1.0);
+    std::ranges::fill(normal, T(1));
     return {normal, shape};
   case 2:
   {
@@ -517,7 +517,7 @@ cell::scaled_facet_normals(cell::type cell_type)
   switch (tdim)
   {
   case 1:
-    std::ranges::fill(normal, 1.0);
+    std::ranges::fill(normal, T(1));
     return {normal, shape};
   case 2:
   {

--- a/cpp/basix/e-lagrange.cpp
+++ b/cpp/basix/e-lagrange.cpp
@@ -577,7 +577,7 @@ basix::element::create_lagrange(cell::type celltype, int degree,
         = lattice::create<T>(celltype, 0, lattice_type, true, simplex_method);
     x[tdim].emplace_back(md::dextents<std::size_t, 2>{shape[0], shape[1]}, pt);
     auto& _M = M[tdim].emplace_back(shape[0], 1, shape[0], 1);
-    std::fill(_M.data(), _M.data() + _M.size(), 0);
+    std::fill(_M.data(), _M.data() + _M.size(), T(0));
     for (std::size_t i = 0; i < shape[0]; ++i)
       _M(i, 0, i, 0) = 1;
   }
@@ -598,7 +598,7 @@ basix::element::create_lagrange(cell::type celltype, int degree,
                               entity_x);
           auto& _M
               = M[dim].emplace_back(entity_x_shape[0], 1, entity_x_shape[0], 1);
-          std::fill(_M.data(), _M.data() + _M.size(), 0);
+          std::fill(_M.data(), _M.data() + _M.size(), T(0));
           for (std::size_t i = 0; i < entity_x_shape[0]; ++i)
             _M(i, 0, i, 0) = 1;
         }
@@ -609,7 +609,7 @@ basix::element::create_lagrange(cell::type celltype, int degree,
           x[dim].emplace_back(md::dextents<std::size_t, 2>{shape[0], shape[1]},
                               pt);
           auto& _M = M[dim].emplace_back(shape[0], 1, shape[0], 1);
-          std::fill(_M.data(), _M.data() + _M.size(), 0);
+          std::fill(_M.data(), _M.data() + _M.size(), T(0));
           for (std::size_t i = 0; i < shape[0]; ++i)
             _M(i, 0, i, 0) = 1;
         }
@@ -634,7 +634,7 @@ basix::element::create_lagrange(cell::type celltype, int degree,
                 _x(j, q) += (entity_x_view(k + 1, q) - x0[q]) * lattice(j, k);
 
           auto& _M = M[dim].emplace_back(shape[0], 1, shape[0], 1);
-          std::fill(_M.data(), _M.data() + _M.size(), 0);
+          std::fill(_M.data(), _M.data() + _M.size(), T(0));
           for (std::size_t i = 0; i < shape[0]; ++i)
             _M(i, 0, i, 0) = 1;
         }
@@ -788,7 +788,7 @@ FiniteElement<T> basix::element::create_iso(cell::type celltype, int degree,
                 _x(j, q) += (entity_x_view(k + 1, q) - x0[q]) * lattice(j, k);
 
           auto& _M = M[dim].emplace_back(shape[0], 1, shape[0], 1);
-          std::fill(_M.data(), _M.data() + _M.size(), 0);
+          std::fill(_M.data(), _M.data() + _M.size(), T(0));
           for (std::size_t i = 0; i < shape[0]; ++i)
             _M(i, 0, i, 0) = 1;
         }

--- a/cpp/basix/finite-element.cpp
+++ b/cpp/basix/finite-element.cpp
@@ -105,7 +105,7 @@ std::pair<std::vector<T>, std::array<std::size_t, 2>> compute_dual_matrix(
 
   std::size_t pdim = polyset::dim(cell_type, poly_type, degree);
   mdarray_t<T, 3> D(vs, pdim, num_dofs);
-  std::fill(D.data(), D.data() + D.size(), 0);
+  std::fill(D.data(), D.data() + D.size(), T(0));
   std::vector<T> Pb;
 
   // Loop over different dimensions
@@ -910,8 +910,9 @@ FiniteElement<T> basix::create_custom_element(
   // Check that inputs are valid
   const std::size_t psize
       = polyset::dim(cell_type, poly_type, embedded_superdegree);
-  const std::size_t value_size = std::reduce(
-      value_shape.begin(), value_shape.end(), 1, std::multiplies{});
+  const std::size_t value_size
+      = std::reduce(value_shape.begin(), value_shape.end(), std::size_t{1},
+                    std::multiplies{});
   const std::size_t deriv_count
       = polyset::nderivs(cell_type, interpolation_nderivs);
   const std::size_t tdim = cell::topological_dimension(cell_type);
@@ -1132,8 +1133,9 @@ FiniteElement<F>::FiniteElement(
           _points.first.push_back(x_e(p, k));
 
   // Copy into _matM
-  const std::size_t value_size = std::accumulate(
-      value_shape.begin(), value_shape.end(), 1, std::multiplies{});
+  const std::size_t value_size
+      = std::accumulate(value_shape.begin(), value_shape.end(), std::size_t{1},
+                        std::multiplies{});
 
   // Count number of dofs and point
   std::size_t num_dofs(0), num_points1(0);
@@ -1331,7 +1333,7 @@ FiniteElement<F>::FiniteElement(
           std::pair<std::vector<F>, std::array<std::size_t, 2>> identity
               = {std::vector<F>(perm.size() * perm.size()),
                  {perm.size(), perm.size()}};
-          std::ranges::fill(identity.first, 0.);
+          std::ranges::fill(identity.first, F(0));
           for (std::size_t k = 0; k < perm.size(); ++k)
             identity.first[k * perm.size() + k] = 1;
 
@@ -1848,8 +1850,9 @@ void FiniteElement<F>::tabulate(int nd, impl::mdspan_t<const F, 2> x,
   mdspan_t<F, 3> basis(basis_b.data(), bsize);
   polyset::tabulate(basis, _cell_type, _poly_type, _embedded_superdegree, nd,
                     x);
-  const std::size_t vs = std::accumulate(
-      _value_shape.begin(), _value_shape.end(), 1, std::multiplies{});
+  const std::size_t vs
+      = std::accumulate(_value_shape.begin(), _value_shape.end(),
+                        std::size_t{1}, std::multiplies{});
   const std::size_t ndofs = _coeffs.second[0];
 
   // _coeffs's (ndofs, vs * psize) row-major buffer is exactly (ndofs * vs,
@@ -2008,8 +2011,9 @@ FiniteElement<F>::pull_back(impl::mdspan_t<const F, 3> u,
                             std::span<const F> detJ,
                             impl::mdspan_t<const F, 3> K) const
 {
-  const std::size_t reference_value_size = std::accumulate(
-      _value_shape.begin(), _value_shape.end(), 1, std::multiplies{});
+  const std::size_t reference_value_size
+      = std::accumulate(_value_shape.begin(), _value_shape.end(),
+                        std::size_t{1}, std::multiplies{});
 
   std::array<std::size_t, 3> shape
       = {u.extent(0), u.extent(1), reference_value_size};

--- a/cpp/basix/finite-element.h
+++ b/cpp/basix/finite-element.h
@@ -370,7 +370,7 @@ public:
     for (std::size_t i = 1; i <= nd; ++i)
       ndsize /= i;
     std::size_t vs = std::accumulate(_value_shape.begin(), _value_shape.end(),
-                                     1, std::multiplies{});
+                                     std::size_t{1}, std::multiplies{});
     std::size_t ndofs = _coeffs.second[0];
     return {ndsize, num_points, ndofs, vs};
   }

--- a/cpp/basix/interpolation.cpp
+++ b/cpp/basix/interpolation.cpp
@@ -36,12 +36,12 @@ basix::compute_interpolation_operator(const FiniteElement<T>& element_from,
   const std::size_t dim_from = element_from.dim();
   const std::size_t npts = tab.extent(1);
 
-  const std::size_t vs_from
-      = std::accumulate(element_from.value_shape().begin(),
-                        element_from.value_shape().end(), 1, std::multiplies{});
-  const std::size_t vs_to
-      = std::reduce(element_to.value_shape().begin(),
-                    element_to.value_shape().end(), 1, std::multiplies{});
+  const std::size_t vs_from = std::accumulate(
+      element_from.value_shape().begin(), element_from.value_shape().end(),
+      std::size_t{1}, std::multiplies{});
+  const std::size_t vs_to = std::reduce(element_to.value_shape().begin(),
+                                        element_to.value_shape().end(),
+                                        std::size_t{1}, std::multiplies{});
 
   if (vs_from != vs_to)
   {

--- a/cpp/basix/lattice.cpp
+++ b/cpp/basix/lattice.cpp
@@ -584,7 +584,8 @@ create_tet_warped(std::size_t n, lattice::type lattice_type, bool exterior)
 
   std::transform(std::next(r.begin()), std::prev(r.end()),
                  std::next(wbar.begin()), std::next(wbar.begin()),
-                 [](auto r, auto w) { return w / (r * (1.0 - r)); });
+                 [](auto r, auto w)
+                 { return static_cast<T>(w / (r * (1.0 - r))); });
 
   std::array<std::size_t, 2> shape
       = {(n - 4 * b + 1) * (n - 4 * b + 2) * (n - 4 * b + 3) / 6, 3};

--- a/cpp/basix/moments.cpp
+++ b/cpp/basix/moments.cpp
@@ -118,8 +118,8 @@ moments::make_integral_moments(const FiniteElement<T>& V, cell::type celltype,
   mdspan_t<const T, 2> pts(_pts.data(), wts.size(), _pts.size() / wts.size());
 
   // Evaluate moment space at quadrature points
-  assert(std::accumulate(V.value_shape().begin(), V.value_shape().end(), 1,
-                         std::multiplies{})
+  assert(std::accumulate(V.value_shape().begin(), V.value_shape().end(),
+                         std::size_t{1}, std::multiplies{})
          == 1);
   const auto [phib, phishape] = V.tabulate(0, pts);
   mdspan_t<const T, 4> phi(phib.data(), phishape);
@@ -132,8 +132,8 @@ moments::make_integral_moments(const FiniteElement<T>& V, cell::type celltype,
   const std::array<std::size_t, 4> Dshape
       = {num_dofs, value_size, pts.extent(0), 1};
 
-  const std::size_t size
-      = std::reduce(Dshape.begin(), Dshape.end(), 1, std::multiplies{});
+  const std::size_t size = std::reduce(Dshape.begin(), Dshape.end(),
+                                       std::size_t{1}, std::multiplies{});
   std::vector<std::vector<T>> Db(num_entities, std::vector<T>(size));
   std::vector<mdspan_t<T, 4>> D;
 
@@ -225,8 +225,8 @@ moments::make_dot_integral_moments(const FiniteElement<T>& V,
   // Shape (num dofs, value size, num points)
   const std::array<std::size_t, 4> Dshape
       = {phi.extent(2), value_size, pts.extent(0), 1};
-  const std::size_t size
-      = std::reduce(Dshape.begin(), Dshape.end(), 1, std::multiplies{});
+  const std::size_t size = std::reduce(Dshape.begin(), Dshape.end(),
+                                       std::size_t{1}, std::multiplies{});
   std::vector<std::vector<T>> Db(num_entities, std::vector<T>(size));
   std::vector<mdspan_t<T, 4>> D;
 
@@ -291,8 +291,8 @@ moments::make_tangent_integral_moments(const FiniteElement<T>& V,
   mdspan_t<const T, 2> pts(_pts.data(), wts.size(), _pts.size() / wts.size());
 
   // Evaluate moment space at quadrature points
-  assert(std::accumulate(V.value_shape().begin(), V.value_shape().end(), 1,
-                         std::multiplies{})
+  assert(std::accumulate(V.value_shape().begin(), V.value_shape().end(),
+                         std::size_t{1}, std::multiplies{})
          == 1);
   const auto [phib, phishape] = V.tabulate(0, pts);
   mdspan_t<const T, 4> phi(phib.data(), phishape);
@@ -302,8 +302,8 @@ moments::make_tangent_integral_moments(const FiniteElement<T>& V,
 
   const std::array<std::size_t, 4> Dshape
       = {phi.extent(2), value_size, phi.extent(1), 1};
-  const std::size_t size
-      = std::reduce(Dshape.begin(), Dshape.end(), 1, std::multiplies{});
+  const std::size_t size = std::reduce(Dshape.begin(), Dshape.end(),
+                                       std::size_t{1}, std::multiplies{});
   std::vector<std::vector<T>> Db(num_entities, std::vector<T>(size));
   std::vector<mdspan_t<T, 4>> D;
 
@@ -365,8 +365,8 @@ moments::make_normal_integral_moments(const FiniteElement<T>& V,
   mdspan_t<const T, 2> pts(_pts.data(), wts.size(), _pts.size() / wts.size());
 
   // Evaluate moment space at quadrature points
-  assert(std::accumulate(V.value_shape().begin(), V.value_shape().end(), 1,
-                         std::multiplies{})
+  assert(std::accumulate(V.value_shape().begin(), V.value_shape().end(),
+                         std::size_t{1}, std::multiplies{})
          == 1);
   const auto [phib, phishape] = V.tabulate(0, pts);
   mdspan_t<const T, 4> phi(phib.data(), phishape);
@@ -378,8 +378,8 @@ moments::make_normal_integral_moments(const FiniteElement<T>& V,
   // Storage for interpolation matrix
   const std::array<std::size_t, 4> Dshape
       = {phi.extent(2), value_size, phi.extent(1), 1};
-  const std::size_t size
-      = std::reduce(Dshape.begin(), Dshape.end(), 1, std::multiplies{});
+  const std::size_t size = std::reduce(Dshape.begin(), Dshape.end(),
+                                       std::size_t{1}, std::multiplies{});
   std::vector<std::vector<T>> Db(num_entities, std::vector<T>(size));
   std::vector<mdspan_t<T, 4>> D;
 

--- a/cpp/basix/polynomials.cpp
+++ b/cpp/basix/polynomials.cpp
@@ -160,7 +160,7 @@ void tabulate_lagrange_pyramid(
   const auto x2 = md::submdspan(x, md::full_extent, 2);
 
   // Traverse derivatives in increasing order
-  std::fill(P.data_handle(), P.data_handle() + P.size(), 0.0);
+  std::fill(P.data_handle(), P.data_handle() + P.size(), T(0));
 
   if (n == 0)
   {

--- a/cpp/basix/polyset.cpp
+++ b/cpp/basix/polyset.cpp
@@ -52,7 +52,7 @@ void tabulate_polyset_point_derivs(
   assert(P.extent(1) == 1);
   assert(P.extent(2) == x.extent(0));
 
-  std::fill(P.data_handle(), P.data_handle() + P.size(), 0.0);
+  std::fill(P.data_handle(), P.data_handle() + P.size(), T(0));
   for (std::size_t i = 0; i < P.extent(2); ++i)
     P(0, 0, i) = 1.0;
 }
@@ -73,7 +73,7 @@ void tabulate_polyset_line_derivs(
   assert(P.extent(1) == n + 1);
   assert(P.extent(2) == x.extent(0));
 
-  std::fill(P.data_handle(), P.data_handle() + P.size(), 0.0);
+  std::fill(P.data_handle(), P.data_handle() + P.size(), T(0));
   for (std::size_t j = 0; j < P.extent(2); ++j)
     P(0, 0, j) = 1.0;
 
@@ -135,7 +135,7 @@ void tabulate_polyset_line_macroedge_derivs(
 
   auto x0 = md::submdspan(x, md::full_extent, 0);
 
-  std::fill(P.data_handle(), P.data_handle() + P.size(), 0.0);
+  std::fill(P.data_handle(), P.data_handle() + P.size(), T(0));
 
   std::vector<T> factorials(n + 1, 0.0);
 
@@ -242,7 +242,7 @@ void tabulate_polyset_quadrilateral_macroedge_derivs(
   auto x0 = md::submdspan(x, md::full_extent, 0);
   auto x1 = md::submdspan(x, md::full_extent, 1);
 
-  std::fill(P.data_handle(), P.data_handle() + P.size(), 0.0);
+  std::fill(P.data_handle(), P.data_handle() + P.size(), T(0));
 
   std::vector<T> factorials(n + 1, 0.0);
 
@@ -450,7 +450,7 @@ void tabulate_polyset_triangle_macroedge_derivs(
   auto x0 = md::submdspan(x, md::full_extent, 0);
   auto x1 = md::submdspan(x, md::full_extent, 1);
 
-  std::fill(P.data_handle(), P.data_handle() + P.size(), 0.0);
+  std::fill(P.data_handle(), P.data_handle() + P.size(), T(0));
 
   if (n == 0)
   {
@@ -941,7 +941,7 @@ void tabulate_polyset_tetrahedron_macroedge_derivs(
   auto x1 = md::submdspan(x, md::full_extent, 1);
   auto x2 = md::submdspan(x, md::full_extent, 2);
 
-  std::fill(P.data_handle(), P.data_handle() + P.size(), 0.0);
+  std::fill(P.data_handle(), P.data_handle() + P.size(), T(0));
 
   if (n == 0)
   {
@@ -1279,7 +1279,7 @@ void tabulate_polyset_hexahedron_macroedge_derivs(
   auto x1 = md::submdspan(x, md::full_extent, 1);
   auto x2 = md::submdspan(x, md::full_extent, 2);
 
-  std::fill(P.data_handle(), P.data_handle() + P.size(), 0.0);
+  std::fill(P.data_handle(), P.data_handle() + P.size(), T(0));
 
   std::vector<T> factorials(n + 1, 0.0);
 
@@ -1612,7 +1612,7 @@ void tabulate_polyset_triangle_derivs(
   assert(P.extent(1) == (n + 1) * (n + 2) / 2);
   assert(P.extent(2) == x.extent(0));
 
-  std::fill(P.data_handle(), P.data_handle() + P.size(), 0.0);
+  std::fill(P.data_handle(), P.data_handle() + P.size(), T(0));
   if (n == 0)
   {
     for (std::size_t j = 0; j < P.extent(2); ++j)
@@ -1757,7 +1757,7 @@ void tabulate_polyset_tetrahedron_derivs(
   auto x2 = md::submdspan(x, md::full_extent, 2);
 
   // Traverse derivatives in increasing order
-  std::fill(P.data_handle(), P.data_handle() + P.size(), 0.0);
+  std::fill(P.data_handle(), P.data_handle() + P.size(), T(0));
   for (std::size_t i = 0; i < P.extent(2); ++i)
     P(idx(0, 0, 0), 0, i) = 1.0;
 
@@ -2042,7 +2042,7 @@ void tabulate_polyset_pyramid_derivs(
   const auto x2 = md::submdspan(x, md::full_extent, 2);
 
   // Traverse derivatives in increasing order
-  std::fill(P.data_handle(), P.data_handle() + P.size(), 0.0);
+  std::fill(P.data_handle(), P.data_handle() + P.size(), T(0));
 
   if (n == 0)
   {
@@ -2260,7 +2260,7 @@ void tabulate_polyset_quad_derivs(
   assert(x1.extent(0) > 0);
 
   // Compute tabulation of interval for px = 0
-  std::fill(P.data_handle(), P.data_handle() + P.size(), 0.0);
+  std::fill(P.data_handle(), P.data_handle() + P.size(), T(0));
   for (std::size_t j = 0; j < P.extent(2); ++j)
     P(idx(0, 0), quad_idx(0, 0), j) = 1.0;
 
@@ -2429,7 +2429,7 @@ void tabulate_polyset_hex_derivs(
   assert(x1.extent(0) > 0);
   assert(x2.extent(0) > 0);
 
-  std::fill(P.data_handle(), P.data_handle() + P.size(), 0.0);
+  std::fill(P.data_handle(), P.data_handle() + P.size(), T(0));
   for (std::size_t i = 0; i < P.extent(2); ++i)
     P(idx(0, 0, 0), hex_idx(0, 0, 0), i) = 1.0;
 
@@ -2725,7 +2725,7 @@ void tabulate_polyset_prism_derivs(
   { return (n + 1) * idx(py, px) + pz; };
 
   // Tabulate triangle for px=0
-  std::fill(P.data_handle(), P.data_handle() + P.size(), 0.0);
+  std::fill(P.data_handle(), P.data_handle() + P.size(), T(0));
   if (n == 0)
   {
     for (std::size_t i = 0; i < P.extent(2); ++i)

--- a/cpp/basix/quadrature.cpp
+++ b/cpp/basix/quadrature.cpp
@@ -46,23 +46,25 @@ std::array<std::vector<T>, 2> rec_jacobi(int N, T a, T b)
                * std::tgamma(b + 1.0) / std::tgamma(a + b + 2.0);
 
   std::vector<T> n(N - 1);
-  std::iota(n.begin(), n.end(), 1.0);
+  std::iota(n.begin(), n.end(), T(1));
   std::vector<T> nab(n.size());
-  std::ranges::transform(n, nab.begin(),
-                         [a, b](auto x) { return 2.0 * x + a + b; });
+  std::ranges::transform(n, nab.begin(), [a, b](auto x)
+                         { return static_cast<T>(2.0 * x + a + b); });
 
   std::vector<T> alpha(N);
   alpha.front() = nu;
-  std::ranges::transform(nab, std::next(alpha.begin()), [a, b](auto nab)
-                         { return (b * b - a * a) / (nab * (nab + 2.0)); });
+  std::ranges::transform(
+      nab, std::next(alpha.begin()), [a, b](auto nab)
+      { return static_cast<T>((b * b - a * a) / (nab * (nab + 2.0))); });
 
   std::vector<T> beta(N);
   beta.front() = mu;
   std::ranges::transform(n, nab, std::next(beta.begin()),
                          [a, b](auto n, auto nab)
                          {
-                           return 4 * (n + a) * (n + b) * n * (n + a + b)
-                                  / (nab * nab * (nab + 1.0) * (nab - 1.0));
+                           return static_cast<T>(
+                               4 * (n + a) * (n + b) * n * (n + a + b)
+                               / (nab * nab * (nab + 1.0) * (nab - 1.0)));
                          });
 
   return {std::move(alpha), std::move(beta)};
@@ -5002,7 +5004,7 @@ std::vector<T> quadrature::get_gl_points(int m)
 {
   std::vector<T> pts = compute_gauss_jacobi_points<T>(0, m);
   std::ranges::transform(pts, pts.begin(),
-                         [](auto x) { return 0.5 + 0.5 * x; });
+                         [](auto x) { return static_cast<T>(0.5 + 0.5 * x); });
   return pts;
 }
 //-----------------------------------------------------------------------------

--- a/cpp/basix/quadrature.cpp
+++ b/cpp/basix/quadrature.cpp
@@ -309,9 +309,10 @@ template <std::floating_point T>
 std::array<std::vector<T>, 2> make_quadrature_line(int m)
 {
   auto [ptx, wx] = compute_gauss_jacobi_rule<T>(0.0, m);
-  std::ranges::transform(wx, wx.begin(), [](auto w) { return 0.5 * w; });
-  std::ranges::transform(ptx, ptx.begin(),
-                         [](auto x) { return 0.5 * (x + 1.0); });
+  std::ranges::transform(wx, wx.begin(),
+                         [](auto w) { return static_cast<T>(0.5 * w); });
+  std::ranges::transform(ptx, ptx.begin(), [](auto x)
+                         { return static_cast<T>(0.5 * (x + 1.0)); });
   return {std::move(ptx), std::move(wx)};
 }
 //-----------------------------------------------------------------------------
@@ -499,9 +500,10 @@ template <std::floating_point T>
 std::array<std::vector<T>, 2> make_gll_line(int m)
 {
   auto [ptx, wx] = compute_gll_rule<T>(m);
-  std::ranges::transform(wx, wx.begin(), [](auto w) { return 0.5 * w; });
-  std::ranges::transform(ptx, ptx.begin(),
-                         [](auto x) { return 0.5 * (x + 1.0); });
+  std::ranges::transform(wx, wx.begin(),
+                         [](auto w) { return static_cast<T>(0.5 * w); });
+  std::ranges::transform(ptx, ptx.begin(), [](auto x)
+                         { return static_cast<T>(0.5 * (x + 1.0)); });
   return {ptx, wx};
 }
 //-----------------------------------------------------------------------------

--- a/python/wrapper.cpp
+++ b/python/wrapper.cpp
@@ -242,8 +242,8 @@ void declare_float(nb::module_& m, const std::string& type)
                    [](const FiniteElement<T>& self)
                    {
                      return std::accumulate(self.value_shape().begin(),
-                                            self.value_shape().end(), 1,
-                                            std::multiplies{});
+                                            self.value_shape().end(),
+                                            std::size_t{1}, std::multiplies{});
                    })
       .def_prop_ro("value_shape", &FiniteElement<T>::value_shape)
       .def_prop_ro("discontinuous", &FiniteElement<T>::discontinuous)


### PR DESCRIPTION
MSVC produces stricter warnings on narrowing:

C4244: in T-templated code, double/int literals were passed to `std::fill`, `std::iota` and `std::ranges::fill` over float buffers, and some transform lambdas returned double into a vector<float>. Use T(0)/T(1) for the fills, and wrap the lambda results in static_cast<T> so the intermediate arithmetic stays in double exactly as before and only the final store is explicit.

C4267: std::reduce/std::accumulate over size_t shape vectors used an init value of 1, making the whole reduction int before narrowing (JSH: widening?) back to size_t. Use std::size_t{1}.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
