### PR TITLE
Fix build type names in install instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ Editable/development install:
 ```console
 cd python
 pip -v install --check-build-dependencies -Cbuild-dir="build" \
-  -Ccmake.build-type="Development" -Cinstall.strip=false \
+  -Ccmake.build-type="Developer" -Cinstall.strip=false \
   --no-build-isolation -e .
 ```
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -22,7 +22,7 @@ cmake --build build-dir
 cmake --install build-dir
 ```
 
-Using the CMake build type `Release` or `RelWithDebug` is strongly recommended
+Using the CMake build type `Release` or `RelWithDebInfo` is strongly recommended
 for performance.
 
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -36,7 +36,7 @@ pip install .
 
 For a debug and editable build for development:
 ```console
-pip -v install --check-build-dependencies -Cbuild-dir="build" -Ccmake.build-type="Development" -Cinstall.strip=false --no-build-isolation -e .
+pip -v install --check-build-dependencies -Cbuild-dir="build" -Ccmake.build-type="Developer" -Cinstall.strip=false --no-build-isolation -e .
 ```
 When using the `--no-build-isolation` option all build dependencies must
 already be installed, e.g. via `pip install --group build`


### PR DESCRIPTION
Two incorrect CMake build type names in the docs.

`cmake.build-type="Development"` in the editable install recipe (`AGENTS.md`, `INSTALL.md`) does not match the `$<CONFIG:Developer>` guards in `python/CMakeLists.txt`, so anyone following the instructions silently got none of the developer flags — no `-Wall -Werror -Wextra -pedantic`, and no `_LIBCPP_HARDENING_MODE` or `_GLIBCXX_ASSERTIONS`. Confirmed by configuring both ways: `Development` yields no such flags, `Developer` yields them.

`RelWithDebug` in `INSTALL.md` is not a CMake build type; the standard name is `RelWithDebInfo`. An unrecognised build type leaves the optimisation flags empty, so this was recommending a build with no optimisation.

DOLFINx uses `Developer` consistently and is unaffected by the first issue, but had the same `RelWithDebug` mistake in its wheel builds (FEniCS/dolfinx#4430).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
