### PR TITLE
Lighten CI by not building on every push

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -12,6 +12,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   clang-tidy:
     runs-on: ubuntu-24.04

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -2,8 +2,6 @@ name: clang-tidy
 
 on:
   push:
-    branches:
-      - "**"
     tags:
       - "v*"
   pull_request:
@@ -13,9 +11,6 @@ on:
     branches:
       - main
   workflow_dispatch:
-  # Weekly build on Mondays at 8 am
-  schedule:
-    - cron: "0 8 * * 1"
 
 jobs:
   clang-tidy:

--- a/.github/workflows/dolfinx-tests.yml
+++ b/.github/workflows/dolfinx-tests.yml
@@ -12,6 +12,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Run DOLFINx tests

--- a/.github/workflows/ffcx-tests.yml
+++ b/.github/workflows/ffcx-tests.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
     branches:
       - main
-  push:
-    branches:
-      - "main"
   merge_group:
     branches:
       - main

--- a/.github/workflows/ffcx-tests.yml
+++ b/.github/workflows/ffcx-tests.yml
@@ -11,6 +11,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Run FFCx tests

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -3,9 +3,6 @@ name: oneAPI
 # Test Basix using Intel oneAPI compilers and MKL
 
 on:
-  push:
-    branches:
-      - "main"
   pull_request:
     branches:
       - main

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -11,6 +11,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build and test (oneAPI)

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -11,8 +11,6 @@ on:
   push:
     tags:
       - "v*"
-    branches:
-      - main
   merge_group:
     branches:
       - main

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -16,6 +16,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build and test (MacOS)

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -6,8 +6,6 @@ name: Basix CI
 
 on:
   push:
-    branches:
-      - "**"
     tags:
       - "v*"
   pull_request:
@@ -17,9 +15,6 @@ on:
     branches:
       - main
   workflow_dispatch:
-  # Weekly build on Mondays at 8 am
-  schedule:
-    - cron: "0 8 * * 1"
 jobs:
   lint:
     name: Lint code

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -15,6 +15,11 @@ on:
     branches:
       - main
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Lint code

--- a/.github/workflows/redhat.yml
+++ b/.github/workflows/redhat.yml
@@ -11,6 +11,10 @@ on:
       - main
   workflow_dispatch: ~
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build and test (Red Hat)

--- a/.github/workflows/redhat.yml
+++ b/.github/workflows/redhat.yml
@@ -3,15 +3,9 @@ name: Red Hat clone
 # This workflow will test Basix on Red Hat
 
 on:
-  schedule:
-    # '*' is a special character in YAML, so string must be quoted
-    - cron: "0 2 * * TUE"
   pull_request:
     branches:
       - main
-  push:
-    branches:
-      - "main"
   merge_group:
     branches:
       - main

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -3,6 +3,11 @@ on:
   pull_request:
     branches:
       - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,8 +1,5 @@
 name: SonarCloud
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -5,9 +5,6 @@ on:
   # push:
   #  branches:
   #    - "**"
-  schedule:
-    # '*' is a special character in YAML, so string must be quoted
-    - cron: "0 2 * * TUE"
   workflow_dispatch:
     inputs:
       spack_package_repo:

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -1,8 +1,6 @@
 name: valgrind
 on:
   push:
-    branches:
-      - "**"
     tags:
       - "v*"
   pull_request:
@@ -12,9 +10,6 @@ on:
     branches:
       - main
   workflow_dispatch:
-  # Weekly build on Mondays at 8 am
-  schedule:
-    - cron: "0 8 * * 1"
 
 jobs:
  valgrind:

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -11,6 +11,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
  valgrind:
     runs-on: ubuntu-24.04

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,6 +12,10 @@ on:
        - main
    workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-combined:
     name: Combined build and test

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,8 +7,6 @@ on:
    push:
      tags:
        - "v*"
-     branches:
-       - main
    merge_group:
      branches:
        - main


### PR DESCRIPTION
Also remove schedule. CI should be managed tightly such that environment remains consistent.