### PR TITLE
Convert development dependencies to PEP 735 dependency groups

### DIFF
--- a/.github/workflows/ffcx.yml
+++ b/.github/workflows/ffcx.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install UFL
         run: pip install git+https://github.com/${{ env.ufl_repository }}.git@${{ env.ufl_ref }}
       - name: Install Basix
-        run: pip -v install .[ci]
+        run: pip -v install --group ci .
       - name: Get FFCx source
         uses: actions/checkout@v7
         with:

--- a/.github/workflows/platform-builds.yml
+++ b/.github/workflows/platform-builds.yml
@@ -83,7 +83,7 @@ jobs:
         run: python3 -m pip install pip --upgrade
       - uses: actions/checkout@v7
       - name: Install Basix
-        run: python3 -m pip install -Ccmake.build-type="Developer" .[test]
+        run: python3 -m pip install -Ccmake.build-type="Developer" --group test .
       - name: Run tests
         run: |
           python3 -m pytest --durations 20 test/
@@ -102,7 +102,7 @@ jobs:
       - name: Install dependencies (non-Python)
         run: brew install ninja
       - name: Install Basix
-        run: pip -v install -Ccmake.build-type="Developer" .[test]
+        run: pip -v install -Ccmake.build-type="Developer" --group test .
       - name: Run tests
         run: |
           pip install --only-binary :all: pytest-xdist

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Install UFL
         run: pip -v install git+https://github.com/${{ env.ufl_repository }}.git@${{ env.ufl_ref }}
       - name: Install Basix
-        run: pip -v install -Ccmake.build-type="Developer" .[ci]
+        run: pip -v install -Ccmake.build-type="Developer" --group ci .
       - name: Run units tests
         run: pytest -n auto --durations 20 test/
       - name: Run simple CMake integration test
@@ -189,10 +189,10 @@ jobs:
       - name: Install Basix Python wrapper
         run: |
           cd python
-          pip install .[test]
+          pip install --group test .
       - name: Run units tests
         run: |
-          pip install pytest-xdist # in ci extras, but most not needed.
+          pip install pytest-xdist # in ci group, but most not needed.
           pytest -n auto --durations 20 test/
       - name: Run Python demos
         run: pytest demo/python/test.py

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install UFL branch
         run: pip -v install git+https://github.com/${{ env.ufl_repository }}.git@${{ env.ufl_ref }}
       - name: Install Basix
-        run: pip -v install .[ci] --config-settings=cmake.build-type="RelWithDebInfo"
+        run: pip -v install --group ci . --config-settings=cmake.build-type="RelWithDebInfo"
       - name: Run unit tests
         run: valgrind ${VALGRIND_FLAGS} pytest -n auto --durations 20 test/
       - name: Run Python demos

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Install Basix (combined)
         run: |
-          python -m pip -v install --no-cache-dir .[ci] --config-settings=cmake.args=-DINSTALL_RUNTIME_DEPENDENCIES=ON --config-settings=cmake.args=-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
+          python -m pip -v install --no-cache-dir --group ci . --config-settings=cmake.args=-DINSTALL_RUNTIME_DEPENDENCIES=ON --config-settings=cmake.args=-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
 
       - name: Run mypy
         run: |
@@ -114,7 +114,7 @@ jobs:
       - name: Install Basix (Python)
         run: |
           cd python
-          python -m pip -v install --no-cache-dir .[ci] --config-settings=cmake.args=-DBasix_DIR=D:/a/basix/install/lib/cmake/basix
+          python -m pip -v install --no-cache-dir --group ci . --config-settings=cmake.args=-DBasix_DIR=D:/a/basix/install/lib/cmake/basix
           cd ../
 
       - name: Run mypy

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,11 @@ cmake --build build-dir
 
 Requires a C++20 compiler, BLAS, and LAPACK.
 
-Python unit tests (from repo root, after installing `.[test]`):
+Dependency groups (`docs`, `lint`, `test`, `ci`) use PEP 735 syntax and
+require `pip >= 25.1` (or another PEP 735-compliant build frontend) for
+the `--group` flag.
+
+Python unit tests (from repo root, after installing with `pip install --group test .`):
 
 ```console
 pytest test/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,9 +55,9 @@ cmake --build build-dir
 
 Requires a C++20 compiler, BLAS, and LAPACK.
 
-Dependency groups (`docs`, `lint`, `test`, `ci`) use PEP 735 syntax and
-require `pip >= 25.1` (or another PEP 735-compliant build frontend) for
-the `--group` flag.
+Dependency groups (`build`, `docs`, `lint`, `test`, `ci`) use PEP 735
+syntax and require `pip >= 25.1` (or another PEP 735-compliant build
+frontend) for the `--group` flag.
 
 Python unit tests (from repo root, after installing with `pip install --group test .`):
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,8 +42,8 @@ pip -v install --check-build-dependencies -Cbuild-dir="build" \
   --no-build-isolation -e .
 ```
 
-(`--no-build-isolation` requires build dependencies to already be installed —
-see `python/pyproject.toml`.)
+(`--no-build-isolation` requires build dependencies to already be installed,
+e.g. via `pip install --group build`; see `python/pyproject.toml`.)
 
 C++ only:
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -39,7 +39,8 @@ For a debug and editable build for development:
 pip -v install --check-build-dependencies -Cbuild-dir="build" -Ccmake.build-type="Development" -Cinstall.strip=false --no-build-isolation -e .
 ```
 When using the `--no-build-isolation` option all build dependencies must
-already be installed (see `python/pyproject.toml`).
+already be installed, e.g. via `pip install --group build`
+(see `python/pyproject.toml`).
 
 RPATH manipulation can be disabled by passing
 `-Ccmake.args=-DBASIX_SET_INSTALL_RPATH=FALSE`.
@@ -72,9 +73,9 @@ dependencies for the C++ and Python parts of Basix are fetched
 automatically.
 
 Basix specifies the optional extra `optional` for enabling optional
-features, and the dependency groups `docs`, `lint`, `test`, and `ci`
-for building documentation, linting, testing and continuous
-integration, respectively, e.g.:
+features, and the dependency groups `build`, `docs`, `lint`, `test`,
+and `ci` for installing build dependencies, building documentation,
+linting, testing and continuous integration, respectively, e.g.:
 ```console
 pip install --group docs --group lint .
 ```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -50,7 +50,7 @@ To install Basix and the extra dependencies required to run the Python
 unit tests:
 
 ```console
-pip install .[test]
+pip install --group test .
 ```
 
 From the directory `python/` the tests can be run with:
@@ -71,9 +71,10 @@ When using the standard install approach all build and runtime
 dependencies for the C++ and Python parts of Basix are fetched
 automatically.
 
-Basix specifies sets of optional extras `docs`, `lint`, `optional`,
-`test`, and `ci` for building documentation, linting, enabling optional
-features, testing and for continuous integration, respectively, e.g.:
+Basix specifies the optional extra `optional` for enabling optional
+features, and the dependency groups `docs`, `lint`, `test`, and `ci`
+for building documentation, linting, testing and continuous
+integration, respectively, e.g.:
 ```console
-pip install .[docs,lint]
+pip install --group docs --group lint .
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ documentation = "https://docs.fenicsproject.org"
 optional = ["numba; (sys_platform != 'darwin' or platform_machine != 'x86_64') and (sys_platform != 'win32' or platform_machine != 'ARM64')", "fenics-ufl@git+https://github.com/fenics/ufl"]
 
 [dependency-groups]
-# Keep in sync with [build-system].requires above.
+# Keep build in sync with [build-system].requires above.
 build = ["scikit-build-core[pyproject]>=0.11", "nanobind>=2.5.0"]
 docs = ["markdown", "pylit3", "pyyaml", "sphinx", "pydata-sphinx-theme"]
 lint = ["ruff", "gersemi"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ documentation = "https://docs.fenicsproject.org"
 optional = ["numba; (sys_platform != 'darwin' or platform_machine != 'x86_64') and (sys_platform != 'win32' or platform_machine != 'ARM64')", "fenics-ufl@git+https://github.com/fenics/ufl"]
 
 [dependency-groups]
+# Keep in sync with [build-system].requires above.
+build = ["scikit-build-core[pyproject]>=0.11", "nanobind>=2.5.0"]
 docs = ["markdown", "pylit3", "pyyaml", "sphinx", "pydata-sphinx-theme"]
 lint = ["ruff", "gersemi"]
 test = ["pytest", "sympy", "scipy", "matplotlib", "fenics-basix[optional]"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,12 +22,14 @@ repository = "https://github.com/fenics/basix.git"
 documentation = "https://docs.fenicsproject.org"
 
 [project.optional-dependencies]
-docs = ["markdown", "pylit3", "pyyaml", "sphinx", "pydata-sphinx-theme"]
-lint = ["ruff", "gersemi"]
 # llvmlite (numba) is not built for x86_64 on macOS or arm64 on Windows - advanced users can install manually.
 optional = ["numba; (sys_platform != 'darwin' or platform_machine != 'x86_64') and (sys_platform != 'win32' or platform_machine != 'ARM64')", "fenics-ufl@git+https://github.com/fenics/ufl"]
+
+[dependency-groups]
+docs = ["markdown", "pylit3", "pyyaml", "sphinx", "pydata-sphinx-theme"]
+lint = ["ruff", "gersemi"]
 test = ["pytest", "sympy", "scipy", "matplotlib", "fenics-basix[optional]"]
-ci = ["mypy", "pytest-xdist", "fenics-basix[docs,lint,test,optional]"]
+ci = ["mypy", "pytest-xdist", { include-group = "docs" }, { include-group = "lint" }, { include-group = "test" }]
 
 [tool.pytest.ini_options]
 testpaths = ["test"]
@@ -58,7 +60,7 @@ test-command = [
     "python -m pytest -n auto --durations 20 {project}/test/",
 ]
 test-requires = ["pytest-xdist"]
-test-extras = ["test"]
+test-groups = ["test"]
 
 [tool.cibuildwheel.windows]
 # Pin VCPKG_INSTALLED_DIR so the DLLs are at a fixed path.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -26,6 +26,8 @@ documentation = "https://docs.fenicsproject.org"
 optional = ["numba; (sys_platform != 'darwin' or platform_machine != 'x86_64') and (sys_platform != 'win32' or platform_machine != 'ARM64')", "fenics-ufl@git+https://github.com/fenics/ufl"]
 
 [dependency-groups]
+# Keep in sync with [build-system].requires above.
+build = ["scikit-build-core[pyproject]>=0.11", "nanobind>=2.5.0"]
 docs = ["markdown", "pylit3", "pyyaml", "sphinx", "pydata-sphinx-theme"]
 lint = ["ruff", "gersemi"]
 test = ["pytest", "sympy", "scipy", "matplotlib", "fenics-basix[optional]"]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -22,12 +22,14 @@ repository = "https://github.com/fenics/basix.git"
 documentation = "https://docs.fenicsproject.org"
 
 [project.optional-dependencies]
-docs = ["markdown", "pylit3", "pyyaml", "sphinx", "pydata-sphinx-theme"]
-lint = ["ruff", "gersemi"]
 # llvmlite (numba) is not built for x86_64 on macOS or arm64 on Windows.
 optional = ["numba; (sys_platform != 'darwin' or platform_machine != 'x86_64') and (sys_platform != 'win32' or platform_machine != 'ARM64')", "fenics-ufl@git+https://github.com/fenics/ufl"]
+
+[dependency-groups]
+docs = ["markdown", "pylit3", "pyyaml", "sphinx", "pydata-sphinx-theme"]
+lint = ["ruff", "gersemi"]
 test = ["pytest", "sympy", "scipy", "matplotlib", "fenics-basix[optional]"]
-ci = ["mypy", "pytest-xdist", "fenics-basix[docs,lint,test,optional]"]
+ci = ["mypy", "pytest-xdist", { include-group = "docs" }, { include-group = "lint" }, { include-group = "test" }]
 
 [tool.mypy]
 ignore_missing_imports = true


### PR DESCRIPTION
Move docs/lint/test/ci from optional-dependencies to dependency-groups in both pyproject.toml files, keep `optional` as a real extra, and update CI to use `--group` instead of `.[...]`.

https://packaging.python.org/en/latest/specifications/dependency-groups/#dependency-groups

This makes it possible to install a group without building/installing the package:

``pip install --group ci``

I also added a `build` dependency-group. Sadly at this time this might be kept manually in-sync with `build-system.requires`, but it means the `scikit-build-core` specific JSON extraction isn't needed.
