### PR TITLE
Enable Nanobind split build

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -49,6 +49,9 @@ jobs:
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v4.2.0
+        env:
+          BASIX_NANOBIND_SPLIT: "true"
+          CIBW_ENVIRONMENT_PASS_LINUX: BASIX_NANOBIND_SPLIT
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,8 @@ introducing a new pattern.
 - `cpp/CMakeLists.txt` — C++ library build.
 - `python/basix/` — Python package (thin wrappers around the C++ core).
 - `python/wrapper.cpp` — nanobind bindings exposing the C++ core to Python.
+  Optionally built in nanobind split mode (`BASIX_NANOBIND_SPLIT=true`, off by
+  default, enabled for wheels) — see `INSTALL.md`.
 - `test/` — Python unit tests (pytest), plus `test/test_cmake` and
   `test/test_pkgconfig` integration tests for the installed C++ library.
 - `demo/` — C++ and Python demos, also exercised in CI.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -45,6 +45,14 @@ already be installed, e.g. via `pip install --group build`
 RPATH manipulation can be disabled by passing
 `-Ccmake.args=-DBASIX_SET_INSTALL_RPATH=FALSE`.
 
+### nanobind split mode (optional)
+
+The Python extension can be built in [nanobind split
+mode](https://nanobind.readthedocs.io/en/latest/split_mode.html) by setting
+`BASIX_NANOBIND_SPLIT=true` in the environment. It requires nanobind >= 3.0 and
+adds `nanobind-backend` as a run-time dependency. Off by default, used for the
+wheels built by `.github/workflows/build-wheels.yml`.
+
 ## Running the unit tests
 
 To install Basix and the extra dependencies required to run the Python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,9 +53,7 @@ result = ["numpy>=2"]
 if.env.CIBUILDWHEEL = true
 wheel.py-api = "cp312"
 
-# nanobind split mode, see INSTALL.md. Must come after the block above to win on
-# py-api. The '.dev' specifiers are what make pip accept the (currently
-# unreleased) nanobind 3.0 prereleases.
+# nanobind split mode, see INSTALL.md. Must come after the previous override. 
 [[tool.scikit-build.overrides]]
 if.env.BASIX_NANOBIND_SPLIT = true
 inherit.cmake.define = "append"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ authors = [
     { email = "fenics-steering-council@googlegroups.com" },
     { name = "FEniCS Steering Council" },
 ]
-dependencies = ["numpy>=2"]
+# Allows split mode to override.
+dynamic = ["dependencies"]
 
 [project.urls]
 homepage = "https://fenicsproject.org"
@@ -43,10 +44,30 @@ wheel.packages = ["python/basix"]
 # Set to FALSE to disable install RPATH adjustments
 BASIX_SET_INSTALL_RPATH = "TRUE"
 
+[tool.scikit-build.metadata.dependencies]
+provider = "scikit_build_core.metadata.template"
+result = ["numpy>=2"]
+
+# Stable ABI wheels; cibuildwheel sets CIBUILDWHEEL itself.
+[[tool.scikit-build.overrides]]
+if.env.CIBUILDWHEEL = true
+wheel.py-api = "cp312"
+
+# nanobind split mode, see INSTALL.md. Must come after the block above to win on
+# py-api. The '.dev' specifiers are what make pip accept the (currently
+# unreleased) nanobind 3.0 prereleases.
+[[tool.scikit-build.overrides]]
+if.env.BASIX_NANOBIND_SPLIT = true
+inherit.cmake.define = "append"
+cmake.define.BASIX_NANOBIND_SPLIT = "ON"
+# nanobind-backend is needed at build time too - stub generation imports the extension.
+build.requires = ["nanobind>=3.0.0.dev3", "nanobind-backend>=1.0.0.dev3"]
+metadata.dependencies.provider = "scikit_build_core.metadata.template"
+metadata.dependencies.result = ["numpy>=2", "nanobind-backend>=1.0.0.dev3"]
+wheel.py-api = "cp311"
+
 [tool.cibuildwheel]
-build-frontend = { name = "build", args = [
-    "-Cwheel.py-api=cp312",
-] }
+build-frontend = { name = "build" }
 build = [
     "cp3{11,12,13,14}-manylinux_x86_64",
     "cp3{11,12,13,14}-manylinux_aarch64",
@@ -67,7 +88,6 @@ test-groups = ["test"]
 [tool.cibuildwheel.windows]
 # Pin VCPKG_INSTALLED_DIR so the DLLs are at a fixed path.
 build-frontend = { name = "build", args = [
-    "-Cwheel.py-api=cp312",
     "-Ccmake.args=-DVCPKG_INSTALLED_DIR=C:/vcpkg_installed",
     "-Ccmake.args=-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake",
 ] }

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -36,6 +36,17 @@ add_feature_info(
   "Set rpath of _basixcpp to location of installed C++ library"
 )
 
+option(
+  BASIX_NANOBIND_SPLIT
+  "Build _basixcpp in nanobind split mode (requires nanobind >= 3.0)"
+  OFF
+)
+add_feature_info(
+  BASIX_NANOBIND_SPLIT
+  BASIX_NANOBIND_SPLIT
+  "Build _basixcpp in nanobind split mode (requires nanobind >= 3.0)"
+)
+
 feature_summary(WHAT ALL)
 
 # Detect the installed nanobind package and import it into CMake
@@ -48,11 +59,18 @@ execute_process(
 list(APPEND CMAKE_PREFIX_PATH "${NB_DIR}")
 find_package(nanobind CONFIG REQUIRED)
 
-# Create the binding library
-if(NOT "${SKBUILD_SABI_VERSION}" STREQUAL "")
-  set(NANOBIND_SABI "STABLE_ABI")
+# nanobind < 3.0 ignores BACKEND_MODULE silently.
+if(BASIX_NANOBIND_SPLIT AND nanobind_VERSION VERSION_LESS 3.0)
+  message(FATAL_ERROR "BASIX_NANOBIND_SPLIT requires nanobind >= 3.0.")
 endif()
-nanobind_add_module(_basixcpp NB_SUPPRESS_WARNINGS ${NANOBIND_SABI} wrapper.cpp)
+
+# Create the binding library
+if(BASIX_NANOBIND_SPLIT)
+  set(NANOBIND_MODE BACKEND_MODULE nanobind_backend)
+elseif(NOT "${SKBUILD_SABI_VERSION}" STREQUAL "")
+  set(NANOBIND_MODE STABLE_ABI)
+endif()
+nanobind_add_module(_basixcpp NB_SUPPRESS_WARNINGS ${NANOBIND_MODE} wrapper.cpp)
 target_compile_features(_basixcpp PRIVATE cxx_std_20)
 
 # Windows requires all symbols to be manually exported; this exports them


### PR DESCRIPTION
This beta initiative in nanobind allows for split mode builds, fully described: https://nanobind.readthedocs.io/en/latest/split_mode.html

Stable API and targeted/optimised API builds are still supported.

The `scikit-build-core` end is not totally smooth, not a big fan of dynamic metadata - I guess this will be improved upstream.

I used Claude Opus 5.0 to sketch out this commit and I agree to the default disclaimer.