### PR TITLE
Enable warnings from Basix headers in Developer builds

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -7,6 +7,14 @@ if(TARGET basix)
   add_library(Basix::basix ALIAS basix)
 else()
   find_package(Basix REQUIRED)
+  if(
+    CMAKE_BUILD_TYPE STREQUAL "Developer"
+    AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.25
+  )
+    # This enables warnings from Basix headers even though they are a SYSTEM
+    # dependency.
+    set_target_properties(Basix::basix PROPERTIES SYSTEM OFF)
+  endif()
 endif()
 
 find_package(

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -7,10 +7,7 @@ if(TARGET basix)
   add_library(Basix::basix ALIAS basix)
 else()
   find_package(Basix REQUIRED)
-  if(
-    CMAKE_BUILD_TYPE STREQUAL "Developer"
-    AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.25
-  )
+  if(CMAKE_BUILD_TYPE STREQUAL "Developer")
     # This enables warnings from Basix headers even though they are a SYSTEM
     # dependency.
     set_target_properties(Basix::basix PROPERTIES SYSTEM OFF)


### PR DESCRIPTION
When the Python wrapper is built standalone (`pip install python/`, the documented editable-install workflow), `Basix::basix` comes from `find_package` and is an IMPORTED target. Imported targets default to `SYSTEM ON` since CMake 3.25, so the Developer `-Wall -Werror -Wextra -pedantic` flags do not apply to anything coming from the Basix headers — in exactly the configuration used for development.

This didn't pickup any new warnings because we already had coverage via the combined build and install path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)