### PR TITLE
Use delvewheel for relocation on Windows

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-26, macos-26-intel, windows-11-arm, windows-2025]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-26, macos-26-intel, windows-11-arm, windows-2022]
 
     steps:
       - uses: actions/checkout@v7

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -4,12 +4,10 @@ cmake_minimum_required(VERSION 3.21)
 project(Basix VERSION 0.12.0.0 LANGUAGES CXX)
 include(GNUInstallDirs)
 
-if(SKBUILD AND UNIX)
-  # Avoid lib64/ which can lead to linking issues.
-  set(CMAKE_INSTALL_LIBDIR basix/lib)
-endif()
-
 if(SKBUILD)
+  # Make sure libraries, the CMake package and basix.pc end up inside basix/
+  # subdirectory in wheel. Also avoids lib64/, which can lead to linking issues.
+  set(CMAKE_INSTALL_LIBDIR basix/lib)
   # Make sure includes end up inside basix/ subdirectory in wheel.
   set(CMAKE_INSTALL_INCLUDEDIR basix/include)
   # Make sure all binaries end up inside basix/ subdirectory in wheel.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,8 +71,10 @@ build-frontend = { name = "build", args = [
 # C++ consumers link against it. --with-mangle still mangles its dependencies,
 # which delvewheel vendors from vcpkg. Only one triplet exists per runner.
 repair-wheel-command = 'delvewheel repair --ignore-existing --with-mangle --add-path "C:/vcpkg_installed/x64-windows/bin;C:/vcpkg_installed/arm64-windows/bin" -w {dest_dir} -v {wheel}'
+# cibuildwheel sets VIRTUAL_ENV for the test environment; the Unix
+# $(which python) trick does not work in cmd.
 test-command = [
-    "cmake -B build-dir -S {project}/test/test_cmake",
+    "cmake -B build-dir -S {project}/test/test_cmake -DPython3_EXECUTABLE=%VIRTUAL_ENV%\\Scripts\\python.exe",
     "cmake --build build-dir --config Release",
     "build-dir\\Release\\a.out.exe",
     "python -m pytest -n auto --durations 20 {project}/test/",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,14 +61,11 @@ test-requires = ["pytest-xdist"]
 test-extras = ["test"]
 
 [tool.cibuildwheel.windows]
-# Pin VCPKG_INSTALLED_DIR so the DLLs are at a fixed path.
 build-frontend = { name = "build", args = [
     "-Cwheel.py-api=cp312",
-    "-Ccmake.args=-DVCPKG_INSTALLED_DIR=C:/vcpkg_installed",
+    "-Ccmake.args=-DINSTALL_RUNTIME_DEPENDENCIES=ON",
     "-Ccmake.args=-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake",
 ] }
-# Tell delvewheel where vcpkg puts the DLLs. Only one triplet exists per runner.
-repair-wheel-command = 'delvewheel repair --add-path "C:/vcpkg_installed/x64-windows/bin;C:/vcpkg_installed/arm64-windows/bin" -w {dest_dir} -v {wheel}'
 test-command = ["python -m pytest -n auto --durations 20 {project}/test/"]
 
 [tool.cibuildwheel.linux]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,12 +61,22 @@ test-requires = ["pytest-xdist"]
 test-extras = ["test"]
 
 [tool.cibuildwheel.windows]
+# Pin VCPKG_INSTALLED_DIR so the DLLs are at a fixed path.
 build-frontend = { name = "build", args = [
     "-Cwheel.py-api=cp312",
-    "-Ccmake.args=-DINSTALL_RUNTIME_DEPENDENCIES=ON",
+    "-Ccmake.args=-DVCPKG_INSTALLED_DIR=C:/vcpkg_installed",
     "-Ccmake.args=-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake",
 ] }
-test-command = ["python -m pytest -n auto --durations 20 {project}/test/"]
+# --ignore-existing keeps basix.dll in place under its plain name, as downstream
+# C++ consumers link against it. --with-mangle still mangles its dependencies,
+# which delvewheel vendors from vcpkg. Only one triplet exists per runner.
+repair-wheel-command = 'delvewheel repair --ignore-existing --with-mangle --add-path "C:/vcpkg_installed/x64-windows/bin;C:/vcpkg_installed/arm64-windows/bin" -w {dest_dir} -v {wheel}'
+test-command = [
+    "cmake -B build-dir -S {project}/test/test_cmake",
+    "cmake --build build-dir --config Release",
+    "build-dir\\Release\\a.out.exe",
+    "python -m pytest -n auto --durations 20 {project}/test/",
+]
 
 [tool.cibuildwheel.linux]
 archs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,12 +67,10 @@ build-frontend = { name = "build", args = [
     "-Ccmake.args=-DVCPKG_INSTALLED_DIR=C:/vcpkg_installed",
     "-Ccmake.args=-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake",
 ] }
-# --ignore-existing keeps basix.dll in place under its plain name, as downstream
-# C++ consumers link against it. --with-mangle still mangles its dependencies,
-# which delvewheel vendors from vcpkg. Only one triplet exists per runner.
+# --ignore-existing keeps basix.dll under its usual name, as downstream C++
+# consumers may link against it. --with-mangle still mangles its dependencies,
+# which delvewheel copies in from from vcpkg.
 repair-wheel-command = 'delvewheel repair --ignore-existing --with-mangle --add-path "C:/vcpkg_installed/x64-windows/bin;C:/vcpkg_installed/arm64-windows/bin" -w {dest_dir} -v {wheel}'
-# cibuildwheel sets VIRTUAL_ENV for the test environment; the Unix
-# $(which python) trick does not work in cmd.
 test-command = [
     "cmake -B build-dir -S {project}/test/test_cmake -DPython3_EXECUTABLE=%VIRTUAL_ENV%\\Scripts\\python.exe",
     "cmake --build build-dir --config Release",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,11 +61,14 @@ test-requires = ["pytest-xdist"]
 test-extras = ["test"]
 
 [tool.cibuildwheel.windows]
+# Pin VCPKG_INSTALLED_DIR so the DLLs are at a fixed path.
 build-frontend = { name = "build", args = [
     "-Cwheel.py-api=cp312",
-    "-Ccmake.args=-DINSTALL_RUNTIME_DEPENDENCIES=ON",
+    "-Ccmake.args=-DVCPKG_INSTALLED_DIR=C:/vcpkg_installed",
     "-Ccmake.args=-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake",
 ] }
+# Tell delvewheel where vcpkg puts the DLLs. Only one triplet exists per runner.
+repair-wheel-command = 'delvewheel repair --add-path "C:/vcpkg_installed/x64-windows/bin;C:/vcpkg_installed/arm64-windows/bin" -w {dest_dir} -v {wheel}'
 test-command = ["python -m pytest -n auto --durations 20 {project}/test/"]
 
 [tool.cibuildwheel.linux]

--- a/test/test_cmake/CMakeLists.txt
+++ b/test/test_cmake/CMakeLists.txt
@@ -4,11 +4,6 @@ cmake_minimum_required(VERSION 3.16)
 
 project(basix_test)
 
-# Set the C++ standard
-set(CMAKE_CXX_STANDARD 23)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
 # Use Python for detecting Basix
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/BasixPythonHints.cmake)
 find_package(Basix REQUIRED CONFIG HINTS ${BASIX_PY_DIR})
@@ -25,8 +20,8 @@ if(BASIX_PY_DIR AND IS_DIRECTORY ${BASIX_PY_DIR}/../fenics_basix.libs)
   )
 endif()
 if(WIN32 AND BASIX_PY_DIR)
-  # Windows has no rpath: copy basix.dll and the delvewheel-vendored
-  # dependencies next to the executable instead.
+  # Windows has no rpath: copy basix.dll and any vendored dlls next to
+  # the executable instead.
   file(
     GLOB _basix_dlls
     ${BASIX_PY_DIR}/*.dll

--- a/test/test_cmake/CMakeLists.txt
+++ b/test/test_cmake/CMakeLists.txt
@@ -35,8 +35,9 @@ if(WIN32 AND BASIX_PY_DIR)
   add_custom_command(
     TARGET a.out
     POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${_basix_dlls}
-            $<TARGET_FILE_DIR:a.out>
+    COMMAND
+      ${CMAKE_COMMAND} -E copy_if_different ${_basix_dlls}
+      $<TARGET_FILE_DIR:a.out>
   )
 endif()
 

--- a/test/test_cmake/CMakeLists.txt
+++ b/test/test_cmake/CMakeLists.txt
@@ -24,4 +24,20 @@ if(BASIX_PY_DIR AND IS_DIRECTORY ${BASIX_PY_DIR}/../fenics_basix.libs)
     PROPERTIES INSTALL_RPATH ${BASIX_PY_DIR}/../fenics_basix.libs
   )
 endif()
+if(WIN32 AND BASIX_PY_DIR)
+  # Windows has no rpath: copy basix.dll and the delvewheel-vendored
+  # dependencies next to the executable instead.
+  file(
+    GLOB _basix_dlls
+    ${BASIX_PY_DIR}/*.dll
+    ${BASIX_PY_DIR}/../fenics_basix.libs/*.dll
+  )
+  add_custom_command(
+    TARGET a.out
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${_basix_dlls}
+            $<TARGET_FILE_DIR:a.out>
+  )
+endif()
+
 target_link_libraries(a.out PRIVATE Basix::basix)


### PR DESCRIPTION
This is the standard way to achieve relocatable binary wheels on Windows now. Allows `DINSTALL_RUNTIME_DEPENDENCIES` to be set to `OFF`.