### PR TITLE
 Revert "Fix: remove PETSc stub for tmp. typing fix (#1004)" 

### DIFF
--- a/.github/workflows/dolfinx-tests.yml
+++ b/.github/workflows/dolfinx-tests.yml
@@ -60,19 +60,18 @@ jobs:
         run: |
           python3 -m pip install scikit-build-core
           python3 -m scikit_build_core.build requires | python3 -c "import sys, json; print(' '.join(json.load(sys.stdin)))" | xargs pip install
-          python3 -m pip -v install --break-system-packages --check-build-dependencies --no-build-isolation dolfinx/python/
+          python3 -m pip -v install --break-system-packages --check-build-dependencies --no-build-isolation 'dolfinx/python/[mypy,test]'
       - name: Run mypy checks
         run: |
-          python3 -m pip install --break-system-packages mypy
-          cd dolfinx/python
-          python3 -m mypy dolfinx
+          mypy --config-file python/pyproject.toml -p dolfinx --exclude superlu_dist.py
+          cd python/
+          mypy test
+        # mypy demo
       - name: Install Python demo/test dependencies
         run: python3 -m pip install --break-system-packages matplotlib numba pyamg pytest pytest-xdist scipy pyvista networkx
       - name: Run DOLFINx Python unit tests
-        run: |
-          cd dolfinx
-          python3 -m pytest -n auto python/test/unit
+        working-directory: dolfinx
+        run: python3 -m pytest -n auto python/test/unit
       - name: Run DOLFINx Python demos
-        run: |
-          cd dolfinx/
-          python3 -m pytest -n auto -m serial --durations=10 python/demo/test.py
+        working-directory: dolfinx
+        run: python3 -m pytest -n auto -m serial --durations=10 python/demo/test.py

--- a/.github/workflows/dolfinx-tests.yml
+++ b/.github/workflows/dolfinx-tests.yml
@@ -4,6 +4,7 @@ name: DOLFINx integration
 # unit tests.
 
 on:
+  push:
   pull_request:
     branches:
       - main

--- a/.github/workflows/dolfinx-tests.yml
+++ b/.github/workflows/dolfinx-tests.yml
@@ -63,8 +63,8 @@ jobs:
           python3 -m pip -v install --break-system-packages --check-build-dependencies --no-build-isolation 'dolfinx/python/[mypy,test]'
       - name: Run mypy checks
         run: |
-          mypy --config-file python/pyproject.toml -p dolfinx --exclude superlu_dist.py
-          cd python/
+          mypy --config-file dolfinx/python/pyproject.toml -p dolfinx --exclude superlu_dist.py
+          cd dolfinx/python/
           mypy test
         # mypy demo
       - name: Install Python demo/test dependencies

--- a/.github/workflows/dolfinx-tests.yml
+++ b/.github/workflows/dolfinx-tests.yml
@@ -60,8 +60,6 @@ jobs:
           python3 -m pip install scikit-build-core
           python3 -m scikit_build_core.build requires | python3 -c "import sys, json; print(' '.join(json.load(sys.stdin)))" | xargs pip install
           python3 -m pip -v install --break-system-packages --check-build-dependencies --no-build-isolation dolfinx/python/
-      - name: Workaround (dolfinx typing limitation)
-        run: rm /dolfinx-env/lib64/python3.12/site-packages/petsc4py/PETSc.pyi
       - name: Run mypy checks
         run: |
           python3 -m pip install --break-system-packages mypy

--- a/.github/workflows/dolfinx-tests.yml
+++ b/.github/workflows/dolfinx-tests.yml
@@ -4,7 +4,6 @@ name: DOLFINx integration
 # unit tests.
 
 on:
-  push:
   pull_request:
     branches:
       - main


### PR DESCRIPTION
With the merge of https://github.com/FEniCS/dolfinx/pull/4364 we can revert the changes of #1004. 

- Resolves basix part of https://github.com/FEniCS/dolfinx/issues/4059

- tidies CI dependency usage
- extends type checked source