### PR TITLE
CI: install typing dependencies before the DOLFINx mypy check

### DIFF
--- a/.github/workflows/dolfinx-tests.yml
+++ b/.github/workflows/dolfinx-tests.yml
@@ -60,13 +60,15 @@ jobs:
           python3 -m pip install scikit-build-core
           python3 -m scikit_build_core.build requires | python3 -c "import sys, json; print(' '.join(json.load(sys.stdin)))" | xargs pip install
           python3 -m pip -v install --break-system-packages --check-build-dependencies --no-build-isolation dolfinx/python/
-      - name: Run mypy checks
-        run: |
-          python3 -m pip install --break-system-packages mypy
-          cd dolfinx/python
-          python3 -m mypy dolfinx --exclude superlu_dist.py
       - name: Install Python demo/test dependencies
         run: python3 -m pip install --break-system-packages matplotlib numba pyamg pytest pytest-xdist scipy pyvista networkx
+      - name: Run mypy checks
+        # numba, scipy and the stub packages must be installed, otherwise
+        # DOLFINx's mypy configuration reports missing imports.
+        run: |
+          python3 -m pip install --break-system-packages mypy scipy-stubs types-cffi types-setuptools
+          cd dolfinx/python
+          python3 -m mypy dolfinx --exclude superlu_dist.py
       - name: Run DOLFINx Python unit tests
         run: |
           cd dolfinx


### PR DESCRIPTION
The `DOLFINx integration` workflow currently fails for every PR at the `Run mypy checks` step, e.g. https://github.com/FEniCS/basix/actions/runs/31871362967/job/94980407741.

The step installed only `mypy` and ran *before* the demo/test dependencies. DOLFINx's mypy configuration sets `ignore_missing_imports = false` and `disallow_any_unimported = true`, so with `scipy`, `numba` and the `cffi` stubs absent mypy reports missing stubs/implementations for `scipy`, `scipy.sparse`, `cffi` and `numba`, plus two knock-on `unused-ignore` errors in `dolfinx/fem/petsc.py` (those `type: ignore[attr-defined]` comments are only needed when `types-cffi` is installed).

This moves the mypy check after the demo/test dependencies (which provide `numba` and `scipy`) and installs the stub packages listed in DOLFINx's `mypy` extra (`scipy-stubs`, `types-cffi`, `types-setuptools`), matching what DOLFINx's own CI installs before running the same command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)