### PR TITLE
Use Xiao-Gimbutas for the default tetrahedron rule at degree 4-8

### DIFF
--- a/cpp/basix/quadrature.cpp
+++ b/cpp/basix/quadrature.cpp
@@ -4942,8 +4942,6 @@ quadrature::type quadrature::get_default_rule(cell::type celltype, int m)
   {
     if (m <= 3)
       return type::zienkiewicz_taylor;
-    else if (m <= 8)
-      return type::keast;
     else if (m <= 15)
       return type::xiao_gimbutas;
     else


### PR DESCRIPTION
## Problem

\`get_default_rule()\` splits tetrahedra into \`keast\` for degree 4-8 and \`xiao_gimbutas\` for degree 9-15. \`xiao_gimbutas\` is already implemented and already the default one degree above that range, so I checked whether it's actually worse anywhere in 4-8 and it isn't:

| degree | keast points | xiao_gimbutas points |
| --- | --- | --- |
| 4 | 14 | **11** |
| 5 | 15 | **14** |
| 6 | 24 | **23** |
| 7 | 31 | 31 |
| 8 | 45 | **44** |

`xiao_gimbutas` matches or beats `keast`'s point count at every degree in the range, and `keast`'s degree-7 rule also carries small negative weights where `xiao_gimbutas`'s don't. So `QuadratureType::Default` was resolving to a rule strictly dominated (point count and weight positivity both) by one basix already ships for the adjacent degree range.

## Where this came from

I was benchmarking FFCx-generated kernels (a full write-up is [here](https://claude.ai/code/artifact/b2b2e22b-e0e5-4803-83ea-960ae2bc1506) if useful context). A degree-4 tetrahedron bilinear form (P3 Poisson, or a plain P2 mass matrix) came out needlessly quadrature-heavy: FFCx passes UFL's default `quadrature_rule` metadata straight through to `basix.make_quadrature` unless a form explicitly sets `dx(scheme=...)`, so `QuadratureType.default` is what the overwhelming majority of forms actually get.

## Fix

Route the whole tetrahedron degree 4-15 range to \`xiao_gimbutas\` and drop the \`keast\` branch:

\`\`\`diff
     if (m <= 3)
       return type::zienkiewicz_taylor;
-    else if (m <= 8)
-      return type::keast;
     else if (m <= 15)
       return type::xiao_gimbutas;
     else
       return type::gauss_jacobi;
\`\`\`

\`keast\` itself is untouched (still implemented, just no longer reachable via \`Default\` for tetrahedra) in case anything selects it another way.

## Measured effect

Rebuilt, regenerated FFCx kernels for a P3 Poisson bilinear form (degree-4 tetrahedron integral), timed directly (gcc -O2, self-calibrated microbenchmark, no DOLFINx dependency): **6459 -> 5197 ns**, a 20% cut in line with the 21% fewer quadrature points.
## Correctness

- \`pytest test/test_quadrature.py\`: 212 passed (includes the sympy-verified polynomial-exactness checks against known degree bounds).
- \`pytest test/\` (excluding \`test_numba.py\`, which needs a numba/numpy combination not present in my environment): 9827 passed, 337 skipped, 23 xfailed.

AI assistance: I used Claude Code (Opus 5) to draft this change. I reviewed and take responsibility for the final contribution.