### PR TITLE
Fix Windows build: write py.typed at install time instead of copying it

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -169,10 +169,11 @@ if(WIN32)
 
   # nanobind_add_stub's INSTALL_TIME marker-file generation below requires
   # importing basix._basixcpp, which (per the note above) can fail on
-  # Windows, silently skipping marker-file creation. Install the static
-  # marker directly so the package is always recognised as typed (PEP
-  # 561), matching the non-Windows branch below.
-  install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/basix/py.typed DESTINATION basix)
+  # Windows, silently skipping marker-file creation. py.typed is not a
+  # tracked source file (it is generated, hence gitignored), so write
+  # the (empty) PEP 561 marker directly at install time instead of
+  # copying it from a source path that may not exist.
+  install(CODE "file(WRITE \"\${CMAKE_INSTALL_PREFIX}/basix/py.typed\" \"\")")
 
   # nanobind automatically installs into ${CMAKE_INSTALL_PREFIX} in
   # INSTALL_TIME mode.


### PR DESCRIPTION
## Summary

Fixes a regression introduced in #1048 that currently breaks both Windows CI jobs on `main`.

`python/basix/py.typed` is **not a tracked source file** — it's listed in `.gitignore` and only ever exists as a build artifact generated by nanobind's stub tooling (on Unix, `nanobind_add_stub`'s non-`INSTALL_TIME` mode writes it into the source tree as part of the normal build step, before the separate `install(FILES ...)` copies it into the wheel).

#1048's Windows fix assumed it was a static committed file like on Unix, and added:
```cmake
install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/basix/py.typed DESTINATION basix)
```
On a fresh checkout that source path doesn't exist, so `file(INSTALL)` hard-fails during `cmake --install`, breaking the wheel build entirely on both Windows jobs (confirmed via [run 30586685876](https://github.com/FEniCS/basix/actions/runs/30586685876)):
```
CMake Error at .../cmake_install.cmake:48 (file):
  file INSTALL cannot find "D:/a/basix/basix/python/basix/py.typed": File
  exists.
```

## Fix

Replace the broken `install(FILES ...)` with an unconditional
```cmake
install(CODE "file(WRITE \"${CMAKE_INSTALL_PREFIX}/basix/py.typed\" \"\")")
```
which writes the (empty, per PEP 561) marker directly at the install destination — no dependency on any pre-existing source file, and no dependency on `nanobind_add_stub`'s `INSTALL_TIME` import of `basix._basixcpp` succeeding (that import is what can fail on the Windows split build per the existing code comment, which is the actual root cause of the *original*, silently-tolerated "missing py.typed marker" mypy note this was trying to fix).

## Test plan
- [x] Verified standalone with a minimal CMake project that this exact `install(CODE ...)` construct creates the file correctly, both when the destination directory pre-exists and when it doesn't (auto-created).
- [x] `gersemi --diff` clean.
- [ ] Windows CI (this PR) — both jobs should build successfully again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)